### PR TITLE
Enable Dependabot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+﻿# Configuration based on https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Description
Adds a `dependabot.yml` to enable automatic PRs for updating nuget packages. See [the documentation](https://help.github.com/en/github/administering-a-repository/about-github-dependabot) for details around this.

## Related issues
Addresses AB#74244
