### PR TITLE
Bugfix: Auditing ActionType Executed on Exception.

### DIFF
--- a/src/Microsoft.Health.Api/Features/Audit/AuditLoggingFilterAttribute.cs
+++ b/src/Microsoft.Health.Api/Features/Audit/AuditLoggingFilterAttribute.cs
@@ -36,6 +36,18 @@ namespace Microsoft.Health.Api.Features.Audit
             base.OnActionExecuting(context);
         }
 
+        public override void OnActionExecuted(ActionExecutedContext context)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+
+            if (context.Exception != null)
+            {
+                _auditHelper.LogExecuted(context.HttpContext, _claimsExtractor, context.Exception);
+            }
+
+            base.OnActionExecuted(context);
+        }
+
         public override void OnResultExecuted(ResultExecutedContext context)
         {
             EnsureArg.IsNotNull(context, nameof(context));

--- a/src/Microsoft.Health.Api/Features/Audit/IAuditHelper.cs
+++ b/src/Microsoft.Health.Api/Features/Audit/IAuditHelper.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Health.Core.Features.Security;
 
@@ -25,6 +26,7 @@ namespace Microsoft.Health.Api.Features.Audit
         /// </summary>
         /// <param name="httpContext">The HTTP context.</param>
         /// <param name="claimsExtractor">The extractor used to extract claims.</param>
-        void LogExecuted(HttpContext httpContext, IClaimsExtractor claimsExtractor);
+        /// <param name="exception">Exception.</param>
+        void LogExecuted(HttpContext httpContext, IClaimsExtractor claimsExtractor, Exception exception = null);
     }
 }


### PR DESCRIPTION
## Description
In cases of exceptions, ActionType Executed was not being logged. This is fixed in this PR.

## Related issues
[AB#75611](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/75611).

## Testing
All the existing tests are passing.
