### PR TITLE
Set semver variables as output

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -25,6 +25,12 @@ jobs:
     vmImage: 'windows-latest'
   dependsOn:
   - Semver
+  variables:
+    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemVer']]
+    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
+    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.informationalVersion']]
+    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.majorMinorPatch']]
+    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.nuGetVersion']]
   steps:
   - template: build.yml
 
@@ -33,6 +39,12 @@ jobs:
     vmImage: 'ubuntu-latest'
   dependsOn:
   - Semver
+  variables:
+    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemVer']]
+    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
+    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.informationalVersion']]
+    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.majorMinorPatch']]
+    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.nuGetVersion']]
   steps:
   - template: build.yml
     parameters:

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -11,7 +11,7 @@ variables:
 jobs:
 - job: Semver
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'windows-latest'
   steps:
   - template: ./update-semver.yml
   - script: echo %Action%%BuildVersion%

--- a/build/build.yml
+++ b/build/build.yml
@@ -2,8 +2,6 @@ parameters:
   packageArtifacts: true
   
 steps:
-- template: ./update-semver.yml
-
 - task: UseDotNet@2
   displayName: 'Use .NET Core 3.1.x SDK'
   inputs:

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -13,11 +13,11 @@ steps:
 # Can set these: https://github.com/GitTools/actions/blob/master/gitversion/execute/action.yml
 - powershell: |
     Write-Host "##vso[task.setvariable variable=semVer]$(GitVersion.semVer)"
-    Write-Host "##vso[task.setvariable variable=informationalVersion]$(GitVersion.informationalVersion)"
-    Write-Host "##vso[task.setvariable variable=majorMinorPatch]$(GitVersion.majorMinorPatch)"
-    Write-Host "##vso[task.setvariable variable=nuGetVersion]$(GitVersion.semVer)"
-    Write-Host "##vso[task.setvariable variable=assemblySemVer]$(GitVersion.assemblySemVer)"
-    Write-Host "##vso[task.setvariable variable=assemblySemFileVer]$(GitVersion.assemblySemFileVer)"
+    Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$(GitVersion.informationalVersion)"
+    Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$(GitVersion.majorMinorPatch)"
+    Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$(GitVersion.semVer)"
+    Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$(GitVersion.assemblySemVer)"
+    Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$(GitVersion.assemblySemFileVer)"
   name: SetVariablesFromGitVersion
 
 - powershell: |


### PR DESCRIPTION
## Description
Sets the semver variables as output so other steps in the build can use them.

## Related issues
Prevents semver from running in the linux build which isn't working currently

## Testing
