### PR TITLE
Adding support to read from and write to float column.

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -217,6 +217,24 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
         }
     }
 
+    public class FloatColumn : Column<double>
+    {
+        public FloatColumn(string name, byte precision)
+            :base(name, SqlDbType.Float, precision, 0)
+        {
+        }
+
+        public override double Read(SqlDataReader reader, int ordinal)
+        {
+            return reader.GetDouble(Metadata.name, ordinal);
+        }
+
+        public override void Set(SqlDataRecord record, int ordinal, double value)
+        {
+            record.SetDouble(ordinal, value);
+        }
+    }
+
     public class SmallIntColumn : Column<short>
     {
         public SmallIntColumn(string name)

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -434,7 +434,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
         {
         }
 
-        public override double Read(SqlDataReader reader, int ordinal)
+        public override double? Read(SqlDataReader reader, int ordinal)
         {
             return reader.IsDBNull(Metadata.Name, ordinal) ? default(float?) : reader.GetDouble(Metadata.name, ordinal);
         }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
     public class FloatColumn : Column<double>
     {
         public FloatColumn(string name, byte precision)
-            :base(name, SqlDbType.Float, precision, 0)
+            : base(name, SqlDbType.Float, false, precision, 0)
         {
         }
 
@@ -419,6 +419,31 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
             if (value.HasValue)
             {
                 record.SetDecimal(ordinal, value.Value);
+            }
+            else
+            {
+                record.SetDBNull(ordinal);
+            }
+        }
+    }
+
+    public class NullableFloatColumn : Column<double?>
+    {
+        public NullableFloatColumn(string name, byte precision)
+            : base(name, SqlDbType.Float, true, precision, 0)
+        {
+        }
+
+        public override double Read(SqlDataReader reader, int ordinal)
+        {
+            return reader.IsDBNull(Metadata.Name, ordinal) ? default(float?) : reader.GetDouble(Metadata.name, ordinal);
+        }
+
+        public override void Set(SqlDataRecord record, int ordinal, double? value)
+        {
+            if (value.HasValue)
+            {
+                record.SetDouble(ordinal, value);
             }
             else
             {

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
 
         public override double Read(SqlDataReader reader, int ordinal)
         {
-            return reader.GetDouble(Metadata.name, ordinal);
+            return reader.GetDouble(Metadata.Name, ordinal);
         }
 
         public override void Set(SqlDataRecord record, int ordinal, double value)
@@ -436,7 +436,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
 
         public override double? Read(SqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(Metadata.Name, ordinal) ? default(float?) : reader.GetDouble(Metadata.name, ordinal);
+            return reader.IsDBNull(Metadata.Name, ordinal) ? default(float?) : reader.GetDouble(Metadata.Name, ordinal);
         }
 
         public override void Set(SqlDataRecord record, int ordinal, double? value)

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -436,14 +436,14 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
 
         public override double? Read(SqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(Metadata.Name, ordinal) ? default(float?) : reader.GetDouble(Metadata.Name, ordinal);
+            return reader.IsDBNull(Metadata.Name, ordinal) ? default(double?) : reader.GetDouble(Metadata.Name, ordinal);
         }
 
         public override void Set(SqlDataRecord record, int ordinal, double? value)
         {
             if (value.HasValue)
             {
-                record.SetDouble(ordinal, value);
+                record.SetDouble(ordinal, value.Value);
             }
             else
             {


### PR DESCRIPTION
Add support to handle float as a column's data type.  Per [documentation](https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/sql-server-data-type-mappings), a SQL float maps to a .NET double.
