### PR TITLE
Adds Semver to Assemblies, Nugets and Release names

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,39 @@
+mode: Mainline
+assembly-versioning-scheme: MajorMinorPatch
+ignore:
+  sha: []
+
+branches:
+  master:
+    regex: ^master$|^main$
+    tag: ''
+    increment: Patch
+    prevent-increment-of-merged-branch-version: true
+    track-merge-target: false
+    tracks-release-branches: false
+    is-release-branch: true
+  pull-request:
+    regex: ^(pull|pull\-requests|pr)[/-]
+    tag: pr
+    increment: Inherit
+    prevent-increment-of-merged-branch-version: false
+    tag-number-pattern: '[/-](?<number>\d+)[-/]'
+    track-merge-target: false
+    tracks-release-branches: false
+    is-release-branch: false
+  hotfix:
+    regex: ^hotfix(es)?[/-]
+    tag: beta
+    increment: Patch
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: false
+    tracks-release-branches: false
+    is-release-branch: false
+  feature:
+    regex: ^(personal|dev|feature|dependabot|auto\-nuget\-update)[/-]
+    tag: useBranchName
+    increment: Patch
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: false
+    tracks-release-branches: false
+    is-release-branch: false

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,8 +1,9 @@
 mode: Mainline
-assembly-versioning-scheme: MajorMinorPatch
+# assembly-version: If this number changes, other assemblies have to update references to the assembly
+assembly-versioning-scheme: Major
+assembly-file-versioning-scheme: MajorMinorPatch
 ignore:
   sha: []
-
 branches:
   master:
     regex: ^master$|^main$

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -9,15 +9,30 @@ name: $(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:-r)
 variables:
   buildConfiguration: 'Release'
 jobs:
+- job: Semver
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+  - template: ./update-semver.yml
+  - script: echo %Action%%BuildVersion%
+    displayName: 'Set build version'
+    env:
+      Action: '##vso[build.updatebuildnumber]'
+      BuildVersion: $(GitVersion.semVer)
+
 - job: Windows
   pool:
     vmImage: 'windows-latest'
+  dependsOn:
+  - Semver
   steps:
   - template: build.yml
 
 - job: Linux
   pool:
     vmImage: 'ubuntu-latest'
+  dependsOn:
+  - Semver
   steps:
   - template: build.yml
     parameters:

--- a/build/build.yml
+++ b/build/build.yml
@@ -2,14 +2,18 @@ parameters:
   packageArtifacts: true
   
 steps:
+- template: ./update-semver.yml
 
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk'
   inputs:
     useGlobalJson: true
 
-- script: dotnet build --configuration $(buildConfiguration) --version-suffix $(build.buildNumber) /warnaserror
+- task: DotNetCoreCLI@2
   displayName: 'dotnet build $(buildConfiguration)'
+  inputs:
+    command: build
+    arguments: '--configuration $(buildConfiguration) /p:AssemblyVersion="$(assemblySemVer)" /p:FileVersion="$(assemblySemFileVer)" /p:InformationalVersion="$(informationalVersion)" /p:Version="$(majorMinorPatch)" /warnaserror'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test UnitTests'

--- a/build/build.yml
+++ b/build/build.yml
@@ -13,7 +13,7 @@ steps:
   displayName: 'dotnet build $(buildConfiguration)'
   inputs:
     command: build
-    arguments: '--configuration $(buildConfiguration) /p:AssemblyVersion="$(assemblySemVer)" /p:FileVersion="$(assemblySemFileVer)" /p:InformationalVersion="$(informationalVersion)" /p:Version="$(majorMinorPatch)" /warnaserror'
+    arguments: '--configuration $(buildConfiguration) /p:AssemblyVersion="$(assemblySemVer)" /p:FileVersion="$(assemblySemFileVer)" /p:InformationalVersion="$(informationalVersion)" /warnaserror'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test UnitTests'

--- a/build/package.yml
+++ b/build/package.yml
@@ -12,7 +12,7 @@ steps:
       nobuild: true
       zipAfterPublish: true
     env:
-      nuget_version: 1.0.0-$(build.buildNumber)
+      nuget_version: $(nuGetVersion)
 
   # Publish artifacts
 

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -1,0 +1,31 @@
+steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk (for GitVersion)'
+  inputs:
+    packageType: sdk
+    version: 2.1.x
+    
+- task: GitVersion@5
+  displayName: 'GitVersion'
+  inputs:
+    configFilePath: '$(Build.SourcesDirectory)/GitVersion.yml'
+
+# Can set these: https://github.com/GitTools/actions/blob/master/gitversion/execute/action.yml
+- powershell: |
+    Write-Host "##vso[task.setvariable variable=semVer]$(GitVersion.semVer)"
+    Write-Host "##vso[task.setvariable variable=informationalVersion]$(GitVersion.informationalVersion)"
+    Write-Host "##vso[task.setvariable variable=majorMinorPatch]$(GitVersion.majorMinorPatch)"
+    Write-Host "##vso[task.setvariable variable=nuGetVersion]$(GitVersion.semVer)"
+    Write-Host "##vso[task.setvariable variable=assemblySemVer]$(GitVersion.assemblySemVer)"
+    Write-Host "##vso[task.setvariable variable=assemblySemFileVer]$(GitVersion.assemblySemFileVer)"
+  name: SetVariablesFromGitVersion
+
+- powershell: |
+    Write-Host '----------Variables to use for build----------'
+    Write-Host 'semVer: $(semVer)'
+    Write-Host 'informationalVersion: $(informationalVersion)'
+    Write-Host 'majorMinorPatch: $(majorMinorPatch)'
+    Write-Host 'assemblySemVer: $(assemblySemVer)'
+    Write-Host 'assemblySemFileVer: $(assemblySemFileVer)'
+    Write-Host 'nuGetVersion: $(nuGetVersion)'
+  name: PrintVariablesFromGitVersion

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -1,0 +1,35 @@
+# Semantic Versioning for Shared Components
+
+This guide gives an overview of the Semantic versioning implementation in use with this project.
+To achieve semantic versioning consistently and relaiably the [GitVersion](https://github.com/GitTools/GitVersion) library is used.
+
+## Git Version
+
+### Overview
+GitVersion is a software library and build task that uses Git history to calculate the version that should be used for the current build. The following sections explain how it is configured and the commands available to assist in versioning.
+
+### Setup
+A [configuration](https://github.com/microsoft/fhir-server/blob/master/GitVersion.yml) file is included in the root directory that is used to setup the version strategy and specify how versioning should be calculated against the default and other branches. Currently, all commits to main will be treated as a release, all commits to other branches (including pull requests) will be treated as pre-release (e.g. `1.2.0-my-branch+1`).
+
+The configured GitVersion versioning strategy is [mainline development](https://gitversion.net/docs/reference/versioning-modes/mainline-development), which increments the patch version on every commit to the main branch. Our current development workflow assumes that the main branch will stage a release on every commit, some releases however will be not be approved.
+
+When a release is approved this should result in the assets being published to the nuget feed and a tag being created against the code to mark the release.
+
+### Commands
+Several commands are available during the squash-merge to allow incrementing the major/minor release numbers.
+
+For a major feature or major breaking changes, the following commands can be added to the commit message:
+```
++semver: breaking
+or
++semver: major
+```
+
+Smaller changes can choose to increment the minor version:
+```
++semver: feature
+or
++semver: minor
+```
+
+For bug fixes or other incremental changes, nothing needs to be added, this will happen automatically.

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -1,7 +1,7 @@
 # Semantic Versioning for Shared Components
 
 This guide gives an overview of the Semantic versioning implementation in use with this project.
-To achieve semantic versioning consistently and relaiably the [GitVersion](https://github.com/GitTools/GitVersion) library is used.
+To achieve semantic versioning consistently and reliably the [GitVersion](https://github.com/GitTools/GitVersion) library is used.
 
 ## Git Version
 
@@ -33,3 +33,18 @@ or
 ```
 
 For bug fixes or other incremental changes, nothing needs to be added, this will happen automatically.
+
+## Examples of when to increment versions
+
+| Action  | Command  |
+|---|---|
+| Updated a minor nuget package version  | None :beach_umbrella: |
+| Fixed a bug  | None :beach_umbrella: |
+| Small backwards-compatible change  | None :beach_umbrella: :tropical_drink: |
+| Updated documentation  | None or `+semver: skip` |
+| Adding a new feature/component/library | `+semver: feature` :bowtie: |
+| Major product-level change | `+semver: major` |
+| Incompatible binary change | `+semver: major` :boom: |
+<br />
+
+:exclamation: Note: The Assembly version is using the Major version with static Minor and Patch versions (e.g. {major}.0.0), so using `+semver: major` will force downstream applications to be recompiled. Incrementing the Minor or Patch versions will keep resulting assemblies binary-compatible.


### PR DESCRIPTION
## Description
Adds semver with [GitVersioning](https://github.com/GitTools/GitVersion)

This package allows controlling versioning through Git, version bumps can be utilized through `+semver: major|minor|feature|breaking` syntax in commit messages. 

For all incremental bug fixes, nothing needs to be changed, GitVersion will increment the patch version automatically based on commits in main.

For breaking changes you can use the following syntax in the commit message:
```
+semver: breaking
or
+semver: major
```

Features can use:
```
+semver: feature
or
+semver: minor
```

I believe this will help solve a lot of the incompatibilities with breaking changes we've been seeing with downstream projects.