### PR TITLE
Throw specific exception when fail to retrieve token

### DIFF
--- a/src/Microsoft.Health.Client.UnitTests/CredentialProviderTests.cs
+++ b/src/Microsoft.Health.Client.UnitTests/CredentialProviderTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Client.UnitTests
             var mockHandler = new Mock<HttpMessageHandler>();
             var response = new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.BadRequest,
                 Content = new StringContent(@"{""error"": ""This is an error!""}"),
             };
 
@@ -71,7 +71,7 @@ namespace Microsoft.Health.Client.UnitTests
             var mockHandler = new Mock<HttpMessageHandler>();
             var response = new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.BadRequest,
                 Content = new StringContent(@"{""error"": ""This is an error!""}"),
             };
 

--- a/src/Microsoft.Health.Client.UnitTests/CredentialProviderTests.cs
+++ b/src/Microsoft.Health.Client.UnitTests/CredentialProviderTests.cs
@@ -4,7 +4,14 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Client.Exceptions;
+using Moq;
+using Moq.Protected;
 using Xunit;
 
 namespace Microsoft.Health.Client.UnitTests
@@ -26,6 +33,68 @@ namespace Microsoft.Health.Client.UnitTests
 
             // JWT token expiration is limited to second precision
             Assert.InRange(credentialProvider.TokenExpiration, expirationTime.AddSeconds(-1), expirationTime.AddSeconds(1));
+        }
+
+        [Fact]
+        public async Task InvalidOAuth2ClientCredential_RetrieveToken_ShouldThrowError()
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(@"{""error"": ""This is an error!""}"),
+            };
+
+            mockHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(mockHandler.Object);
+
+            var credentialConfiguration = new OAuth2ClientCredentialConfiguration(
+                        new Uri("https://fakehost/connect/token"),
+                        "invalid resource",
+                        "invalid scope",
+                        "invalid client id",
+                        "invalid client secret");
+            var credentialProvider = new OAuth2ClientCredentialProvider(Options.Create(credentialConfiguration), httpClient);
+            await Assert.ThrowsAsync<FailToRetrieveTokenException>(() => credentialProvider.GetBearerToken(cancellationToken: default));
+        }
+
+        [Fact]
+        public async Task InvalidOAuth2UserPasswordCredential_RetrieveToken_ShouldThrowError()
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(@"{""error"": ""This is an error!""}"),
+            };
+
+            mockHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(mockHandler.Object);
+
+            var credentialConfiguration = new OAuth2UserPasswordCredentialConfiguration(
+                        new Uri("https://fakehost/connect/token"),
+                        "invalid resource",
+                        "invalid scope",
+                        "invalid client id",
+                        "invalid client secret",
+                        "invalid username",
+                        "invaid password");
+            var credentialProvider = new OAuth2UserPasswordCredentialProvider(Options.Create(credentialConfiguration), httpClient);
+            await Assert.ThrowsAsync<FailToRetrieveTokenException>(() => credentialProvider.GetBearerToken(cancellationToken: default));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
+++ b/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="Moq" Version="4.14.7" />
         <PackageReference Include="NSubstitute" Version="3.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/src/Microsoft.Health.Client/Exceptions/FailToRetrieveTokenException.cs
+++ b/src/Microsoft.Health.Client/Exceptions/FailToRetrieveTokenException.cs
@@ -1,0 +1,17 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Client.Exceptions
+{
+    public class FailToRetrieveTokenException : Exception
+    {
+        public FailToRetrieveTokenException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Client/OAuth2ClientCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/OAuth2ClientCredentialProvider.cs
@@ -49,9 +49,9 @@ namespace Microsoft.Health.Client
             using HttpResponseMessage tokenResponse = await _httpClient.PostAsync(_oAuth2ClientCredentialConfiguration.TokenUri, formContent, cancellationToken);
 
             var openIdConnectMessage = new OpenIdConnectMessage(await tokenResponse.Content.ReadAsStringAsync());
-            if (openIdConnectMessage.AccessToken == null)
+            if (tokenResponse.StatusCode == System.Net.HttpStatusCode.BadRequest)
             {
-                throw new FailToRetrieveTokenException(openIdConnectMessage.Error);
+                throw new FailToRetrieveTokenException(openIdConnectMessage.ErrorDescription);
             }
 
             return openIdConnectMessage.AccessToken;

--- a/src/Microsoft.Health.Client/OAuth2ClientCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/OAuth2ClientCredentialProvider.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Client.Exceptions;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Microsoft.Health.Client
@@ -48,6 +49,11 @@ namespace Microsoft.Health.Client
             using HttpResponseMessage tokenResponse = await _httpClient.PostAsync(_oAuth2ClientCredentialConfiguration.TokenUri, formContent, cancellationToken);
 
             var openIdConnectMessage = new OpenIdConnectMessage(await tokenResponse.Content.ReadAsStringAsync());
+            if (openIdConnectMessage.AccessToken == null)
+            {
+                throw new FailToRetrieveTokenException(openIdConnectMessage.Error);
+            }
+
             return openIdConnectMessage.AccessToken;
         }
     }

--- a/src/Microsoft.Health.Client/OAuth2UserPasswordCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/OAuth2UserPasswordCredentialProvider.cs
@@ -51,9 +51,9 @@ namespace Microsoft.Health.Client
             using HttpResponseMessage tokenResponse = await _httpClient.PostAsync(_oAuth2UserPasswordCredentialConfiguration.TokenUri, formContent, cancellationToken);
 
             var openIdConnectMessage = new OpenIdConnectMessage(await tokenResponse.Content.ReadAsStringAsync());
-            if (openIdConnectMessage.AccessToken == null)
+            if (tokenResponse.StatusCode == System.Net.HttpStatusCode.BadRequest)
             {
-                throw new FailToRetrieveTokenException(openIdConnectMessage.Error);
+                throw new FailToRetrieveTokenException(openIdConnectMessage.ErrorDescription);
             }
 
             return openIdConnectMessage.AccessToken;

--- a/src/Microsoft.Health.Client/OAuth2UserPasswordCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/OAuth2UserPasswordCredentialProvider.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Client.Exceptions;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Microsoft.Health.Client
@@ -50,6 +51,11 @@ namespace Microsoft.Health.Client
             using HttpResponseMessage tokenResponse = await _httpClient.PostAsync(_oAuth2UserPasswordCredentialConfiguration.TokenUri, formContent, cancellationToken);
 
             var openIdConnectMessage = new OpenIdConnectMessage(await tokenResponse.Content.ReadAsStringAsync());
+            if (openIdConnectMessage.AccessToken == null)
+            {
+                throw new FailToRetrieveTokenException(openIdConnectMessage.Error);
+            }
+
             return openIdConnectMessage.AccessToken;
         }
     }


### PR DESCRIPTION
## Description
When the clients failed to obtain a token it would just throw a System.ArgumentNullException. This updates to throw a specific FailToRetrieveTokenException in the case that it does not obtain a token in the OAuth2ClientCredentialProvider or the OAuth2UserPasswordCredentialProvider.

## Related issues
https://microsofthealth.visualstudio.com/Health/_boards/board/t/Medical%20Imaging/Stories/?workitem=74886

## Testing
Added unit tests.
