### PR TITLE
Updates SQL service registration

### DIFF
--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Health.SqlServer.Registration
                 .AsImplementedInterfaces();
 
             services.Add<SqlTransactionHandler>()
-                .Scoped()
+                .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();
 
@@ -76,7 +76,7 @@ namespace Microsoft.Health.SqlServer.Registration
                 .AsService<SqlCommandWrapperFactory>();
 
             services.Add<SqlConnectionWrapperFactory>()
-                .Scoped()
+                .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();
 


### PR DESCRIPTION
## Description
A new SQL service is being added to the FHIR server to manage search parameter statuses (please see [this PR](https://github.com/microsoft/fhir-server/pull/1136)). A couple of changes are required to the SQL service registration in the healthcare shared components repo in order for the services to start up.

## Related issues
Addresses [#AB74236](https://microsofthealth.visualstudio.com/Health/_workitems/edit/74236).

## Testing
All tests pass as before.
