### PR TITLE
Update NuGet Package Content and Metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,29 +1,28 @@
 <Project>
 
   <PropertyGroup>
+    <Authors>Microsot Health Team</Authors>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <Company>Microsoft Corporation</Company>
+    <Copyright>Copyright © Microsoft Corporation. All rights reserved.</Copyright>
+    <Deterministic>true</Deterministic>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <HighEntropyVA>true</HighEntropyVA>
+    <LangVersion>8.0</LangVersion>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Product>Microsoft Health</Product>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RepositoryUrl>https://github.com/microsoft/healthcare-components</RepositoryUrl>
+    <SdkPackageVersion>3.1.7</SdkPackageVersion>
+    <SupportedFrameworks>netcoreapp3.1;net5.0</SupportedFrameworks>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-    <DebugType>Portable</DebugType>
-    <LangVersion>8.0</LangVersion>
-    <HighEntropyVA>true</HighEntropyVA>
-    <EnableSourceLink Condition="$([MSBuild]::IsOSPlatform('osx'))">false</EnableSourceLink>
-    <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
-    <!--This will target the latest patch release of the runtime released with the current SDK.  -->
-    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
-    <RepositoryUrl>https://github.com/microsoft/healthcare-components</RepositoryUrl>
-
-    <SupportedFrameworks>netcoreapp3.1;net5.0</SupportedFrameworks>
-    <SdkPackageVersion>3.1.7</SdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net5'))">
     <SdkPackageVersion>5.0.0</SdkPackageVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(EnableSourceLink)' == 'true' ">
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <Choose>
@@ -46,15 +45,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
   </ItemGroup>
 
   <Choose>
     <When Condition="$(MSBuildProjectName)!='Microsoft.Health.Extensions.BuildTimeCodeGenerator' AND !$(MSBuildProjectName.Contains('Test'))">
       <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" />
+        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" PrivateAssets="All" />
       </ItemGroup>
     </When>
   </Choose>
+
 </Project>

--- a/build/build.yml
+++ b/build/build.yml
@@ -1,6 +1,6 @@
 parameters:
   packageArtifacts: true
-  
+
 steps:
 - task: UseDotNet@2
   displayName: 'Use .NET Core 3.1.x SDK'
@@ -17,7 +17,7 @@ steps:
   displayName: 'dotnet build $(buildConfiguration)'
   inputs:
     command: build
-    arguments: '--configuration $(buildConfiguration) /p:AssemblyVersion="$(assemblySemVer)" /p:FileVersion="$(assemblySemFileVer)" /p:InformationalVersion="$(informationalVersion)" /warnaserror'
+    arguments: '--configuration $(buildConfiguration) /p:AssemblyVersion="$(assemblySemVer)" /p:FileVersion="$(assemblySemFileVer)" /p:InformationalVersion="$(informationalVersion)" /p:ContinuousIntegrationBuild=true /warnaserror'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test UnitTests'
@@ -25,6 +25,6 @@ steps:
     command: test
     projects: '**/*UnitTests/*.csproj'
     arguments: '--configuration $(buildConfiguration)'
- 
+
 - ${{ if eq(parameters.packageArtifacts, 'true') }}:
   - template: package.yml

--- a/src/Microsoft.Health.Abstractions/Microsoft.Health.Abstractions.csproj
+++ b/src/Microsoft.Health.Abstractions/Microsoft.Health.Abstractions.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Abstractions used by Microsoft Health.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/Microsoft.Health.Api.UnitTests/Microsoft.Health.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Api.UnitTests/Microsoft.Health.Api.UnitTests.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-        <PackageReference Include="NSubstitute" Version="4.2.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\test\Microsoft.Health.Test.Common\Microsoft.Health.Test.Utilities.csproj" />
-      <ProjectReference Include="..\Microsoft.Health.Api\Microsoft.Health.Api.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\test\Microsoft.Health.Test.Common\Microsoft.Health.Test.Utilities.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Api\Microsoft.Health.Api.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.Health.Api/Microsoft.Health.Api.csproj
+++ b/src/Microsoft.Health.Api/Microsoft.Health.Api.csproj
@@ -1,36 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <Description>Common components, such as middleware, for Microsoft Health APIs using ASP.NET Core.</Description>
+    <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    </ItemGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Microsoft.Health.Core\Microsoft.Health.Core.csproj" />
-      <ProjectReference Include="..\Microsoft.Health.Extensions.DependencyInjection\Microsoft.Health.Extensions.DependencyInjection.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Core\Microsoft.Health.Core.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Extensions.DependencyInjection\Microsoft.Health.Extensions.DependencyInjection.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <Compile Update="Resources.Designer.cs">
-        <DesignTime>True</DesignTime>
-        <AutoGen>True</AutoGen>
-        <DependentUpon>Resources.resx</DependentUpon>
-      </Compile>
-    </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
 
-    <ItemGroup>
-      <EmbeddedResource Update="Resources.resx">
-        <Generator>ResXFileCodeGenerator</Generator>
-        <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      </EmbeddedResource>
-    </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Health.Api/Modules/InitializationModule.cs
+++ b/src/Microsoft.Health.Api/Modules/InitializationModule.cs
@@ -14,8 +14,8 @@ using Microsoft.Health.Extensions.DependencyInjection;
 namespace Microsoft.Health.Api.Modules
 {
     /// <summary>
-    /// Starts all <see cref="IStartable"/> instances in the IoC container and ensures that all <see cref="IRequireInitializationOnFirstRequest"/> instances
-    /// are initialized before any controllers are invoked.
+    /// Ensures that all <see cref="IRequireInitializationOnFirstRequest"/> instances are
+    /// initialized before any controllers are invoked.
     /// </summary>
     public class InitializationModule : IStartupModule, IStartupFilter
     {

--- a/src/Microsoft.Health.Blob/Microsoft.Health.Blob.csproj
+++ b/src/Microsoft.Health.Blob/Microsoft.Health.Blob.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Azure blob storage utilities for Microsoft Health.</Description>
     <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
+++ b/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
@@ -1,19 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-        <PackageReference Include="Moq" Version="4.14.7" />
-        <PackageReference Include="NSubstitute" Version="3.1.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Microsoft.Health.Client\Microsoft.Health.Client.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Client\Microsoft.Health.Client.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Health.Client/Microsoft.Health.Client.csproj
+++ b/src/Microsoft.Health.Client/Microsoft.Health.Client.csproj
@@ -1,13 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <Description>Utilities for HTTP clients that communicate with Microsoft Health services.</Description>
+    <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Ensure.That" Version="9.2.0" />
-        <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
-        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.5.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Ensure.That" Version="9.2.0" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.5.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.Health.Core.UnitTests/Microsoft.Health.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Core.UnitTests/Microsoft.Health.Core.UnitTests.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
-        <RootNamespace>Microsoft.Health.Extensions.UnitTests</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
+    <RootNamespace>Microsoft.Health.Extensions.UnitTests</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-        <PackageReference Include="NSubstitute" Version="4.2.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Microsoft.Health.Core\Microsoft.Health.Core.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Core\Microsoft.Health.Core.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Health.Core/Microsoft.Health.Core.csproj
+++ b/src/Microsoft.Health.Core/Microsoft.Health.Core.csproj
@@ -1,34 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <Description>Common primitives and utilities used by Microsoft Health.</Description>
+    <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(SdkPackageVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(SdkPackageVersion)" />
-        <PackageReference Include="Ensure.That" Version="9.2.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Ensure.That" Version="9.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Microsoft.Health.Abstractions\Microsoft.Health.Abstractions.csproj" />
-      <ProjectReference Include="..\Microsoft.Health.Extensions.DependencyInjection\Microsoft.Health.Extensions.DependencyInjection.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Abstractions\Microsoft.Health.Abstractions.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Extensions.DependencyInjection\Microsoft.Health.Extensions.DependencyInjection.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <Compile Update="Resources.Designer.cs">
-        <DesignTime>True</DesignTime>
-        <AutoGen>True</AutoGen>
-        <DependentUpon>Resources.resx</DependentUpon>
-      </Compile>
-    </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
 
-    <ItemGroup>
-      <EmbeddedResource Update="Resources.resx">
-        <Generator>ResXFileCodeGenerator</Generator>
-        <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      </EmbeddedResource>
-    </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.Health.Development.IdentityProvider/Microsoft.Health.Development.IdentityProvider.csproj
+++ b/src/Microsoft.Health.Development.IdentityProvider/Microsoft.Health.Development.IdentityProvider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Identity primitives used by Microsoft Health.</Description>
+    <Description>Identity primitives used by Microsoft Health for local development.</Description>
     <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Microsoft.Health.Development.IdentityProvider/Microsoft.Health.Development.IdentityProvider.csproj
+++ b/src/Microsoft.Health.Development.IdentityProvider/Microsoft.Health.Development.IdentityProvider.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Identity primitives used by Microsoft Health.</Description>
     <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Microsoft.Health.Extensions.DependencyInjection/Microsoft.Health.Extensions.DependencyInjection.csproj
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/Microsoft.Health.Extensions.DependencyInjection.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Dependency injection extensions for Microsoft's default implementation used by Microsoft Health.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationExtensions.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Health.Extensions.DependencyInjection
             EnsureArg.IsNotNull(provider, nameof(provider));
 
             var delegateType = typeof(TDelegate);
-            Func<TService> factory = () => (TService)provider.GetService<TImplementation>();
+            Func<TService> factory = () => provider.GetService<TImplementation>();
             var invokeMethod = factory.GetType().GetMethod(nameof(factory.Invoke));
             return invokeMethod.CreateDelegate(delegateType, factory);
         }

--- a/src/Microsoft.Health.SqlServer.Api.UnitTests/Microsoft.Health.SqlServer.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.SqlServer.Api.UnitTests/Microsoft.Health.SqlServer.Api.UnitTests.csproj
@@ -22,4 +22,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/src/Microsoft.Health.SqlServer.Api/Microsoft.Health.SqlServer.Api.csproj
+++ b/src/Microsoft.Health.SqlServer.Api/Microsoft.Health.SqlServer.Api.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Common SQL Server-related components, such as controllers, for Microsoft Health APIs using ASP.NET Core.</Description>
     <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Microsoft.Health.SqlServer.UnitTests/Microsoft.Health.SqlServer.UnitTests.csproj
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Microsoft.Health.SqlServer.UnitTests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Microsoft.Health.SqlServer\Microsoft.Health.SqlServer.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.SqlServer\Microsoft.Health.SqlServer.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-        <PackageReference Include="NSubstitute" Version="4.2.1" />
-        <PackageReference Include="Polly" Version="7.2.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="Polly" Version="7.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Remove="Features\Schema\Migrations\1.sql" />

--- a/src/Microsoft.Health.SqlServer/Extensions/SqlExceptionExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Extensions/SqlExceptionExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.SqlServer.Extensions
         /// Determines whether the exception is transient.
         /// </summary>
         /// <param name="exception">The exception to check.</param>
-        /// <returns><c>true</c> if the exception is transient; otherwise, <c>false</c>.</returns
+        /// <returns><c>true</c> if the exception is transient; otherwise, <c>false</c>.</returns>
         /// <remarks>
         /// Inspired by https://github.com/Azure/elastic-db-tools/blob/master/Src/ElasticScale.Client/ElasticScale.Common/TransientFaultHandling/Implementation/SqlDatabaseTransientErrorDetectionStrategy.cs.
         /// </remarks>

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlCommandWrapper.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlCommandWrapper.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Health.SqlServer.Features.Client
             => _sqlCommand.PrepareAsync(cancellationToken);
 
         /// <summary>
-        /// <see cref="SqlCommand.ExecuteReader"/>.
+        /// <see cref="SqlCommand.ExecuteReader()"/>.
         /// </summary>
         /// <returns>A <see cref="SqlDataReader"/> object.</returns>
         public virtual SqlDataReader ExecuteReader()

--- a/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
+++ b/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <Import Project="..\..\tools\Microsoft.Health.Extensions.BuildTimeCodeGenerator\Microsoft.Health.Extensions.BuildTimeCodeGenerator.targets" />
 
   <PropertyGroup>
+    <Description>SQL Server extensions and utilities used by Microsoft Health.</Description>
     <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
   </PropertyGroup>
 
@@ -74,4 +76,5 @@
       <Output TaskParameter="TargetOutputs" PropertyName="GeneratorPath" />
     </MSBuild>
   </Target>
+
 </Project>

--- a/test/Microsoft.Health.SqlServer.Tests.E2E/Microsoft.Health.SqlServer.Tests.E2E.csproj
+++ b/test/Microsoft.Health.SqlServer.Tests.E2E/Microsoft.Health.SqlServer.Tests.E2E.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <RootNamespace>Microsoft.Health.SqlServer.Tests.E2E</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Microsoft.Health.SqlServer.Tests.E2E</RootNamespace>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(SdkPackageVersion)" />

--- a/test/Microsoft.Health.SqlServer.Web/Microsoft.Health.SqlServer.Web.csproj
+++ b/test/Microsoft.Health.SqlServer.Web/Microsoft.Health.SqlServer.Web.csproj
@@ -1,49 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
   <Import Project="..\..\tools\Microsoft.Health.Extensions.BuildTimeCodeGenerator\Microsoft.Health.Extensions.BuildTimeCodeGenerator.targets" />
 
   <PropertyGroup>
-        <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+    <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.7" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.7" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Microsoft.Health.SqlServer.Api\Microsoft.Health.SqlServer.Api.csproj" />
-        <ProjectReference Include="..\..\src\Microsoft.Health.SqlServer\Microsoft.Health.SqlServer.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Health.SqlServer.Api\Microsoft.Health.SqlServer.Api.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Health.SqlServer\Microsoft.Health.SqlServer.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <None Remove="Features\Schema\Migrations\1.sql" />
-      <None Remove="Features\Schema\Migrations\2.diff.sql" />
-      <None Remove="Features\Schema\Migrations\3.diff.sql" />
-      <None Remove="Features\Schema\Migrations\3.sql" />
-      <EmbeddedResource Include="Features\Schema\Migrations\3.diff.sql" />
-      <EmbeddedResource Include="Features\Schema\Migrations\3.sql" />
-      <EmbeddedResource Include="Features\Schema\Migrations\2.diff.sql" />
-      <EmbeddedResource Include="Features\Schema\Migrations\1.sql" />
-      <None Remove="Features\Schema\Migrations\2.sql" />
-      <EmbeddedResource Include="Features\Schema\Migrations\2.sql" />
-      <GenerateFilesInputs Include="Features\Schema\Migrations\2.sql" />
-      <GenerateFilesInputs Include="Features\Schema\Migrations\3.sql" />
-      <Generated Include="Features\Schema\Model\VLatest.Generated.cs">
-        <Generator>MutableSqlModelGenerator</Generator>
-        <Namespace>Microsoft.Health.SqlServer.Web.Features.Schema.Model</Namespace>
-        <Args>"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\Features\Schema\Migrations\3.sql'))"</Args>
-      </Generated>
-      <Generated Include="Features\Schema\Model\ImmutableTypes.Generated.cs">
-        <Generator>ImmutableSqlModelGenerator</Generator>
-        <Namespace>Microsoft.Health.SqlServer.Web.Features.Schema.Model</Namespace>
-        <Args>"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\Features\Schema\Migrations\2.sql'))" "$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\Features\Schema\Migrations\3.sql'))"</Args>
-      </Generated>
-    </ItemGroup>
+  <ItemGroup>
+    <None Remove="Features\Schema\Migrations\1.sql" />
+    <None Remove="Features\Schema\Migrations\2.diff.sql" />
+    <None Remove="Features\Schema\Migrations\3.diff.sql" />
+    <None Remove="Features\Schema\Migrations\3.sql" />
+    <EmbeddedResource Include="Features\Schema\Migrations\3.diff.sql" />
+    <EmbeddedResource Include="Features\Schema\Migrations\3.sql" />
+    <EmbeddedResource Include="Features\Schema\Migrations\2.diff.sql" />
+    <EmbeddedResource Include="Features\Schema\Migrations\1.sql" />
+    <None Remove="Features\Schema\Migrations\2.sql" />
+    <EmbeddedResource Include="Features\Schema\Migrations\2.sql" />
+    <GenerateFilesInputs Include="Features\Schema\Migrations\2.sql" />
+    <GenerateFilesInputs Include="Features\Schema\Migrations\3.sql" />
+    <Generated Include="Features\Schema\Model\VLatest.Generated.cs">
+      <Generator>MutableSqlModelGenerator</Generator>
+      <Namespace>Microsoft.Health.SqlServer.Web.Features.Schema.Model</Namespace>
+      <Args>"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\Features\Schema\Migrations\3.sql'))"</Args>
+    </Generated>
+    <Generated Include="Features\Schema\Model\ImmutableTypes.Generated.cs">
+      <Generator>ImmutableSqlModelGenerator</Generator>
+      <Namespace>Microsoft.Health.SqlServer.Web.Features.Schema.Model</Namespace>
+      <Args>"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\Features\Schema\Migrations\2.sql'))" "$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\Features\Schema\Migrations\3.sql'))"</Args>
+    </Generated>
+  </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Features\Schema\Model\" />
-      <Folder Include="Properties" />
-    </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Features\Schema\Model\" />
+    <Folder Include="Properties" />
+  </ItemGroup>
 
   <PropertyGroup>
     <GeneratorProjectPath>$(MSBuildThisFileDirectory)..\..\tools\Microsoft.Health.Extensions.BuildTimeCodeGenerator\Microsoft.Health.Extensions.BuildTimeCodeGenerator.csproj</GeneratorProjectPath>
@@ -54,4 +55,5 @@
       <Output TaskParameter="TargetOutputs" PropertyName="GeneratorPath" />
     </MSBuild>
   </Target>
+
 </Project>

--- a/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
+++ b/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
     <NoWarn>$(NoWarn);NU1603</NoWarn>
-    <DefineConstants>R5</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
+++ b/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(SupportedFrameworks);</TargetFrameworks>
     <NoWarn>$(NoWarn);NU1603</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup>
     <DefineConstants>R5</DefineConstants>
   </PropertyGroup>
 

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.csproj
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.csproj
@@ -29,4 +29,5 @@
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=net5.0" />
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=netcoreapp3.1" />
   </Target>
+
 </Project>


### PR DESCRIPTION
## Description
The NuGet packages are missing some important metadata that would make development easier, and some of the dependencies are incorrect. This PR sets out to address the following:
- Remove build and development dependencies from NuGet's metadata (Eg. consumers don't need the analyzers)
- Add XML doc to *.nupkg* for intellisense
    - Fix malformed or invalid XML doc
- Ensure symbol (*.pdb) files are included in *.nupkg*
- Compile code as deterministic
    - Add CI build flag to CI builds
- Update NuGet metadata
    - Author
    - Company
    - Copyright
    - Description
    - Product
- Normalize *.csproj* identation to 2 spaces

## Related issues
N/A

## Testing
- Re-ran tests
- Check package metadata locally
