### PR TITLE
Removes the DeleteAllDataOnStartup setting

### DIFF
--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -15,12 +15,6 @@ namespace Microsoft.Health.SqlServer.Configs
         public bool Initialize { get; set; }
 
         /// <summary>
-        /// WARNING: THIS RESETS ALL DATA IN THE DATABASE
-        /// If set, this applies schema 1 which resets all the data in the database. This is temporary until the schema migration tool is complete.
-        /// </summary>
-        public bool DeleteAllDataOnStartup { get; set; }
-
-        /// <summary>
         /// Allows the experimental schema initializer to attempt to create the database if not present.
         /// </summary>
         public bool AllowDatabaseCreation { get; set; }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
             _logger.LogInformation("Schema version is {version}", _schemaInformation.Current?.ToString() ?? "NULL");
 
             // If the stored procedure to get the current schema version doesn't exist
-            if (_schemaInformation.Current == null || _sqlServerDataStoreConfiguration.DeleteAllDataOnStartup)
+            if (_schemaInformation.Current == null)
             {
                 if (forceIncrementalSchemaUpgrade)
                 {


### PR DESCRIPTION
## Description
Removes the DeleteAllDataOnStartup setting as now the schema migration tool work is completed.
And it is dangerous to keep this setting which can accidentally wipe out the database.

## Related issues
Addresses #73760.

## Testing
Manual testing and existing test continue to pass.
