### PR TITLE
Fixes base schema execution

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Migrations/BaseSchema.sql
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Migrations/BaseSchema.sql
@@ -5,8 +5,9 @@
     Configure database
 **************************************************************/
 -- Enable RCSI
+-- ROLLBACK IMMEDIATE will cut off live connections and roll back any open transactions immediately
 IF ((SELECT is_read_committed_snapshot_on FROM sys.databases WHERE database_id = DB_ID()) = 0) BEGIN
-    ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON
+    ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON WITH ROLLBACK IMMEDIATE
 END
 
 -- Avoid blocking queries when statistics need to be rebuilt

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Migrations/BaseSchema.sql
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Migrations/BaseSchema.sql
@@ -5,9 +5,8 @@
     Configure database
 **************************************************************/
 -- Enable RCSI
--- ROLLBACK IMMEDIATE will cut off live connections and roll back any open transactions immediately
 IF ((SELECT is_read_committed_snapshot_on FROM sys.databases WHERE database_id = DB_ID()) = 0) BEGIN
-    ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON WITH ROLLBACK IMMEDIATE
+    ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON
 END
 
 -- Avoid blocking queries when statistics need to be rebuilt

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Migrations/BaseSchema.sql
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Migrations/BaseSchema.sql
@@ -4,10 +4,10 @@
 /*************************************************************
     Configure database
 **************************************************************/
-
 -- Enable RCSI
+-- ROLLBACK IMMEDIATE will cut off live connections and roll back any open transactions immediately
 IF ((SELECT is_read_committed_snapshot_on FROM sys.databases WHERE database_id = DB_ID()) = 0) BEGIN
-    ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON
+    ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON WITH ROLLBACK IMMEDIATE
 END
 
 -- Avoid blocking queries when statistics need to be rebuilt

--- a/test/Microsoft.Health.SqlServer.Web/Startup.cs
+++ b/test/Microsoft.Health.SqlServer.Web/Startup.cs
@@ -3,13 +3,10 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Health.Core;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.SqlServer.Api.Features;
 using Microsoft.Health.SqlServer.Api.Registration;
@@ -49,17 +46,6 @@ namespace Microsoft.Health.SqlServer.Web
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public virtual void Configure(IApplicationBuilder app)
         {
-            ILogger logger = app.ApplicationServices.GetRequiredService<ILoggerFactory>().CreateLogger<Startup>();
-
-            // Start IStartable services.
-            foreach (var startable in app.ApplicationServices.GetService<IEnumerable<IStartable>>())
-            {
-                using (logger.BeginTimedScope($"Initializing {startable.GetType().Name}."))
-                {
-                    startable.Start();
-                }
-            }
-
             app.UseMvc();
         }
     }

--- a/test/Microsoft.Health.SqlServer.Web/Startup.cs
+++ b/test/Microsoft.Health.SqlServer.Web/Startup.cs
@@ -3,10 +3,13 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Core;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.SqlServer.Api.Features;
 using Microsoft.Health.SqlServer.Api.Registration;
@@ -46,6 +49,17 @@ namespace Microsoft.Health.SqlServer.Web
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public virtual void Configure(IApplicationBuilder app)
         {
+            ILogger logger = app.ApplicationServices.GetRequiredService<ILoggerFactory>().CreateLogger<Startup>();
+
+            // Start IStartable services.
+            foreach (var startable in app.ApplicationServices.GetService<IEnumerable<IStartable>>())
+            {
+                using (logger.BeginTimedScope($"Initializing {startable.GetType().Name}."))
+                {
+                    startable.Start();
+                }
+            }
+
             app.UseMvc();
         }
     }

--- a/tools/SchemaManager/Commands/ApplyCommand.cs
+++ b/tools/SchemaManager/Commands/ApplyCommand.cs
@@ -57,7 +57,7 @@ namespace SchemaManager.Commands
                     {
                         Console.WriteLine(string.Format(Resources.RetryCurrentSchemaVersion, attemptCount++, RetryAttempts));
                     })
-                .ExecuteAsync(() => FetchUpdatedAvailableVersionsAsync(schemaClient, connectionString, cancellationToken));
+                .ExecuteAsync(token => FetchUpdatedAvailableVersionsAsync(schemaClient, connectionString, token), cancellationToken);
 
                 if (availableVersions.Count == 1)
                 {
@@ -114,7 +114,7 @@ namespace SchemaManager.Commands
                             {
                                 Console.WriteLine(string.Format(Resources.RetryCurrentVersions, attemptCount++, RetryAttempts));
                             })
-                        .ExecuteAsync(() => ValidateInstancesVersion(schemaClient, executingVersion, cancellationToken));
+                        .ExecuteAsync(token => ValidateInstancesVersionAsync(schemaClient, executingVersion, token), cancellationToken);
                     }
 
                     string script = await GetScriptAsync(schemaClient, executingVersion, availableVersion.ScriptUri, cancellationToken, availableVersion.DiffUri);
@@ -180,7 +180,7 @@ namespace SchemaManager.Commands
             }
         }
 
-        private static async Task ValidateInstancesVersion(ISchemaClient schemaClient, int version, CancellationToken cancellationToken)
+        private static async Task ValidateInstancesVersionAsync(ISchemaClient schemaClient, int version, CancellationToken cancellationToken)
         {
             List<CurrentVersion> currentVersions = await schemaClient.GetCurrentVersionInformationAsync(cancellationToken);
 

--- a/tools/SchemaManager/Commands/ApplyCommand.cs
+++ b/tools/SchemaManager/Commands/ApplyCommand.cs
@@ -41,9 +41,9 @@ namespace SchemaManager.Commands
 
                 // If InstanceSchema table is just created(as part of baseSchema), it takes a while to insert a version record
                 // since the Schema job polls and upserts at the specified interval in the service.
-                await BaseSchemaRunner.EnsureInstanceSchemaRecordExistsAsync(connectionString);
+                await BaseSchemaRunner.EnsureInstanceSchemaRecordExistsAsync(connectionString, cancellationToken);
 
-                availableVersions = await schemaClient.GetAvailability();
+                availableVersions = await schemaClient.GetAvailabilityAsync(cancellationToken);
 
                 // If the user hits apply command multiple times in a row, then the service schema job might not poll the updated available versions
                 // so there are retries to give it a fair amount of time.
@@ -57,7 +57,7 @@ namespace SchemaManager.Commands
                     {
                         Console.WriteLine(string.Format(Resources.RetryCurrentSchemaVersion, attemptCount++, RetryAttempts));
                     })
-                .ExecuteAsync(() => FetchUpdatedAvailableVersions(schemaClient, connectionString));
+                .ExecuteAsync(() => FetchUpdatedAvailableVersionsAsync(schemaClient, connectionString, cancellationToken));
 
                 if (availableVersions.Count == 1)
                 {
@@ -83,7 +83,7 @@ namespace SchemaManager.Commands
 
                 if (!force)
                 {
-                    await ValidateVersionCompatibility(schemaClient, availableVersions.Last().Id);
+                    await ValidateVersionCompatibility(schemaClient, availableVersions.Last().Id, cancellationToken);
                 }
 
                 if (availableVersions.First().Id == 1)
@@ -91,8 +91,8 @@ namespace SchemaManager.Commands
                     // Upgrade schema directly to the latest schema version
                     Console.WriteLine(string.Format(Resources.SchemaMigrationStartedMessage, availableVersions.Last().Id));
 
-                    string script = await GetScript(schemaClient, 1, availableVersions.Last().ScriptUri);
-                    await UpgradeSchema(connectionString, availableVersions.Last().Id, script);
+                    string script = await GetScriptAsync(schemaClient, 1, availableVersions.Last().ScriptUri, cancellationToken);
+                    await UpgradeSchemaAsync(connectionString, availableVersions.Last().Id, script, cancellationToken);
                     return;
                 }
 
@@ -114,12 +114,12 @@ namespace SchemaManager.Commands
                             {
                                 Console.WriteLine(string.Format(Resources.RetryCurrentVersions, attemptCount++, RetryAttempts));
                             })
-                        .ExecuteAsync(() => ValidateInstancesVersion(schemaClient, executingVersion));
+                        .ExecuteAsync(() => ValidateInstancesVersion(schemaClient, executingVersion, cancellationToken));
                     }
 
-                    string script = await GetScript(schemaClient, executingVersion, availableVersion.ScriptUri, availableVersion.DiffUri);
+                    string script = await GetScriptAsync(schemaClient, executingVersion, availableVersion.ScriptUri, cancellationToken, availableVersion.DiffUri);
 
-                    await UpgradeSchema(connectionString, executingVersion, script);
+                    await UpgradeSchemaAsync(connectionString, executingVersion, script, cancellationToken);
                 }
             }
             catch (Exception ex) when (ex is SchemaManagerException || ex is InvalidOperationException)
@@ -150,29 +150,29 @@ namespace SchemaManager.Commands
             }
         }
 
-        private static async Task UpgradeSchema(string connectionString, int version, string script)
+        private static async Task UpgradeSchemaAsync(string connectionString, int version, string script, CancellationToken cancellationToken)
         {
             // check if the record for given version exists in failed status
-            await SchemaDataStore.DeleteSchemaVersionAsync(connectionString, version, SchemaDataStore.Failed);
+            await SchemaDataStore.DeleteSchemaVersionAsync(connectionString, version, SchemaDataStore.Failed, cancellationToken);
 
-            await SchemaDataStore.ExecuteScriptAndCompleteSchemaVersionAsync(connectionString, script, version);
+            await SchemaDataStore.ExecuteScriptAndCompleteSchemaVersionAsync(connectionString, script, version, cancellationToken);
 
             Console.WriteLine(string.Format(Resources.SchemaMigrationSuccessMessage, version));
         }
 
-        private static async Task<string> GetScript(ISchemaClient schemaClient, int version, string scriptUri, string diffUri = null)
+        private static async Task<string> GetScriptAsync(ISchemaClient schemaClient, int version, string scriptUri, CancellationToken cancellationToken, string diffUri = null)
         {
             if (version == 1)
             {
-                return await schemaClient.GetScript(new Uri(scriptUri, UriKind.Relative));
+                return await schemaClient.GetScriptAsync(new Uri(scriptUri, UriKind.Relative), cancellationToken);
             }
 
-            return await schemaClient.GetDiffScript(new Uri(diffUri, UriKind.Relative));
+            return await schemaClient.GetDiffScriptAsync(new Uri(diffUri, UriKind.Relative), cancellationToken);
         }
 
-        private static async Task ValidateVersionCompatibility(ISchemaClient schemaClient, int maxAvailableVersion)
+        private static async Task ValidateVersionCompatibility(ISchemaClient schemaClient, int maxAvailableVersion, CancellationToken cancellationToken)
         {
-            CompatibleVersion compatibleVersion = await schemaClient.GetCompatibility();
+            CompatibleVersion compatibleVersion = await schemaClient.GetCompatibilityAsync(cancellationToken);
 
             if (maxAvailableVersion > compatibleVersion.Max)
             {
@@ -180,9 +180,9 @@ namespace SchemaManager.Commands
             }
         }
 
-        private static async Task ValidateInstancesVersion(ISchemaClient schemaClient, int version)
+        private static async Task ValidateInstancesVersion(ISchemaClient schemaClient, int version, CancellationToken cancellationToken)
         {
-            List<CurrentVersion> currentVersions = await schemaClient.GetCurrentVersionInformation();
+            List<CurrentVersion> currentVersions = await schemaClient.GetCurrentVersionInformationAsync(cancellationToken);
 
             // check if any instance is not running on the previous version
             if (currentVersions.Any(currentVersion => currentVersion.Id != (version - 1) && currentVersion.Servers.Count > 0))
@@ -197,13 +197,13 @@ namespace SchemaManager.Commands
             return string.Equals(Console.ReadLine(), "yes", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static async Task FetchUpdatedAvailableVersions(ISchemaClient schemaClient, string connectionString)
+        private static async Task FetchUpdatedAvailableVersionsAsync(ISchemaClient schemaClient, string connectionString, CancellationToken cancellationToken)
         {
-            availableVersions = await schemaClient.GetAvailability();
+            availableVersions = await schemaClient.GetAvailabilityAsync(cancellationToken);
 
             availableVersions.Sort((x, y) => x.Id.CompareTo(y.Id));
 
-            if (availableVersions.First().Id != await SchemaDataStore.GetCurrentSchemaVersionAsync(connectionString))
+            if (availableVersions.First().Id != await SchemaDataStore.GetCurrentSchemaVersionAsync(connectionString, cancellationToken))
             {
                 throw new SchemaManagerException(Resources.AvailableVersionsErrorMessage);
             }

--- a/tools/SchemaManager/Commands/AvailableCommand.cs
+++ b/tools/SchemaManager/Commands/AvailableCommand.cs
@@ -10,6 +10,7 @@ using System.CommandLine.Rendering;
 using System.CommandLine.Rendering.Views;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using SchemaManager.Exceptions;
 using SchemaManager.Model;
@@ -19,7 +20,7 @@ namespace SchemaManager.Commands
 {
     public static class AvailableCommand
     {
-        public static async Task Handler(InvocationContext invocationContext, Uri server)
+        public static async Task HandlerAsync(InvocationContext invocationContext, Uri server, CancellationToken cancellationToken)
         {
             var region = new Region(
                 0,
@@ -33,7 +34,7 @@ namespace SchemaManager.Commands
 
             try
             {
-                availableVersions = await schemaClient.GetAvailability();
+                availableVersions = await schemaClient.GetAvailabilityAsync(cancellationToken);
 
                 // To ensure that schema version null/0 is not printed
                 if (availableVersions.First().Id == 0)

--- a/tools/SchemaManager/Commands/CurrentCommand.cs
+++ b/tools/SchemaManager/Commands/CurrentCommand.cs
@@ -38,9 +38,9 @@ namespace SchemaManager.Commands
 
                 // If InstanceSchema table is just created(as part of baseSchema), it takes a while to insert a version record
                 // since the Schema job polls and upserts at the specified interval in the service.
-                await BaseSchemaRunner.EnsureInstanceSchemaRecordExistsAsync(connectionString);
+                await BaseSchemaRunner.EnsureInstanceSchemaRecordExistsAsync(connectionString, cancellationToken);
 
-                currentVersions = await schemaClient.GetCurrentVersionInformation();
+                currentVersions = await schemaClient.GetCurrentVersionInformationAsync(cancellationToken);
             }
             catch (SchemaManagerException ex)
             {

--- a/tools/SchemaManager/Commands/CurrentCommand.cs
+++ b/tools/SchemaManager/Commands/CurrentCommand.cs
@@ -38,7 +38,7 @@ namespace SchemaManager.Commands
 
                 // If InstanceSchema table is just created(as part of baseSchema), it takes a while to insert a version record
                 // since the Schema job polls and upserts at the specified interval in the service.
-                BaseSchemaRunner.EnsureInstanceSchemaRecordExists(connectionString);
+                await BaseSchemaRunner.EnsureInstanceSchemaRecordExistsAsync(connectionString);
 
                 currentVersions = await schemaClient.GetCurrentVersionInformation();
             }

--- a/tools/SchemaManager/ISchemaClient.cs
+++ b/tools/SchemaManager/ISchemaClient.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using SchemaManager.Model;
 
@@ -12,14 +13,14 @@ namespace SchemaManager
 {
     public interface ISchemaClient
     {
-        Task<List<CurrentVersion>> GetCurrentVersionInformation();
+        Task<List<CurrentVersion>> GetCurrentVersionInformationAsync(CancellationToken cancellationToken);
 
-        Task<string> GetScript(Uri scriptUri);
+        Task<string> GetScriptAsync(Uri scriptUri, CancellationToken cancellationToken);
 
-        Task<string> GetDiffScript(Uri diffScriptUri);
+        Task<string> GetDiffScriptAsync(Uri diffScriptUri, CancellationToken cancellationToken);
 
-        Task<CompatibleVersion> GetCompatibility();
+        Task<CompatibleVersion> GetCompatibilityAsync(CancellationToken cancellationToken);
 
-        Task<List<AvailableVersion>> GetAvailability();
+        Task<List<AvailableVersion>> GetAvailabilityAsync(CancellationToken cancellationToken);
     }
 }

--- a/tools/SchemaManager/Program.cs
+++ b/tools/SchemaManager/Program.cs
@@ -82,7 +82,7 @@ namespace SchemaManager
             {
                 serverOption,
             };
-            availableCommand.Handler = CommandHandler.Create<InvocationContext, Uri>(AvailableCommand.Handler);
+            availableCommand.Handler = CommandHandler.Create<InvocationContext, Uri, CancellationToken>(AvailableCommand.HandlerAsync);
             availableCommand.Argument.AddValidator(symbol => Validators.RequiredOptionValidator.Validate(symbol, serverOption, Resources.ServerRequiredValidation));
 
             rootCommand.AddCommand(applyCommand);

--- a/tools/SchemaManager/SchemaClient.cs
+++ b/tools/SchemaManager/SchemaClient.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using SchemaManager.Exceptions;
@@ -24,9 +25,9 @@ namespace SchemaManager
             _httpClient.BaseAddress = serverUri;
         }
 
-        public async Task<List<CurrentVersion>> GetCurrentVersionInformation()
+        public async Task<List<CurrentVersion>> GetCurrentVersionInformationAsync(CancellationToken cancellationToken)
         {
-            var response = await _httpClient.GetAsync(RelativeUrl(UrlConstants.Current));
+            var response = await _httpClient.GetAsync(RelativeUrl(UrlConstants.Current), cancellationToken);
             if (response.IsSuccessStatusCode)
             {
                 var responseBodyAsString = await response.Content.ReadAsStringAsync();
@@ -38,9 +39,9 @@ namespace SchemaManager
             }
         }
 
-        public async Task<string> GetScript(Uri scriptUri)
+        public async Task<string> GetScriptAsync(Uri scriptUri, CancellationToken cancellationToken)
         {
-            var response = await _httpClient.GetAsync(scriptUri);
+            var response = await _httpClient.GetAsync(scriptUri, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
                 return await response.Content.ReadAsStringAsync();
@@ -51,9 +52,9 @@ namespace SchemaManager
             }
         }
 
-        public async Task<CompatibleVersion> GetCompatibility()
+        public async Task<CompatibleVersion> GetCompatibilityAsync(CancellationToken cancellationToken)
         {
-            var response = await _httpClient.GetAsync(RelativeUrl(UrlConstants.Compatibility));
+            var response = await _httpClient.GetAsync(RelativeUrl(UrlConstants.Compatibility), cancellationToken);
             if (response.IsSuccessStatusCode)
             {
                 var responseBodyAsString = await response.Content.ReadAsStringAsync();
@@ -65,9 +66,9 @@ namespace SchemaManager
             }
         }
 
-        public async Task<List<AvailableVersion>> GetAvailability()
+        public async Task<List<AvailableVersion>> GetAvailabilityAsync(CancellationToken cancellationToken)
         {
-            var response = await _httpClient.GetAsync(RelativeUrl(UrlConstants.Availability));
+            var response = await _httpClient.GetAsync(RelativeUrl(UrlConstants.Availability), cancellationToken);
             if (response.IsSuccessStatusCode)
             {
                 var responseBodyAsString = await response.Content.ReadAsStringAsync();
@@ -79,9 +80,9 @@ namespace SchemaManager
             }
         }
 
-        public async Task<string> GetDiffScript(Uri diffUri)
+        public async Task<string> GetDiffScriptAsync(Uri diffUri, CancellationToken cancellationToken)
         {
-            var response = await _httpClient.GetAsync(diffUri);
+            var response = await _httpClient.GetAsync(diffUri, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
                 return await response.Content.ReadAsStringAsync();

--- a/tools/SchemaManager/SchemaDataStore.cs
+++ b/tools/SchemaManager/SchemaDataStore.cs
@@ -98,11 +98,11 @@ namespace SchemaManager
             }
         }
 
-        public static async Task ExecuteScript(string connectionString, string script)
+        public static async Task ExecuteScript(string connectionString, string script, CancellationToken cancellationToken)
         {
             using (var connection = new SqlConnection(connectionString))
             {
-                await connection.OpenAsync();
+                await connection.OpenAsync(cancellationToken);
                 var server = new Server(new ServerConnection(connection));
 
                 server.ConnectionContext.ExecuteNonQuery(script);

--- a/tools/SchemaManager/SchemaManager.csproj
+++ b/tools/SchemaManager/SchemaManager.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Health.SqlServer\Microsoft.Health.SqlServer.csproj" />
+    <PackageReference Include="Microsoft.Health.SqlServer" Version="1.0.0-master-20201008-2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/SchemaManager/Utils/BaseSchemaRunner.cs
+++ b/tools/SchemaManager/Utils/BaseSchemaRunner.cs
@@ -24,7 +24,7 @@ namespace SchemaManager.Utils
 
             await InitializeAsync(connectionString, cancellationToken);
 
-            if (!await SchemaDataStore.BaseSchemaExistsAsync(connectionString))
+            if (!await SchemaDataStore.BaseSchemaExistsAsync(connectionString, cancellationToken))
             {
                 var script = baseScriptProvider.GetScript();
 
@@ -40,7 +40,7 @@ namespace SchemaManager.Utils
             }
         }
 
-        public static async Task EnsureInstanceSchemaRecordExistsAsync(string connectionString)
+        public static async Task EnsureInstanceSchemaRecordExistsAsync(string connectionString, CancellationToken cancellationToken)
         {
             // Ensure that the current version record is inserted into InstanceSchema table
             int attempts = 1;
@@ -53,12 +53,12 @@ namespace SchemaManager.Utils
                 {
                     Console.WriteLine(string.Format(Resources.RetryInstanceSchemaRecord, attempts++, RetryAttempts));
                 })
-            .ExecuteAsync(() => InstanceSchemaRecordCreatedAsync(connectionString));
+            .ExecuteAsync(() => InstanceSchemaRecordCreatedAsync(connectionString, cancellationToken));
         }
 
-        private static async Task InstanceSchemaRecordCreatedAsync(string connectionString)
+        private static async Task InstanceSchemaRecordCreatedAsync(string connectionString, CancellationToken cancellationToken)
         {
-            if (!await SchemaDataStore.InstanceSchemaRecordExistsAsync(connectionString))
+            if (!await SchemaDataStore.InstanceSchemaRecordExistsAsync(connectionString, cancellationToken))
             {
                 throw new SchemaManagerException(Resources.InstanceSchemaRecordErrorMessage);
             }

--- a/tools/SchemaManager/Utils/BaseSchemaRunner.cs
+++ b/tools/SchemaManager/Utils/BaseSchemaRunner.cs
@@ -24,13 +24,13 @@ namespace SchemaManager.Utils
 
             await InitializeAsync(connectionString, cancellationToken);
 
-            if (!SchemaDataStore.BaseSchemaExists(connectionString))
+            if (!await SchemaDataStore.BaseSchemaExistsAsync(connectionString))
             {
                 var script = baseScriptProvider.GetScript();
 
                 Console.WriteLine(Resources.BaseSchemaExecuting);
 
-                SchemaDataStore.ExecuteScript(connectionString, script);
+                await SchemaDataStore.ExecuteScript(connectionString, script);
 
                 Console.WriteLine(Resources.BaseSchemaSuccess);
             }
@@ -40,25 +40,25 @@ namespace SchemaManager.Utils
             }
         }
 
-        public static void EnsureInstanceSchemaRecordExists(string connectionString)
+        public static async Task EnsureInstanceSchemaRecordExistsAsync(string connectionString)
         {
             // Ensure that the current version record is inserted into InstanceSchema table
             int attempts = 1;
 
-            Policy.Handle<SchemaManagerException>()
-            .WaitAndRetry(
+            await Policy.Handle<SchemaManagerException>()
+            .WaitAndRetryAsync(
                 retryCount: RetryAttempts,
                 sleepDurationProvider: (retryCount) => RetrySleepDuration,
                 onRetry: (exception, retryCount) =>
                 {
                     Console.WriteLine(string.Format(Resources.RetryInstanceSchemaRecord, attempts++, RetryAttempts));
                 })
-            .Execute(() => InstanceSchemaRecordCreated(connectionString));
+            .ExecuteAsync(() => InstanceSchemaRecordCreatedAsync(connectionString));
         }
 
-        private static void InstanceSchemaRecordCreated(string connectionString)
+        private static async Task InstanceSchemaRecordCreatedAsync(string connectionString)
         {
-            if (!SchemaDataStore.InstanceSchemaRecordExists(connectionString))
+            if (!await SchemaDataStore.InstanceSchemaRecordExistsAsync(connectionString))
             {
                 throw new SchemaManagerException(Resources.InstanceSchemaRecordErrorMessage);
             }

--- a/tools/SchemaManager/Utils/BaseSchemaRunner.cs
+++ b/tools/SchemaManager/Utils/BaseSchemaRunner.cs
@@ -30,7 +30,7 @@ namespace SchemaManager.Utils
 
                 Console.WriteLine(Resources.BaseSchemaExecuting);
 
-                await SchemaDataStore.ExecuteScript(connectionString, script);
+                await SchemaDataStore.ExecuteScript(connectionString, script, cancellationToken);
 
                 Console.WriteLine(Resources.BaseSchemaSuccess);
             }
@@ -53,7 +53,7 @@ namespace SchemaManager.Utils
                 {
                     Console.WriteLine(string.Format(Resources.RetryInstanceSchemaRecord, attempts++, RetryAttempts));
                 })
-            .ExecuteAsync(() => InstanceSchemaRecordCreatedAsync(connectionString, cancellationToken));
+            .ExecuteAsync(token => InstanceSchemaRecordCreatedAsync(connectionString, token), cancellationToken);
         }
 
         private static async Task InstanceSchemaRecordCreatedAsync(string connectionString, CancellationToken cancellationToken)


### PR DESCRIPTION
## Description
Updates base schema for async and fixes the base schema execution by tool while any sql connection is open by the server.

## Related issues
Addresses [issue #].

## Testing
Ran the schema migration tool with schema as null to ensure that base schema is executed before upgrading the schema.
