### PR TITLE
Update credential provider naming to add async suffix.

### DIFF
--- a/src/Microsoft.Health.Client.UnitTests/AuthenticationHttpMessageHandlerTests.cs
+++ b/src/Microsoft.Health.Client.UnitTests/AuthenticationHttpMessageHandlerTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Client.UnitTests
         public AuthenticationHttpMessageHandlerTests()
         {
             var credentialProvider = Substitute.For<ICredentialProvider>();
-            credentialProvider.GetBearerToken(Arg.Any<CancellationToken>()).Returns("token");
+            credentialProvider.GetBearerTokenAsync(Arg.Any<CancellationToken>()).Returns("token");
             _authenticationHttpMessageHandler = new AuthenticationHttpMessageHandler(credentialProvider)
             {
                 InnerHandler = new TestInnerHandler(),

--- a/src/Microsoft.Health.Client.UnitTests/CredentialProviderTests.cs
+++ b/src/Microsoft.Health.Client.UnitTests/CredentialProviderTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Client.UnitTests
             Assert.Null(credentialProvider.Token);
             Assert.Equal(default, credentialProvider.TokenExpiration);
 
-            var token = await credentialProvider.GetBearerToken(cancellationToken: default);
+            var token = await credentialProvider.GetBearerTokenAsync(cancellationToken: default);
 
             Assert.Equal(token, credentialProvider.Token);
 
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Client.UnitTests
             var credentialProvider = new TestCredentialProvider(initialToken);
 
             // Returns the initialToken
-            var initialResult = await credentialProvider.GetBearerToken(cancellationToken: default);
+            var initialResult = await credentialProvider.GetBearerTokenAsync(cancellationToken: default);
             Assert.Equal(initialToken, initialResult);
 
             // Update the token that would be returned if BearerTokenFunction() was called
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Client.UnitTests
             credentialProvider.EncodedToken = secondToken;
 
             // Should return the initialToken since it is not within the expiration window
-            var secondResult = await credentialProvider.GetBearerToken(cancellationToken: default);
+            var secondResult = await credentialProvider.GetBearerTokenAsync(cancellationToken: default);
 
             Assert.Equal(initialResult, secondResult);
         }
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Client.UnitTests
             var credentialProvider = new TestCredentialProvider(initialToken);
 
             // Returns the initialToken
-            var initialResult = await credentialProvider.GetBearerToken(cancellationToken: default);
+            var initialResult = await credentialProvider.GetBearerTokenAsync(cancellationToken: default);
             Assert.Equal(initialToken, initialResult);
 
             // Update the token that will be returned since the initial token is within the expiration window
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Client.UnitTests
             credentialProvider.EncodedToken = secondToken;
 
             // Should return the initialToken since it is not within the expiration window
-            var secondResult = await credentialProvider.GetBearerToken(cancellationToken: default);
+            var secondResult = await credentialProvider.GetBearerTokenAsync(cancellationToken: default);
 
             Assert.Equal(secondToken, secondResult);
             Assert.NotEqual(initialResult, secondResult);

--- a/src/Microsoft.Health.Client.UnitTests/TestCredentialProvider.cs
+++ b/src/Microsoft.Health.Client.UnitTests/TestCredentialProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Client.UnitTests
 
         public string EncodedToken { get; set; }
 
-        protected override Task<string> BearerTokenFunction(CancellationToken cancellationToken)
+        protected override Task<string> BearerTokenFunctionAsync(CancellationToken cancellationToken)
         {
             return Task.FromResult(EncodedToken);
         }

--- a/src/Microsoft.Health.Client/AuthenticationHttpMessageHandler.cs
+++ b/src/Microsoft.Health.Client/AuthenticationHttpMessageHandler.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Client
             CancellationToken cancellationToken)
         {
             request.Headers.Authorization =
-                new AuthenticationHeaderValue("Bearer", await _credentialProvider.GetBearerToken(cancellationToken));
+                new AuthenticationHeaderValue("Bearer", await _credentialProvider.GetBearerTokenAsync(cancellationToken));
 
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/Microsoft.Health.Client/CredentialProvider.cs
+++ b/src/Microsoft.Health.Client/CredentialProvider.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Health.Client
 
         internal DateTime TokenExpiration { get; private set; }
 
-        public async Task<string> GetBearerToken(CancellationToken cancellationToken)
+        public async Task<string> GetBearerTokenAsync(CancellationToken cancellationToken)
         {
             if (TokenExpiration < DateTime.UtcNow + _tokenTimeout)
             {
-                Token = await BearerTokenFunction(cancellationToken);
+                Token = await BearerTokenFunctionAsync(cancellationToken);
                 var decodedToken = new JsonWebToken(Token);
                 TokenExpiration = decodedToken.ValidTo;
             }
@@ -30,6 +30,6 @@ namespace Microsoft.Health.Client
             return Token;
         }
 
-        protected abstract Task<string> BearerTokenFunction(CancellationToken cancellationToken);
+        protected abstract Task<string> BearerTokenFunctionAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Client/ICredentialProvider.cs
+++ b/src/Microsoft.Health.Client/ICredentialProvider.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Health.Client
 {
     public interface ICredentialProvider
     {
-        Task<string> GetBearerToken(CancellationToken cancellationToken = default);
+        Task<string> GetBearerTokenAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Client/ManagedIdentityCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/ManagedIdentityCredentialProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Client
             _httpClientFactory = httpClientFactory;
         }
 
-        protected override async Task<string> BearerTokenFunction(CancellationToken cancellationToken)
+        protected override async Task<string> BearerTokenFunctionAsync(CancellationToken cancellationToken)
         {
             var azureServiceTokenProvider = new AzureServiceTokenProvider(httpClientFactory: _httpClientFactory);
             return await azureServiceTokenProvider.GetAccessTokenAsync(_managedIdentityCredentialConfiguration.Resource, _managedIdentityCredentialConfiguration.TenantId, cancellationToken);

--- a/src/Microsoft.Health.Client/OAuth2ClientCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/OAuth2ClientCredentialProvider.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
@@ -34,7 +33,7 @@ namespace Microsoft.Health.Client
             _oAuth2ClientCredentialConfiguration = oAuth2ClientCredentialConfiguration.Value;
         }
 
-        protected override async Task<string> BearerTokenFunction(CancellationToken cancellationToken)
+        protected override async Task<string> BearerTokenFunctionAsync(CancellationToken cancellationToken)
         {
             var formData = new List<KeyValuePair<string, string>>
             {

--- a/src/Microsoft.Health.Client/OAuth2UserPasswordCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/OAuth2UserPasswordCredentialProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Client
             _oAuth2UserPasswordCredentialConfiguration = oAuth2UserCredentialConfiguration.Value;
         }
 
-        protected override async Task<string> BearerTokenFunction(CancellationToken cancellationToken)
+        protected override async Task<string> BearerTokenFunctionAsync(CancellationToken cancellationToken)
         {
             var formData = new List<KeyValuePair<string, string>>
             {


### PR DESCRIPTION
## Description
This PR updates the naming of `ICredentialProvider` function `GetBearerToken` -> `GetBearerTokenAsync`

## Related issues
Addresses [issue #].

## Testing
Existing unit tests continue to pass.