### PR TITLE
Increases SQL read column count

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlDataReaderRowExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlDataReaderRowExtensions.cs
@@ -183,6 +183,34 @@ namespace Microsoft.Health.SqlServer.Features.Storage
                 reader.Read(column9, 9));
         }
 
+        public static (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) ReadRow<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            this SqlDataReader reader,
+            Column<T0> column0,
+            Column<T1> column1,
+            Column<T2> column2,
+            Column<T3> column3,
+            Column<T4> column4,
+            Column<T5> column5,
+            Column<T6> column6,
+            Column<T7> column7,
+            Column<T8> column8,
+            Column<T9> column9,
+            Column<T10> column10)
+        {
+            return (
+                reader.Read(column0, 0),
+                reader.Read(column1, 1),
+                reader.Read(column2, 2),
+                reader.Read(column3, 3),
+                reader.Read(column4, 4),
+                reader.Read(column5, 5),
+                reader.Read(column6, 6),
+                reader.Read(column7, 7),
+                reader.Read(column8, 8),
+                reader.Read(column9, 9),
+                reader.Read(column10, 10));
+        }
+
         public static T Read<T>(this SqlDataReader reader, Column<T> column, int ordinal)
         {
             return column.Read(reader, ordinal);


### PR DESCRIPTION
## Description
SQL reindexing requires an additional column in `dbo.Resource` for the search parameter hash value. This PR adds the ability to read an 11th column in the SQL search service in the FHIR server.

## Related issues
Addresses [AB#79096](https://microsofthealth.visualstudio.com/Health/_workitems/edit/79096).

## Testing
Copied .pdb and .dll files and tested with the FHIR server locally.
