### PR TITLE
Change semver to use windows VM

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -11,7 +11,7 @@ variables:
 jobs:
 - job: Semver
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'windows-latest'
   steps:
   - template: ./update-semver.yml
   - script: echo %Action%%BuildVersion%


### PR DESCRIPTION
## Description
Changes the semver build step to use a windows VM.

## Related issues
Semver has been failing since the update to use Ubuntu 20.04

## Testing
Fix copied from the fhir server repo
