### PR TITLE
Removes "SqlServer:Initialize" config option from launch settings

### DIFF
--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -10,11 +10,6 @@ namespace Microsoft.Health.SqlServer.Configs
         public string ConnectionString { get; set; }
 
         /// <summary>
-        /// Allows the experimental schema initializer to attempt to bring the schema to the minimum supported version.
-        /// </summary>
-        public bool Initialize { get; set; }
-
-        /// <summary>
         /// Allows the experimental schema initializer to attempt to create the database if not present.
         /// </summary>
         public bool AllowDatabaseCreation { get; set; }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -200,11 +200,6 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
         private async Task<bool> CanInitializeAsync(CancellationToken cancellationToken)
         {
-            if (!_sqlServerDataStoreConfiguration.Initialize)
-            {
-                return false;
-            }
-
             var configuredConnectionBuilder = new SqlConnectionStringBuilder(_sqlServerDataStoreConfiguration.ConnectionString);
             string databaseName = configuredConnectionBuilder.InitialCatalog;
 

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -224,6 +224,8 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                         else
                         {
                             _logger.LogWarning("Insufficient permissions to create the database");
+
+                            // TODO: Throw exception here once database creation is enabled for E2E tests.
                             return false;
                         }
                     }
@@ -231,7 +233,8 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                     {
                         _logger.LogWarning("Database creation is not enabled.");
 
-                        throw new InvalidOperationException(Resources.NewDatabaseCannotBeCreated);
+                        // TODO: Throw exception here once database creation is enabled for E2E tests.
+                        return false;
                     }
                 }
             }

--- a/src/Microsoft.Health.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.SqlServer/Resources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Microsoft.Health.SqlServer {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace Microsoft.Health.SqlServer {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Resources() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Microsoft.Health.SqlServer {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace Microsoft.Health.SqlServer {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The base script is not found..
         /// </summary>
@@ -68,7 +68,7 @@ namespace Microsoft.Health.SqlServer {
                 return ResourceManager.GetString("BaseScriptNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The compatibility information was not found..
         /// </summary>
@@ -77,7 +77,16 @@ namespace Microsoft.Health.SqlServer {
                 return ResourceManager.GetString("CompatibilityRecordNotFound", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to An existing database does not exist, and database creation is not enabled..
+        /// </summary>
+        internal static string NewDatabaseCannotBeCreated {
+            get {
+                return ResourceManager.GetString("NewDatabaseCannotBeCreated", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The SQL operation has failed..
         /// </summary>
@@ -86,7 +95,7 @@ namespace Microsoft.Health.SqlServer {
                 return ResourceManager.GetString("OperationFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The provided version is unknown..
         /// </summary>

--- a/src/Microsoft.Health.SqlServer/Resources.resx
+++ b/src/Microsoft.Health.SqlServer/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -128,5 +128,8 @@
   </data>
   <data name="ScriptNotFound" xml:space="preserve">
     <value>The provided version is unknown.</value>
+  </data>
+  <data name="NewDatabaseCannotBeCreated" xml:space="preserve">
+    <value>An existing database does not exist, and database creation is not enabled.</value>
   </data>
 </root>

--- a/test/Microsoft.Health.SqlServer.Web/Properties/launchSettings.json
+++ b/test/Microsoft.Health.SqlServer.Web/Properties/launchSettings.json
@@ -4,7 +4,6 @@
       "commandName": "Project",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
-        "SqlServer:Initialize": "false",
         "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true",
         "SqlServer:AllowDatabaseCreation": "false",
         "SqlServer:ConnectionString": "server=(local);Initial Catalog=SHARED_HEALTHCARE;Integrated Security=true"

--- a/test/Microsoft.Health.SqlServer.Web/Properties/launchSettings.json
+++ b/test/Microsoft.Health.SqlServer.Web/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
         "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true",
-        "SqlServer:AllowDatabaseCreation": "true",
+        "SqlServer:AllowDatabaseCreation": "false",
         "SqlServer:ConnectionString": "server=(local);Initial Catalog=SHARED_HEALTHCARE;Integrated Security=true"
       },
       "applicationUrl": "https://localhost:63637/"

--- a/test/Microsoft.Health.SqlServer.Web/Properties/launchSettings.json
+++ b/test/Microsoft.Health.SqlServer.Web/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
         "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true",
-        "SqlServer:AllowDatabaseCreation": "false",
+        "SqlServer:AllowDatabaseCreation": "true",
         "SqlServer:ConnectionString": "server=(local);Initial Catalog=SHARED_HEALTHCARE;Integrated Security=true"
       },
       "applicationUrl": "https://localhost:63637/"


### PR DESCRIPTION
## Description
Now that we have `SqlServer:AutomaticUpdatesEnabled`, the `SqlServer:Initialize` config setting is no longer needed.

This PR removes `SqlServer:Initialize` and updates an error message for an edge case that is a bit easier to trigger now that we are removing this setting (please see my review comment below for more context).

## Related issues
Addresses [#AB77211](https://microsofthealth.visualstudio.com/Health/_workitems/edit/77211).

## Testing
Manually tested the startup of the test web project with all possible combinations of the config values. I also copied the SQL health .pdb and .dll files and tested the fhir-server startup as well.
