### PR TITLE
Updates schema upgrade notification

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Extensions/SchemaMediatorExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Extensions/SchemaMediatorExtensions.cs
@@ -33,11 +33,11 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Extensions
             return response;
         }
 
-        public static async Task NotifySchemaUpgradedAsync(this IMediator mediator, int version)
+        public static async Task NotifySchemaUpgradedAsync(this IMediator mediator, int version, bool isFullSchemaSnapshotUpgrade)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
 
-            await mediator.Publish(new SchemaUpgradedNotification(version));
+            await mediator.Publish(new SchemaUpgradedNotification(version, isFullSchemaSnapshotUpgrade));
         }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Messages/Notifications/SchemaUpgradedNotification.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Messages/Notifications/SchemaUpgradedNotification.cs
@@ -11,13 +11,16 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Messages.Notifications
 {
     public class SchemaUpgradedNotification : INotification
     {
-        public SchemaUpgradedNotification(int version)
+        public SchemaUpgradedNotification(int version, bool isFullSchemaSnapshotUpgrade)
         {
             EnsureArg.IsGte(version, 1);
 
             Version = version;
+            IsFullSchemaSnapshotUpgrade = isFullSchemaSnapshotUpgrade;
         }
 
         public int Version { get; }
+
+        public bool IsFullSchemaSnapshotUpgrade { get; }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Messages/Notifications/SchemaUpgradedNotification.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Messages/Notifications/SchemaUpgradedNotification.cs
@@ -11,16 +11,16 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Messages.Notifications
 {
     public class SchemaUpgradedNotification : INotification
     {
-        public SchemaUpgradedNotification(int version, bool isFullSchemaSnapshotUpgrade)
+        public SchemaUpgradedNotification(int version, bool isFullSchemaSnapshot)
         {
             EnsureArg.IsGte(version, 1);
 
             Version = version;
-            IsFullSchemaSnapshotUpgrade = isFullSchemaSnapshotUpgrade;
+            IsFullSchemaSnapshot = isFullSchemaSnapshot;
         }
 
         public int Version { get; }
 
-        public bool IsFullSchemaSnapshotUpgrade { get; }
+        public bool IsFullSchemaSnapshot { get; }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Health.SqlServer.Features.Schema
         private readonly SchemaUpgradeRunner _schemaUpgradeRunner;
         private readonly SchemaInformation _schemaInformation;
         private readonly ILogger<SchemaInitializer> _logger;
-        private bool _started;
 
         public SchemaInitializer(SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration, SchemaUpgradeRunner schemaUpgradeRunner, SchemaInformation schemaInformation, ILogger<SchemaInitializer> logger)
         {
@@ -84,8 +83,6 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
                 GetCurrentSchemaVersion();
             }
-
-            _started = true;
         }
 
         private void GetCurrentSchemaVersion()
@@ -233,17 +230,14 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
         public void Start()
         {
-            if (!_started)
+            if (!string.IsNullOrWhiteSpace(_sqlServerDataStoreConfiguration.ConnectionString))
             {
-                if (!string.IsNullOrWhiteSpace(_sqlServerDataStoreConfiguration.ConnectionString))
-                {
-                    Initialize();
-                }
-                else
-                {
-                    _logger.LogCritical(
-                        "There was no connection string supplied. Schema initialization can not be completed.");
-                }
+                Initialize();
+            }
+            else
+            {
+                _logger.LogCritical(
+                    "There was no connection string supplied. Schema initialization can not be completed.");
             }
         }
     }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
@@ -70,8 +70,8 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                         int? previous = schemaInformation.Current;
                         schemaInformation.Current = await schemaDataStore.UpsertInstanceSchemaInformationAsync(instanceName, schemaInformation, cancellationToken);
 
-                        // If there was a change in the schema version
-                        if (schemaInformation.Current != previous)
+                        // If there was a change in the schema version and this isn't the base schema
+                        if (schemaInformation.Current != previous && schemaInformation.Current > 0)
                         {
                             var isFullSchemaSnapshot = previous == null;
 

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
@@ -75,7 +75,6 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                         {
                             var isFullSchemaSnapshot = previous == null;
 
-                            // Fire a notification
                             await _mediator.NotifySchemaUpgradedAsync((int)schemaInformation.Current, isFullSchemaSnapshot);
                         }
 

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
@@ -71,10 +71,12 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                         schemaInformation.Current = await schemaDataStore.UpsertInstanceSchemaInformationAsync(instanceName, schemaInformation, cancellationToken);
 
                         // If there was a change in the schema version
-                        if (previous != schemaInformation.Current)
+                        if (schemaInformation.Current != previous)
                         {
+                            var isFullSchemaSnapshot = previous == null;
+
                             // Fire a notification
-                            await _mediator.NotifySchemaUpgradedAsync((int)schemaInformation.Current);
+                            await _mediator.NotifySchemaUpgradedAsync((int)schemaInformation.Current, isFullSchemaSnapshot);
                         }
 
                         await schemaDataStore.DeleteExpiredInstanceSchemaAsync(cancellationToken);

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
             CompleteSchemaVersion(version);
 
-            _mediator.NotifySchemaUpgradedAsync(version).Wait();
+            _mediator.NotifySchemaUpgradedAsync(version, applyFullSchemaSnapshot).Wait();
             _logger.LogInformation("Completed applying schema {version}", version);
         }
 


### PR DESCRIPTION
## Description
This PR adds a new property to `SchemaUpgradedNotification` that indicates whether or not a full schema snapshot was applied. This information will be used by the fhir-server to determine which SQL initialization code should be run.

A bit more info: if a full schema snapshot is applied (`x.sql`), then initialization for every version (`V1`, `V2`, ... `V(x-1)`, `Vx`) should be run. If a schema diff is applied (`x.diff.sql`), then only initialization for `Vx` needs to be run.

## Related issues
Addresses [#AB75785](https://microsofthealth.visualstudio.com/Health/_workitems/edit/75785).

## Testing
Manually updated my local fhir-server `.dll` and `.pdb` files and checked that the correct information was being passed when the schema was upgraded.
