### PR TITLE
Fixes apply full schema snapshot

### DIFF
--- a/tools/SchemaManager/Commands/ApplyCommand.cs
+++ b/tools/SchemaManager/Commands/ApplyCommand.cs
@@ -85,7 +85,8 @@ namespace SchemaManager.Commands
                 {
                     await ValidateVersionCompatibility(schemaClient, availableVersions.Last().Id);
                 }
-                else if (availableVersions.First().Id == 1)
+
+                if (availableVersions.First().Id == 1)
                 {
                     // Upgrade schema directly to the latest schema version
                     Console.WriteLine(string.Format(Resources.SchemaMigrationStartedMessage, availableVersions.Last().Id));

--- a/tools/SchemaManager/SchemaDataStore.cs
+++ b/tools/SchemaManager/SchemaDataStore.cs
@@ -30,11 +30,7 @@ namespace SchemaManager
 
                     serverConnection.BeginTransaction();
 
-                    // Since version 3 is just the base schema which must already be executed at the start of apply command and can be skipped
-                    if (version != 3)
-                    {
-                        server.ConnectionContext.ExecuteNonQuery(script);
-                    }
+                    server.ConnectionContext.ExecuteNonQuery(script);
 
                     UpsertSchemaVersion(connection, version, Completed);
 


### PR DESCRIPTION
## Description
This change enables to apply x.sql even without the force option if the current schema version is null, where x is the maximum supported schema version.

## Related issues
Addresses [#75643](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=75643)

## Testing
Manually tested by running the schema migration tool.

- Started the server on schema version null
- Hit the command below command to apply latest supported version
 Microsoft.Health.SchemaManager apply --latest -cs "server=(local);Initial Catalog=SHARED_HEALTHCARE;Integrated Security=true" -s https://localhost:63637/

![image](https://user-images.githubusercontent.com/57157506/94084539-a019a100-fdba-11ea-9d27-688b286bf169.png)

