### PR TITLE
Added helper method to build nested clauses

### DIFF
--- a/src/Microsoft.Health.SqlServer/IndentedStringBuilder.Generated.cs
+++ b/src/Microsoft.Health.SqlServer/IndentedStringBuilder.Generated.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.SqlServer
         }
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        System.Int32 Capacity
+        public System.Int32 Capacity
         {
             get
             {
@@ -31,7 +31,7 @@ namespace Microsoft.Health.SqlServer
         }
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        System.Char this[System.Int32 index]
+        public System.Char this[System.Int32 index]
         {
             get
             {
@@ -45,7 +45,7 @@ namespace Microsoft.Health.SqlServer
         }
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        System.Int32 Length
+        public System.Int32 Length
         {
             get
             {
@@ -59,7 +59,7 @@ namespace Microsoft.Health.SqlServer
         }
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        System.Int32 MaxCapacity
+        public System.Int32 MaxCapacity
         {
             get
             {

--- a/src/Microsoft.Health.SqlServer/IndentedStringBuilderExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/IndentedStringBuilderExtensions.cs
@@ -3,10 +3,37 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.Health.SqlServer
 {
     public static class IndentedStringBuilderExtensions
     {
+        /// <summary>
+        /// Appends a <see cref="Environment.NewLine"/> to the string builder if it does not already have a trailing newline.
+        /// </summary>
+        /// <param name="indentedStringBuilder">The string builder.</param>
+        /// <returns>The same string builder.</returns>
+        public static IndentedStringBuilder AppendLineIfNotConsecutive(this IndentedStringBuilder indentedStringBuilder)
+        {
+            var newLine = Environment.NewLine;
+
+            if (indentedStringBuilder.Length < newLine.Length)
+            {
+                return indentedStringBuilder.AppendLine();
+            }
+
+            for (int i = 1; i <= newLine.Length; i++)
+            {
+                if (indentedStringBuilder[^i] != newLine[^i])
+                {
+                    return indentedStringBuilder.AppendLine();
+                }
+            }
+
+            return indentedStringBuilder;
+        }
+
         /// <summary>
         /// Helps with building a WHERE clause with 0 to many predicates ANDed together.
         /// Call <see cref="IndentedStringBuilder.DelimitedScope.BeginDelimitedElement"/> before appending
@@ -55,21 +82,12 @@ namespace Microsoft.Health.SqlServer
                 });
         }
 
-        /// <summary>
-        /// Helps with building a nested clause with 0 to many predicates joined (ANDed or ORed) together.
-        /// Call <see cref="IndentedStringBuilder.DelimitedScope.BeginDelimitedElement"/> before appending
-        /// a predicate and be sure to dispose the the <see cref="IndentedStringBuilder.DelimitedScope"/>
-        /// at the end.
-        /// </summary>
-        /// <param name="indentedStringBuilder">The string builder</param>
-        /// <param name="delimiter">Delimiter to use for joining. Typically: "AND " or "OR "</param>
-        /// <returns>The scope</returns>
         public static IndentedStringBuilder.DelimitedScope BeginDelimitedClause(this IndentedStringBuilder indentedStringBuilder, string delimiter)
         {
             return indentedStringBuilder.BeginDelimitedScope(
                 sb =>
                 {
-                    sb.AppendLine();
+                    sb.AppendLineIfNotConsecutive();
                     sb.AppendLine("(");
                     sb.IndentLevel++;
                 },
@@ -77,6 +95,66 @@ namespace Microsoft.Health.SqlServer
                 {
                     sb.AppendLine();
                     sb.Append(delimiter);
+                },
+                sb =>
+                {
+                    sb.AppendLine();
+                    sb.IndentLevel--;
+                    sb.Append(")");
+                });
+        }
+
+        /// <summary>
+        /// Helps with building a parenthesized nested clause with 0 to many predicates ANDed together.
+        /// Call <see cref="IndentedStringBuilder.DelimitedScope.BeginDelimitedElement"/> before appending
+        /// a predicate and be sure to dispose the the <see cref="IndentedStringBuilder.DelimitedScope"/>
+        /// at the end.
+        /// </summary>
+        /// <param name="indentedStringBuilder">The string builder</param>
+        /// <returns>The scope</returns>
+        public static IndentedStringBuilder.DelimitedScope BeginAndedDelimitedScope(this IndentedStringBuilder indentedStringBuilder)
+        {
+            return indentedStringBuilder.BeginDelimitedScope(
+                sb =>
+                {
+                    sb.AppendLineIfNotConsecutive();
+                    sb.AppendLine("(");
+                    sb.IndentLevel++;
+                },
+                sb =>
+                {
+                    sb.AppendLine();
+                    sb.Append("AND ");
+                },
+                sb =>
+                {
+                    sb.AppendLine();
+                    sb.IndentLevel--;
+                    sb.Append(")");
+                });
+        }
+
+        /// <summary>
+        /// Helps with building a parenthesized nested clause with 0 to many predicates jORed together.
+        /// Call <see cref="IndentedStringBuilder.DelimitedScope.BeginDelimitedElement"/> before appending
+        /// a predicate and be sure to dispose the the <see cref="IndentedStringBuilder.DelimitedScope"/>
+        /// at the end.
+        /// </summary>
+        /// <param name="indentedStringBuilder">The string builder</param>
+        /// <returns>The scope</returns>
+        public static IndentedStringBuilder.DelimitedScope BeginOredDelimitedScope(this IndentedStringBuilder indentedStringBuilder)
+        {
+            return indentedStringBuilder.BeginDelimitedScope(
+                sb =>
+                {
+                    sb.AppendLineIfNotConsecutive();
+                    sb.AppendLine("(");
+                    sb.IndentLevel++;
+                },
+                sb =>
+                {
+                    sb.AppendLine();
+                    sb.Append("OR ");
                 },
                 sb =>
                 {

--- a/src/Microsoft.Health.SqlServer/IndentedStringBuilderExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/IndentedStringBuilderExtensions.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Health.SqlServer
         }
 
         /// <summary>
-        /// Helps with building a parenthesized nested clause with 0 to many predicates jORed together.
+        /// Helps with building a parenthesized nested clause with 0 to many predicates ORed together.
         /// Call <see cref="IndentedStringBuilder.DelimitedScope.BeginDelimitedElement"/> before appending
         /// a predicate and be sure to dispose the the <see cref="IndentedStringBuilder.DelimitedScope"/>
         /// at the end.

--- a/src/Microsoft.Health.SqlServer/IndentedStringBuilderExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/IndentedStringBuilderExtensions.cs
@@ -54,5 +54,36 @@ namespace Microsoft.Health.SqlServer
                     sb.AppendLine();
                 });
         }
+
+        /// <summary>
+        /// Helps with building a nested clause with 0 to many predicates joined (ANDed or ORed) together.
+        /// Call <see cref="IndentedStringBuilder.DelimitedScope.BeginDelimitedElement"/> before appending
+        /// a predicate and be sure to dispose the the <see cref="IndentedStringBuilder.DelimitedScope"/>
+        /// at the end.
+        /// </summary>
+        /// <param name="indentedStringBuilder">The string builder</param>
+        /// <param name="delimiter">Delimiter to use for joining. Typically: "AND " or "OR "</param>
+        /// <returns>The scope</returns>
+        public static IndentedStringBuilder.DelimitedScope BeginDelimitedClause(this IndentedStringBuilder indentedStringBuilder, string delimiter)
+        {
+            return indentedStringBuilder.BeginDelimitedScope(
+                sb =>
+                {
+                    sb.AppendLine();
+                    sb.AppendLine("(");
+                    sb.IndentLevel++;
+                },
+                sb =>
+                {
+                    sb.AppendLine();
+                    sb.Append(delimiter);
+                },
+                sb =>
+                {
+                    sb.AppendLine();
+                    sb.IndentLevel--;
+                    sb.Append(")");
+                });
+        }
     }
 }

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/IndentedStringBuilderGenerator.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/IndentedStringBuilderGenerator.cs
@@ -49,24 +49,16 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator
 
             public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
             {
-                node = node.WithExplicitInterfaceSpecifier(null);
-                if (IsDeclaredOnObject(node))
-                {
-                    node = node.AddModifiers(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword));
-                }
-
-                return node;
+                return node
+                    .WithExplicitInterfaceSpecifier(null)
+                    .AddModifiers(Token(SyntaxKind.PublicKeyword));
             }
 
             public override SyntaxNode VisitIndexerDeclaration(IndexerDeclarationSyntax node)
             {
-                node = node.WithExplicitInterfaceSpecifier(null);
-                if (IsDeclaredOnObject(node))
-                {
-                    node = node.AddModifiers(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword));
-                }
-
-                return node;
+                return node
+                    .WithExplicitInterfaceSpecifier(null)
+                    .AddModifiers(Token(SyntaxKind.PublicKeyword));
             }
 
             public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.targets
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.targets
@@ -7,9 +7,8 @@
     </PropertyGroup>
 
     <Target Name="CollectGenerateFilesInputs" BeforeTargets="GenerateFiles">
-        <Message Text="hello" />
-
         <ItemGroup>
+            <GenerateFilesInputs Include="$(GeneratorPath)" />
             <GenerateFilesInputs Include="$(MSBuildProjectFile)" />
             <GenerateFilesInputs Include="$(MSBuildThisFileFullPath)" />
         </ItemGroup>


### PR DESCRIPTION
## Description
Added `IndentedStringBuilder` extension method to allow building nested clauses.

To generate the following query:
```sql
...
WHERE s.search_param_id = 981
    AND 
    (

        (
            s.reference_resource_version IS NOT NULL
            AND s.reference_resource_version = t.version
        )
        OR
        (
            s.reference_resource_version IS NULL
            AND t.is_history = 0
        )
    )
    AND s.is_history = 0
```

Using the introduced method:
```csharp
() => {
    ...
    using (var delimited = StringBuilder.BeginDelimitedWhereClause())
    {
        delimited.BeginDelimitedElement().Append("t.search_param_id").Append(" = ").Append("981");

        using (var mainClause = delimited.BeginDelimitedElement().BeginDelimitedClause("OR "))
        {
            using (var clause = mainClause.BeginDelimitedElement().BeginDelimitedClause("AND "))
            {
                clause.BeginDelimitedElement().Append("s.reference_resource_version").Append(" IS NOT NULL");
                clause.BeginDelimitedElement().Append("s.reference_resource_version").Append(" = ").Append("t.version");
            }

            using (var clause = mainClause.BeginDelimitedElement().BeginDelimitedClause("AND "))
            {
                clause.BeginDelimitedElement().Append("s.reference_resource_version").Append(" IS NULL");
                clause.BeginDelimitedElement().Append("t.is_history").Append(" = ").Append("0");
            }
        }

        delimited.BeginDelimitedElement().Append("s.is_history").Append(" = ").Append("0");
        ...
    }
}
```

## Testing
As part of the PR to be submitted to https://github.com/microsoft/fhir-server
