### PR TITLE
Migrate to Microsoft.Data.SqlClient

### DIFF
--- a/src/Microsoft.Health.Client.UnitTests/CredentialProviderTests.cs
+++ b/src/Microsoft.Health.Client.UnitTests/CredentialProviderTests.cs
@@ -4,9 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
-using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
 namespace Microsoft.Health.Client.UnitTests

--- a/src/Microsoft.Health.Client/OAuth2ClientCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/OAuth2ClientCredentialProvider.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;

--- a/src/Microsoft.Health.SqlServer.UnitTests/Extensions/SqlExceptionExtensionsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Extensions/SqlExceptionExtensionsTests.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.SqlServer.Extensions;
 using Xunit;
 

--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Client/RetrySqlCommandWrapperTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Client/RetrySqlCommandWrapperTests.cs
@@ -5,9 +5,9 @@
 
 using System;
 using System.Data;
-using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.SqlServer.Extensions;
 using Microsoft.Health.SqlServer.Features.Client;
 using NSubstitute;

--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Client/SqlServerTransientFaultRetryPolicyFactoryTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Client/SqlServerTransientFaultRetryPolicyFactoryTests.cs
@@ -5,8 +5,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Client;
 using NSubstitute;

--- a/src/Microsoft.Health.SqlServer.UnitTests/SqlExceptionFactory.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/SqlExceptionFactory.cs
@@ -4,9 +4,9 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Data.SqlClient;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Health.SqlServer.UnitTests
 {

--- a/src/Microsoft.Health.SqlServer.UnitTests/SqlMetadataUtilitiesTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/SqlMetadataUtilitiesTests.cs
@@ -4,8 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Data;
+using Microsoft.Data.SqlClient.Server;
 using Microsoft.Health.SqlServer.Features.Schema.Model;
-using Microsoft.SqlServer.Server;
 using Xunit;
 
 namespace Microsoft.Health.SqlServer.UnitTests

--- a/src/Microsoft.Health.SqlServer/Extensions/SqlExceptionExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Extensions/SqlExceptionExtensions.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Health.SqlServer.Extensions
 {

--- a/src/Microsoft.Health.SqlServer/Features/Client/RetrySqlCommandWrapper.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/RetrySqlCommandWrapper.cs
@@ -4,10 +4,10 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Data;
-using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Polly;
 
 namespace Microsoft.Health.SqlServer.Features.Client

--- a/src/Microsoft.Health.SqlServer/Features/Client/RetrySqlCommandWrapperFactory.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/RetrySqlCommandWrapperFactory.cs
@@ -3,8 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Data.SqlClient;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Polly;
 
 namespace Microsoft.Health.SqlServer.Features.Client

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlCommandWrapper.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlCommandWrapper.cs
@@ -5,11 +5,11 @@
 
 using System;
 using System.Data;
-using System.Data.Sql;
-using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using Microsoft.Data.Sql;
+using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Health.SqlServer.Features.Client
 {

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlCommandWrapperFactory.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlCommandWrapperFactory.cs
@@ -3,8 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Data.SqlClient;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Health.SqlServer.Features.Client
 {

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapper.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapper.cs
@@ -5,8 +5,8 @@
 
 using System;
 using System.Data;
-using System.Data.SqlClient;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Storage;
 

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlServerTransientFaultRetryPolicyFactory.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlServerTransientFaultRetryPolicyFactory.cs
@@ -5,8 +5,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Extensions;
 using Polly;

--- a/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
@@ -4,10 +4,10 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.SqlServer.Configs;

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Messages/Notifications/SchemaUpgradedNotification.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Messages/Notifications/SchemaUpgradedNotification.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using EnsureThat;
 using MediatR;
 

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -6,10 +6,10 @@
 using System;
 using System.Buffers;
 using System.Data;
-using System.Data.SqlClient;
 using System.IO;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient.Server;
 using Microsoft.Health.SqlServer.Features.Storage;
-using Microsoft.SqlServer.Server;
 
 namespace Microsoft.Health.SqlServer.Features.Schema.Model
 {

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/ParameterDefinition.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/ParameterDefinition.cs
@@ -4,8 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Data;
-using System.Data.SqlClient;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Health.SqlServer.Features.Schema.Model
 {

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/SqlMetadataUtilities.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/SqlMetadataUtilities.cs
@@ -5,7 +5,7 @@
 
 using System.Data;
 using EnsureThat;
-using Microsoft.SqlServer.Server;
+using Microsoft.Data.SqlClient.Server;
 
 namespace Microsoft.Health.SqlServer.Features.Schema.Model
 {

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/TableValuedParameterDefinition.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/TableValuedParameterDefinition.cs
@@ -5,10 +5,10 @@
 
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 using EnsureThat;
-using Microsoft.SqlServer.Server;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient.Server;
 
 namespace Microsoft.Health.SqlServer.Features.Schema.Model
 {

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -4,8 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Data.SqlClient;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.SqlServer.Configs;

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
@@ -4,9 +4,9 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Data;
-using System.Data.SqlClient;
 using EnsureThat;
 using MediatR;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema.Extensions;

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlDataReaderExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlDataReaderExtensions.cs
@@ -4,9 +4,9 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Data.SqlClient;
 using System.Diagnostics;
 using System.IO;
+using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Health.SqlServer.Features.Storage
 {

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlDataReaderRowExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlDataReaderRowExtensions.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.SqlServer.Features.Schema.Model;
 
 namespace Microsoft.Health.SqlServer.Features.Storage

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlQueryParameterManager.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlQueryParameterManager.cs
@@ -5,8 +5,8 @@
 
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.SqlServer.Features.Schema.Model;
 
 namespace Microsoft.Health.SqlServer.Features.Storage

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
@@ -5,11 +5,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Client;

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlTransactionScope.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlTransactionScope.cs
@@ -4,8 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Data.SqlClient;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.Abstractions.Features.Transactions;
 
 namespace Microsoft.Health.SqlServer.Features.Storage

--- a/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
+++ b/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
@@ -20,10 +20,10 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.7" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.2" />
-    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="150.18208.0" />
+    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.41011.9" />
     <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -40,7 +40,7 @@
       <Args>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\Features\Schema\Migrations\BaseSchema.sql'))</Args>
     </Generated>
   </ItemGroup>
-  
+
   <ItemGroup>
     <Generated Include="IndentedStringBuilder.Generated.cs">
       <Generator>IndentedStringBuilderGenerator</Generator>

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.csproj
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.3.1" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4384.2-preview" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.2.0-alpha.19174.3" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
   </ItemGroup>
 
   <!-- Pack settings -->

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/CreateTableTypeVisitor.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/CreateTableTypeVisitor.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.SqlServer.Server;
+using Microsoft.Data.SqlClient.Server;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/tools/SchemaManager/Commands/ApplyCommand.cs
+++ b/tools/SchemaManager/Commands/ApplyCommand.cs
@@ -5,11 +5,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Management.Common;
 using Polly;
 using SchemaManager.Exceptions;

--- a/tools/SchemaManager/SchemaDataStore.cs
+++ b/tools/SchemaManager/SchemaDataStore.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
 

--- a/tools/SchemaManager/SchemaManager.csproj
+++ b/tools/SchemaManager/SchemaManager.csproj
@@ -11,12 +11,12 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="150.18208.0" />
+    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.41011.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19174.3" />
     <PackageReference Include="System.CommandLine.Rendering" Version="0.2.0-alpha.19174.3" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
     <PackageReference Include="Microsoft.Health.SqlServer" Version="1.0.0-master-20200826-1" />
   </ItemGroup>
 

--- a/tools/SchemaManager/Utils/BaseSchemaRunner.cs
+++ b/tools/SchemaManager/Utils/BaseSchemaRunner.cs
@@ -4,7 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Polly;
 using SchemaManager.Exceptions;


### PR DESCRIPTION
## Description
Switching from System.Data.SqlClient (which is in maintenance mode) to [Microsoft.Data.SqlClient ](https://github.com/dotnet/SqlClient).

[Announcement](https://devblogs.microsoft.com/dotnet/introducing-the-new-microsoftdatasqlclient/) (May 2019).

I've tried this out in this fhir-server codebase and all tests are passing.