### PR TITLE
Adds IIndex<TService> to resolve a service with metadata

### DIFF
--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests
 {
-    public class ServiceControllerExtensionsTests
+    public class ServiceCollectionExtensionsTests
     {
         [Fact]
         public void GivenAnAssembly_WhenScanningForModules_ThenNewModulesShouldBeLoaded()

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/ServiceCollectionTestExtensions.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/ServiceCollectionTestExtensions.cs
@@ -1,0 +1,20 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests
+{
+    public static class ServiceCollectionTestExtensions
+    {
+        public static IEnumerable<ServiceDescriptor> NonSystemTypes(this IServiceCollection serviceCollection)
+        {
+            return serviceCollection.Where(x => !(x.ImplementationInstance is MetadataHelper) &&
+                                                x.ImplementationType != typeof(Index<>));
+        }
+    }
+}

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/ComponentA.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/ComponentA.cs
@@ -3,8 +3,11 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.ComponentModel;
+
 namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests.TestObjects
 {
+    [DisplayName("Component A")]
     public class ComponentA : IComponent
     {
         public string Name { get; } = nameof(ComponentA);

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/ComponentB.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TestObjects/ComponentB.cs
@@ -3,8 +3,11 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.ComponentModel;
+
 namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests.TestObjects
 {
+    [DisplayName("Component B")]
     public class ComponentB : IComponent
     {
         public delegate IComponent Factory();

--- a/src/Microsoft.Health.Extensions.DependencyInjection/IIndex.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/IIndex.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Health.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Provides access to services with its associated metadata.
+    /// </summary>
+    /// <typeparam name="TServiceType">Type of the Service</typeparam>
+    [SuppressMessage("Design", "CA1710", Justification = "This is a dictionary style design")]
+    public interface IIndex<TServiceType> : IEnumerable<KeyValuePair<object, Lazy<TServiceType>>>
+    {
+        /// <summary>
+        /// Gets the associated service by metadata
+        /// </summary>
+        /// <param name="metadata">Metadata associated with a service</param>
+        TServiceType this[object metadata] { get; }
+
+        /// <summary>
+        /// Try get the service instance by using the metadata key
+        /// </summary>
+        /// <param name="metadata">Metadata associated with a service</param>
+        /// <param name="value">Service instance</param>
+        /// <returns>True if service was resolved</returns>
+        bool TryGetValue(object metadata, out TServiceType value);
+    }
+}

--- a/src/Microsoft.Health.Extensions.DependencyInjection/Index.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/Index.cs
@@ -1,0 +1,73 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using EnsureThat;
+
+namespace Microsoft.Health.Extensions.DependencyInjection
+{
+    internal sealed class Index<TServiceType> : IIndex<TServiceType>
+    {
+        private readonly Dictionary<object, Lazy<TServiceType>> _services;
+
+        public Index(IServiceProvider serviceProvider, MetadataHelper metadataHelper)
+        {
+            EnsureArg.IsNotNull(serviceProvider, nameof(TServiceType));
+            EnsureArg.IsNotNull(metadataHelper, nameof(metadataHelper));
+
+            if (metadataHelper.TryGetMetadata(typeof(TServiceType), out var mappings))
+            {
+                _services = mappings
+                    .Select(x =>
+                    {
+                        Type implementation = x.Implementation;
+                        var lazyResolve = new Lazy<TServiceType>(() => (TServiceType)serviceProvider.GetService(implementation));
+                        return new KeyValuePair<object, Lazy<TServiceType>>(x.Metadata, lazyResolve);
+                    })
+                    .ToDictionary(x => x.Key, x => x.Value);
+            }
+            else
+            {
+                _services = new Dictionary<object, Lazy<TServiceType>>();
+            }
+        }
+
+        public TServiceType this[object index]
+        {
+            get
+            {
+                EnsureArg.IsNotNull(index, nameof(index));
+                return _services[index].Value;
+            }
+        }
+
+        public bool TryGetValue(object metadata, out TServiceType value)
+        {
+            EnsureArg.IsNotNull(metadata, nameof(metadata));
+
+            if (_services.TryGetValue(metadata, out Lazy<TServiceType> service))
+            {
+                value = service.Value;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        public IEnumerator<KeyValuePair<object, Lazy<TServiceType>>> GetEnumerator()
+        {
+            return _services.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Microsoft.Health.Extensions.DependencyInjection/MetadataHelper.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/MetadataHelper.cs
@@ -1,0 +1,45 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using EnsureThat;
+
+namespace Microsoft.Health.Extensions.DependencyInjection
+{
+    internal class MetadataHelper
+    {
+        private readonly Dictionary<Type, List<(object Metadata, Type Implementation)>> _serviceMetadata = new Dictionary<Type, List<(object Metadata, Type Implementation)>>();
+
+        public void AddMetadataLookup(object metadata, (Type Service, Type Implementation) serviceMapping)
+        {
+            EnsureArg.IsNotNull(metadata, nameof(metadata));
+            EnsureArg.IsNotNull(serviceMapping.Implementation, nameof(serviceMapping.Implementation));
+            EnsureArg.IsNotNull(serviceMapping.Service, nameof(serviceMapping.Service));
+
+            if (!_serviceMetadata.TryGetValue(serviceMapping.Service, out List<(object Metadata, Type Implementation)> list))
+            {
+                list = new List<(object Metadata, Type Implementation)>();
+            }
+
+            list.Add((metadata, serviceMapping.Implementation));
+            _serviceMetadata[serviceMapping.Service] = list;
+        }
+
+        public bool TryGetMetadata(Type service, out IEnumerable<(object Metadata, Type Implementation)> metadata)
+        {
+            EnsureArg.IsNotNull(service, nameof(service));
+
+            if (_serviceMetadata.TryGetValue(service, out var mapping))
+            {
+                metadata = mapping;
+                return true;
+            }
+
+            metadata = null;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationExtensions.cs
@@ -225,5 +225,19 @@ namespace Microsoft.Health.Extensions.DependencyInjection
 
             return registrations.Do(x => x.AsSelf());
         }
+
+        /// <summary>
+        /// Specify additional metadata with the registration
+        /// </summary>
+        /// <param name="registrations">The registrations.</param>
+        /// <param name="metadataResolver">Function that returns metadata about the registration</param>
+        /// <returns>The registration builder</returns>
+        public static IEnumerable<TypeRegistrationBuilder> WithMetadata(this IEnumerable<TypeRegistrationBuilder> registrations, Func<Type, object> metadataResolver)
+        {
+            EnsureArg.IsNotNull(registrations, nameof(registrations));
+            EnsureArg.IsNotNull(metadataResolver, nameof(metadataResolver));
+
+            return registrations.Do(x => x.WithMetadata(metadataResolver));
+        }
     }
 }


### PR DESCRIPTION
## Description
Adds the ability to register services with Metadata, then resolve this information with IIndex

For example, register all services implementing IComponent with the DisplayName attribute value as metadata
```csharp
            _collection.TypesInSameAssemblyAs<IComponent>()
                .AssignableTo<IComponent>()
                .Scoped()
                .WithMetadata(type => type.GetAttribute<DisplayNameAttribute>()?.DisplayName)
                .AsSelf()
                .AsImplementedInterfaces();
```

This can then be resolved later and the instance can be fetched with this value:

```csharp
            var index = container.GetService<IIndex<IComponent>>();

            IComponent componentAObj = index["Component A"];
            IComponent componentBObj = index["Component B"];
```

## Testing
Adds unit tests
