### PR TITLE
Register RecycalableMemoryStreamManager used by BlobClientReadWriteTestProvider

### DIFF
--- a/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Linq;
 using EnsureThat;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Health.Blob.Configs;
 using Microsoft.Health.Blob.Features.Storage;
 using Microsoft.Health.Extensions.DependencyInjection;
@@ -61,7 +62,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Singleton()
                 .AsService<IBlobClientInitializer>();
 
-            services.AddSingleton<RecyclableMemoryStreamManager>();
+            services.TryAddSingleton<RecyclableMemoryStreamManager>();
 
             return services;
         }


### PR DESCRIPTION
## Description
Microsoft.Health.Blob was missing registration of a Service used in DI.
This was not a issue in Dicom server because API proj also registers it since it is used by Dicom core services.

## Related issues
AB#74004

## Testing
Validated the new package works in dicom-cast.
