### PR TITLE
Updates compatibility validation for apply command

### DIFF
--- a/tools/SchemaManager/Resources.Designer.cs
+++ b/tools/SchemaManager/Resources.Designer.cs
@@ -322,15 +322,6 @@ namespace SchemaManager {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Attempt {0} of {1} to verify if the schema version is compatible..
-        /// </summary>
-        internal static string RetryVersionCompatibility {
-            get {
-                return ResourceManager.GetString("RetryVersionCompatibility", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Schema migration is started for the version : {0}..
         /// </summary>
         internal static string SchemaMigrationStartedMessage {

--- a/tools/SchemaManager/Resources.resx
+++ b/tools/SchemaManager/Resources.resx
@@ -211,10 +211,6 @@
     <value>Attempt {0} of {1} to verify if the base schema is synced up with the service.</value>
     <comment>(0) is retry attempt, {1} is total number of retries.</comment>
   </data>
-  <data name="RetryVersionCompatibility" xml:space="preserve">
-    <value>Attempt {0} of {1} to verify if the schema version is compatible.</value>
-    <comment>(0) is retry attempt, {1} is total retries</comment>
-  </data>
   <data name="SchemaMigrationStartedMessage" xml:space="preserve">
     <value>Schema migration is started for the version : {0}.</value>
     <comment>{0} is a version.</comment>


### PR DESCRIPTION
## Description
Updates the compatibility validation to check if the max available version is lesser than or equals to the max compatible version.
Removes the check for min available version.

## Related issues
Addresses [#AB75644](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=75644)

## Testing
Tested locally by running the apply command via schema migration tool
