### PR TITLE
Increase logging for CachedHealthCheck

### DIFF
--- a/src/Microsoft.Health.Api/Features/HealthChecks/CachedHealthCheck.cs
+++ b/src/Microsoft.Health.Api/Features/HealthChecks/CachedHealthCheck.cs
@@ -46,14 +46,13 @@ namespace Microsoft.Health.Api.Features.HealthChecks
 
             try
             {
-                _logger.LogTrace($"Begining wait for semaphore for {nameof(CheckHealthAsync)}, healthcheck context: {context.Registration}");
+                _logger.LogTrace($"Begining wait for semaphore for {nameof(CheckHealthAsync)}, healthcheck context: {context.Registration}, semaphore count: {_semaphore.CurrentCount}");
                 await _semaphore.WaitAsync(cancellationToken);
-                _logger.LogTrace($"Obtained semaphore for {nameof(CheckHealthAsync)}, healthcheck context: {context.Registration}");
+                _logger.LogTrace($"Entered semaphore for {nameof(CheckHealthAsync)}, healthcheck context: {context.Registration}, semaphore count: {_semaphore.CurrentCount}");
             }
             catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested)
             {
-                _logger.LogTrace(oce, $"Cancellation was requested for {nameof(CheckHealthAsync)}, healthcheck context: {context.Registration}");
-                _semaphore.Release();
+                _logger.LogTrace(oce, $"Cancellation was requested for {nameof(CheckHealthAsync)}, healthcheck context: {context.Registration}, semaphore count: {_semaphore.CurrentCount}");
                 return _lastResult;
             }
 
@@ -85,7 +84,7 @@ namespace Microsoft.Health.Api.Features.HealthChecks
             finally
             {
                 _semaphore.Release();
-                _logger.LogInformation($"Released semaphore for {nameof(CheckHealthAsync)}");
+                _logger.LogTrace($"Released semaphore for {nameof(CheckHealthAsync)}, semaphore count: {_semaphore.CurrentCount} ");
             }
         }
 

--- a/src/Microsoft.Health.Api/Features/HealthChecks/CachedHealthCheck.cs
+++ b/src/Microsoft.Health.Api/Features/HealthChecks/CachedHealthCheck.cs
@@ -46,11 +46,14 @@ namespace Microsoft.Health.Api.Features.HealthChecks
 
             try
             {
+                _logger.LogTrace($"Begining wait for semaphore for {nameof(CheckHealthAsync)}, healthcheck context: {context.Registration}");
                 await _semaphore.WaitAsync(cancellationToken);
+                _logger.LogTrace($"Obtained semaphore for {nameof(CheckHealthAsync)}, healthcheck context: {context.Registration}");
             }
             catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested)
             {
-                _logger.LogInformation(oce, $"Cancellation was requested for {nameof(CheckHealthAsync)}");
+                _logger.LogTrace(oce, $"Cancellation was requested for {nameof(CheckHealthAsync)}, healthcheck context: {context.Registration}");
+                _semaphore.Release();
                 return _lastResult;
             }
 
@@ -82,6 +85,7 @@ namespace Microsoft.Health.Api.Features.HealthChecks
             finally
             {
                 _semaphore.Release();
+                _logger.LogInformation($"Released semaphore for {nameof(CheckHealthAsync)}");
             }
         }
 


### PR DESCRIPTION
## Description
Jarvis logs show to following exception ocurring repeatedly:
System.OperationCanceledException: The operation was canceled.
   at System.Threading.CancellationToken.ThrowOperationCanceledException()
   at System.Threading.SemaphoreSlim.WaitUntilCountOrTimeoutAsync(TaskNode asyncWaiter, Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at Microsoft.Health.Api.Features.HealthChecks.CachedHealthCheck.CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken)

It would seem to indicate that the semaphore is being held by one process.  Updated the logging to confirm if this is the case.

## Related issues
Addresses [issue [AB#74493](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74493)].

## Testing
Manual testing
