### PR TITLE
Add Download Maximum concurrency config setting allowed in the new blob sdk

### DIFF
--- a/src/Microsoft.Health.Blob/Configs/BlobDataStoreRequestOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobDataStoreRequestOptions.cs
@@ -12,5 +12,7 @@ namespace Microsoft.Health.Blob.Configs
         public int ExponentialRetryMaxAttempts { get; set; } = 6;
 
         public int ServerTimeoutInMinutes { get; set; } = 2;
+
+        public int DownloadMaximumConcurrency { get; set; } = 1;
     }
 }


### PR DESCRIPTION
## Description
Will be used as a storagetransferoption in downloadsync.
It will be used in improving parallel download of dicom file in dicom-server.
Recommended in https://github.com/Azure/azure-sdk-for-net/issues/12445 for replacement of parallelThreadCount.

## Related issues
AB#74219

## Testing
Will be tested when consumed in dicom-server