### PR TITLE
Explicitly sets IsolationLevel

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapper.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapper.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Health.SqlServer.Features.Client
             SqlServerDataStoreConfiguration configuration,
             SqlTransactionHandler sqlTransactionHandler,
             SqlCommandWrapperFactory sqlCommandWrapperFactory,
-            bool enlistInTransactionIfPresent)
+            bool enlistInTransactionIfPresent,
+            IsolationLevel isolationLevel = IsolationLevel.ReadCommitted)
         {
             EnsureArg.IsNotNull(configuration, nameof(configuration));
             EnsureArg.IsNotNull(sqlTransactionHandler, nameof(sqlTransactionHandler));
@@ -53,7 +54,7 @@ namespace Microsoft.Health.SqlServer.Features.Client
 
             if (enlistInTransactionIfPresent && sqlTransactionHandler.SqlTransactionScope != null)
             {
-                SqlTransaction = sqlTransactionHandler.SqlTransactionScope.SqlTransaction ?? SqlConnection.BeginTransaction();
+                SqlTransaction = sqlTransactionHandler.SqlTransactionScope.SqlTransaction ?? SqlConnection.BeginTransaction(isolationLevel);
 
                 if (sqlTransactionHandler.SqlTransactionScope.SqlTransaction == null)
                 {


### PR DESCRIPTION
## Description
This is to explicitly set IsolationLevel.
Default IsolationLevel is ReadCommitted.
If for any transaction we need to set different IsolationLevel, we can pass that in the SqlConnectionWrapper.
E.g. We need to set IsolationLevel.Snapshot in SqlServerSearchService

## Related issues
Addresses #70783

## Testing
Existing tests continue to pass.
