### PR TITLE
Eliminate the need to insert schema version from 6.sql, 7.sql..

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInformation.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInformation.cs
@@ -18,5 +18,14 @@ namespace Microsoft.Health.SqlServer.Features.Schema
         public int MaximumSupportedVersion { get; }
 
         public int? Current { get; set; }
+
+        /// <summary>
+        /// Checks if the version is not inside the full schema script.
+        /// </summary>
+        /// <param name="version">The schema version.</param>
+        public static bool DoesNotContainsVersionInSchema(int version)
+        {
+            return version > 5;
+        }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
         {
             _logger.LogInformation("Applying schema {version}", version);
 
-            // Eliminate the need to insert schema version from 6.sql, 7.sql and so on.
+            // Insert schema version as started for diff scripts and 6.sql, 7.sql and so on.
             if (!applyFullSchemaSnapshot || version > 5)
             {
                 await InsertSchemaVersionAsync(version, cancellationToken);

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
@@ -48,7 +48,8 @@ namespace Microsoft.Health.SqlServer.Features.Schema
         {
             _logger.LogInformation("Applying schema {version}", version);
 
-            if (!applyFullSchemaSnapshot)
+            // Eliminate the need to insert schema version from 6.sql, 7.sql and so on.
+            if (!applyFullSchemaSnapshot || version > 5)
             {
                 await InsertSchemaVersionAsync(version, cancellationToken);
             }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
             _logger.LogInformation("Applying schema {version}", version);
 
             // Insert schema version as started for diff scripts and 6.sql, 7.sql and so on.
-            if (!applyFullSchemaSnapshot || version > 5)
+            if (!applyFullSchemaSnapshot || SchemaInformation.DoesNotContainsVersionInSchema(version))
             {
                 await InsertSchemaVersionAsync(version, cancellationToken);
             }

--- a/tools/SchemaManager/Commands/ApplyCommand.cs
+++ b/tools/SchemaManager/Commands/ApplyCommand.cs
@@ -152,6 +152,7 @@ namespace SchemaManager.Commands
 
         private static async Task UpgradeSchemaAsync(string connectionString, int version, string script, CancellationToken cancellationToken, bool isFullSchemaSnapshot = false)
         {
+            // Replace the check(version > 5) with SchemaInformation.DoesNotContainsVersionInSchema after Microsoft.Health.SqlServer dependency upgrade.
             if (!isFullSchemaSnapshot || version > 5)
             {
                 await SchemaDataStore.UpsertSchemaVersionAsync(connectionString, version, "started", cancellationToken);

--- a/tools/SchemaManager/SchemaDataStore.cs
+++ b/tools/SchemaManager/SchemaDataStore.cs
@@ -15,7 +15,6 @@ namespace SchemaManager
 {
     public static class SchemaDataStore
     {
-        public const string DeleteQuery = "DELETE FROM dbo.SchemaVersion WHERE Version = @version AND Status = @status";
         public const string Failed = "failed";
         public const string Completed = "completed";
 
@@ -53,7 +52,7 @@ namespace SchemaManager
             {
                 await connection.OpenAsync(cancellationToken);
 
-                using (var deleteCommand = new SqlCommand(DeleteQuery, connection))
+                using (var deleteCommand = new SqlCommand("DELETE FROM dbo.SchemaVersion WHERE Version = @version AND Status = @status", connection))
                 {
                     deleteCommand.Parameters.AddWithValue("@version", version);
                     deleteCommand.Parameters.AddWithValue("@status", status);
@@ -95,6 +94,16 @@ namespace SchemaManager
                 upsertCommand.Parameters.AddWithValue("@status", status);
 
                 await upsertCommand.ExecuteNonQueryAsync(cancellationToken);
+            }
+        }
+
+        public static async Task UpsertSchemaVersionAsync(string connectionString, int version, string status, CancellationToken cancellationToken)
+        {
+            using (var connection = new SqlConnection(connectionString))
+            {
+                await connection.OpenAsync(cancellationToken);
+
+                await UpsertSchemaVersionAsync(connection, version, status, cancellationToken);
             }
         }
 


### PR DESCRIPTION
## Description
Inserts the schema version as started for full scripts(6.sql, 7.sql..) in the same manner as we insert for diff scripts.

## Related issues
Addresses #113 

## Testing
Tested manually by switching the AutomaticUpdatesEnabled flag to true/false
