### PR TITLE
Adds registration helper for Custom Delegates as factories

### DIFF
--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/ServiceControllerExtensionsTests.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/ServiceControllerExtensionsTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Extensions.DependencyInjection.UnitTests.TestObjects;
 using NSubstitute;
 using Xunit;
 

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/ComponentA.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/ComponentA.cs
@@ -1,0 +1,12 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests.TestObjects
+{
+    public class ComponentA : IComponent
+    {
+        public string Name { get; } = nameof(ComponentA);
+    }
+}

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/ComponentB.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/ComponentB.cs
@@ -3,9 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests
+namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests.TestObjects
 {
-    public class TestComponent
+    public class ComponentB : IComponent
     {
+        public delegate IComponent Factory();
+
+        public string Name { get; } = nameof(ComponentB);
     }
 }

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/IComponent.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/IComponent.cs
@@ -1,0 +1,12 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests.TestObjects
+{
+    public interface IComponent
+    {
+        public string Name { get; }
+    }
+}

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/TestComponent.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/TestComponent.cs
@@ -1,0 +1,11 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests.TestObjects
+{
+    public class TestComponent
+    {
+    }
+}

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/TestDisposableObjectWithInterface.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/TestDisposableObjectWithInterface.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests.TestObjects
+{
+    public class TestDisposableObjectWithInterface : IEquatable<string>, IDisposable
+    {
+        public bool Equals(string other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/TestModule.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/TestModule.cs
@@ -5,7 +5,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests
+namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests.TestObjects
 {
     public class TestModule : IStartupModule
     {

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/TestScope.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/TestScope.cs
@@ -1,0 +1,23 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests.TestObjects
+{
+    public class TestScope : IScoped<IList<string>>
+    {
+        public TestScope(IList<string> value)
+        {
+            Value = value;
+        }
+
+        public IList<string> Value { get; }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationBuilder.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationBuilder.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Health.Extensions.DependencyInjection
     public class TypeRegistrationBuilder
     {
         private readonly MethodInfo _factoryGenericMethod = typeof(TypeRegistrationExtensions).GetMethod(nameof(TypeRegistrationExtensions.AddFactory), BindingFlags.Public | BindingFlags.Static);
+        private readonly MethodInfo _factoryDelegateMethod = typeof(TypeRegistrationExtensions).GetMethod(nameof(TypeRegistrationExtensions.AddDelegate), BindingFlags.Public | BindingFlags.Static);
         private readonly IServiceCollection _serviceCollection;
         private readonly Type _type;
         private readonly Func<IServiceProvider, object> _delegateRegistration;
@@ -80,6 +81,21 @@ namespace Microsoft.Health.Extensions.DependencyInjection
         public TypeRegistrationBuilder AsFactory()
         {
             var factoryMethod = _factoryGenericMethod.MakeGenericMethod(_type);
+
+            factoryMethod.Invoke(null, new object[] { _serviceCollection });
+
+            return this;
+        }
+
+        /// <summary>
+        /// Creates a service registration for the specified interface that can be resolved with a custom delegate
+        /// </summary>
+        /// <typeparam name="TDelegate">Custom delegate that will resolve the service</typeparam>
+        /// <returns>The registration builder</returns>
+        public TypeRegistrationBuilder AsDelegate<TDelegate>()
+            where TDelegate : Delegate
+        {
+            var factoryMethod = _factoryDelegateMethod.MakeGenericMethod(typeof(TDelegate), _type);
 
             factoryMethod.Invoke(null, new object[] { _serviceCollection });
 


### PR DESCRIPTION
## Description
Adds registration helper for Custom Delegates as factories. 

Example:
```
_collection.Add<ComponentA>()
    .Transient()
    .AsSelf()
    .AsService<IComponent>();

_collection.Add<ComponentB>()
    .Transient()
    .AsSelf()
    .AsService<IComponent>()
    .AsDelegate<ComponentB.Factory>();

var provider = _collection.BuildServiceProvider();

// Using Func<IComponent> won't work here because there are 2 components that implement this interface.
// Using the delegate ComponentB.Factory works to resolve the desired instance while maintaining the interface

var componentFactory = provider.GetService<ComponentB.Factory>();
IComponent instance = componentFactory.Invoke();
```

## Testing
Adds unit tests for new registration helper
