### PR TITLE
Add ability for the SQL connection string to be provided via an interface

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionStringProviderTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionStringProviderTests.cs
@@ -19,27 +19,16 @@ namespace Microsoft.Health.SqlServer.UnitTests.Features
             Assert.Throws<ArgumentNullException>(() => new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration: null));
         }
 
-        [Fact]
-        public void GivenNullConnectionString_CtorThrows()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("server=(local);Initial Catalog=Dicom;Integrated Security=true")]
+        public async Task GivenValidSqlServerDataStoreConfiguration_GetSqlConnectionString_ReturnsConnectionString(string sqlConnectionString)
         {
-            var sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration() { ConnectionString = null };
-            Assert.Throws<ArgumentNullException>(() => new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration));
-        }
-
-        [Fact]
-        public void GivenEmptyConnectionString_CtorThrows()
-        {
-            var sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration() { ConnectionString = string.Empty };
-            Assert.Throws<ArgumentException>(() => new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration));
-        }
-
-        [Fact]
-        public async Task GivenValidSqlServerDataStoreConfiguration_GetSqlConnectionString_ReturnsConnectionString()
-        {
-            var sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration() { ConnectionString = $"server=(local);Initial Catalog=Dicom;Integrated Security=true" };
+            var sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration() { ConnectionString = sqlConnectionString };
             ISqlConnectionStringProvider sqlConnectionStringProvider = new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration);
 
-            Assert.Equal(sqlServerDataStoreConfiguration.ConnectionString, await sqlConnectionStringProvider.GetSqlConnectionString(CancellationToken.None));
+            Assert.Equal(sqlConnectionString, await sqlConnectionStringProvider.GetSqlConnectionString(CancellationToken.None));
         }
     }
 }

--- a/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionStringProviderTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionStringProviderTests.cs
@@ -1,0 +1,45 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Health.SqlServer.Configs;
+using Xunit;
+
+namespace Microsoft.Health.SqlServer.UnitTests.Features
+{
+    public class DefaultSqlConnectionStringProviderTests
+    {
+        [Fact]
+        public void GivenNullSqlServerDataStoreConfiguration_CtorThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration: null));
+        }
+
+        [Fact]
+        public void GivenNullConnectionString_CtorThrows()
+        {
+            var sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration() { ConnectionString = null };
+            Assert.Throws<ArgumentNullException>(() => new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration));
+        }
+
+        [Fact]
+        public void GivenEmptyConnectionString_CtorThrows()
+        {
+            var sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration() { ConnectionString = string.Empty };
+            Assert.Throws<ArgumentException>(() => new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration));
+        }
+
+        [Fact]
+        public async Task GivenValidSqlServerDataStoreConfiguration_GetSqlConnectionString_ReturnsConnectionString()
+        {
+            var sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration() { ConnectionString = $"server=(local);Initial Catalog=Dicom;Integrated Security=true" };
+            ISqlConnectionStringProvider sqlConnectionStringProvider = new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration);
+
+            Assert.Equal(sqlServerDataStoreConfiguration.ConnectionString, await sqlConnectionStringProvider.GetSqlConnectionString(CancellationToken.None));
+        }
+    }
+}

--- a/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionTests.cs
@@ -16,14 +16,13 @@ namespace Microsoft.Health.SqlServer.UnitTests.Features
         private const string ServerName = "(local)";
         private const string MasterDatabase = "master";
 
-        private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
         private readonly DefaultSqlConnectionFactory _sqlConnectionFactory;
 
         public DefaultSqlConnectionTests()
         {
-            _sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration();
-            _sqlServerDataStoreConfiguration.ConnectionString = $"server={ServerName};Initial Catalog={DatabaseName};Integrated Security=true";
-            _sqlConnectionFactory = new DefaultSqlConnectionFactory(_sqlServerDataStoreConfiguration);
+            var sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration();
+            sqlServerDataStoreConfiguration.ConnectionString = $"server={ServerName};Initial Catalog={DatabaseName};Integrated Security=true";
+            _sqlConnectionFactory = new DefaultSqlConnectionFactory(new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration));
         }
 
         [Fact]

--- a/src/Microsoft.Health.SqlServer.UnitTests/ManagedIdentitySqlConnectionTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/ManagedIdentitySqlConnectionTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.SqlServer.UnitTests
             SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration();
             sqlServerDataStoreConfiguration.ConnectionString = $"Server={ServerName};Database={DatabaseName};";
             sqlServerDataStoreConfiguration.AuthenticationType = SqlServerAuthenticationType.ManagedIdentity;
-            _sqlConnectionFactory = new ManagedIdentitySqlConnectionFactory(sqlServerDataStoreConfiguration, accessTokenHandler);
+            _sqlConnectionFactory = new ManagedIdentitySqlConnectionFactory(new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration), accessTokenHandler);
         }
 
         [Fact]

--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionFactory.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionFactory.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
-using Microsoft.Health.SqlServer.Configs;
 
 namespace Microsoft.Health.SqlServer
 {
@@ -17,33 +16,32 @@ namespace Microsoft.Health.SqlServer
     /// </summary>
     public class DefaultSqlConnectionFactory : ISqlConnectionFactory
     {
-        private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
+        private readonly ISqlConnectionStringProvider _sqlConnectionStringProvider;
 
-        public DefaultSqlConnectionFactory(SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration)
+        public DefaultSqlConnectionFactory(ISqlConnectionStringProvider sqlConnectionStringProvider)
         {
-            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+            EnsureArg.IsNotNull(sqlConnectionStringProvider, nameof(sqlConnectionStringProvider));
 
-            _sqlServerDataStoreConfiguration = sqlServerDataStoreConfiguration;
+            _sqlConnectionStringProvider = sqlConnectionStringProvider;
         }
 
         /// <inheritdoc />
-        public Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, CancellationToken cancellationToken = default)
+        public async Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, CancellationToken cancellationToken = default)
         {
-            EnsureArg.IsNotNullOrEmpty(_sqlServerDataStoreConfiguration.ConnectionString);
-
             SqlConnection sqlConnection;
+            string sqlConnectionString = await _sqlConnectionStringProvider.GetSqlConnectionString();
 
             if (initialCatalog == null)
             {
-                sqlConnection = new SqlConnection(_sqlServerDataStoreConfiguration.ConnectionString);
+                sqlConnection = new SqlConnection(sqlConnectionString);
             }
             else
             {
-                SqlConnectionStringBuilder connectionBuilder = new SqlConnectionStringBuilder(_sqlServerDataStoreConfiguration.ConnectionString) { InitialCatalog = initialCatalog };
+                SqlConnectionStringBuilder connectionBuilder = new SqlConnectionStringBuilder(sqlConnectionString) { InitialCatalog = initialCatalog };
                 sqlConnection = new SqlConnection(connectionBuilder.ToString());
             }
 
-            return Task.FromResult(sqlConnection);
+            return sqlConnection;
         }
     }
 }

--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionFactory.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionFactory.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -29,7 +30,11 @@ namespace Microsoft.Health.SqlServer
         public async Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, CancellationToken cancellationToken = default)
         {
             SqlConnection sqlConnection;
-            string sqlConnectionString = await _sqlConnectionStringProvider.GetSqlConnectionString();
+            string sqlConnectionString = await _sqlConnectionStringProvider.GetSqlConnectionString(cancellationToken);
+            if (string.IsNullOrEmpty(sqlConnectionString))
+            {
+                throw new InvalidOperationException("The SQL connection string cannot be null or empty.");
+            }
 
             if (initialCatalog == null)
             {

--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
@@ -15,18 +15,17 @@ namespace Microsoft.Health.SqlServer
     /// </summary>
     public class DefaultSqlConnectionStringProvider : ISqlConnectionStringProvider
     {
-        private readonly string _sqlConnectionString;
+        private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
 
         public DefaultSqlConnectionStringProvider(SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration)
         {
-            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
-            _sqlConnectionString = EnsureArg.IsNotNullOrEmpty(sqlServerDataStoreConfiguration.ConnectionString, nameof(sqlServerDataStoreConfiguration.ConnectionString));
+            _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
         }
 
         /// <inheritdoc />
         public Task<string> GetSqlConnectionString(CancellationToken cancellationToken)
         {
-            return Task.FromResult(_sqlConnectionString);
+            return Task.FromResult(_sqlServerDataStoreConfiguration.ConnectionString);
         }
     }
 }

--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
@@ -1,0 +1,31 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Health.SqlServer.Configs;
+
+namespace Microsoft.Health.SqlServer
+{
+    /// <summary>
+    /// The default SQL connection string provider uses the connection string specified in configuration.
+    /// </summary>
+    public class DefaultSqlConnectionStringProvider : ISqlConnectionStringProvider
+    {
+        private readonly string _sqlConnectionString;
+
+        public DefaultSqlConnectionStringProvider(SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration)
+        {
+            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+            _sqlConnectionString = sqlServerDataStoreConfiguration.ConnectionString;
+        }
+
+        /// <inheritdoc />
+        public Task<string> GetSqlConnectionString()
+        {
+            return Task.FromResult(_sqlConnectionString);
+        }
+    }
+}

--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Health.SqlServer.Configs;
@@ -19,11 +20,11 @@ namespace Microsoft.Health.SqlServer
         public DefaultSqlConnectionStringProvider(SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration)
         {
             EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
-            _sqlConnectionString = sqlServerDataStoreConfiguration.ConnectionString;
+            _sqlConnectionString = EnsureArg.IsNotNullOrEmpty(sqlServerDataStoreConfiguration.ConnectionString, nameof(sqlServerDataStoreConfiguration.ConnectionString));
         }
 
         /// <inheritdoc />
-        public Task<string> GetSqlConnectionString()
+        public Task<string> GetSqlConnectionString(CancellationToken cancellationToken)
         {
             return Task.FromResult(_sqlConnectionString);
         }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/BaseSchemaRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/BaseSchemaRunner.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 
         private async Task InitializeAsync(CancellationToken cancellationToken)
         {
-            string sqlConnectionString = await _sqlConnectionStringProvider.GetSqlConnectionString();
+            string sqlConnectionString = await _sqlConnectionStringProvider.GetSqlConnectionString(cancellationToken);
             var configuredConnectionBuilder = new SqlConnectionStringBuilder(sqlConnectionString);
             string databaseName = configuredConnectionBuilder.InitialCatalog;
 

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -27,19 +27,22 @@ namespace Microsoft.Health.SqlServer.Features.Schema
         private readonly SchemaInformation _schemaInformation;
         private readonly ILogger<SchemaInitializer> _logger;
         private readonly ISqlConnectionFactory _sqlConnectionFactory;
+        private readonly ISqlConnectionStringProvider _sqlConnectionStringProvider;
 
-        public SchemaInitializer(SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration, SchemaUpgradeRunner schemaUpgradeRunner, SchemaInformation schemaInformation, ISqlConnectionFactory sqlConnectionFactory, ILogger<SchemaInitializer> logger)
+        public SchemaInitializer(SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration, SchemaUpgradeRunner schemaUpgradeRunner, SchemaInformation schemaInformation, ISqlConnectionFactory sqlConnectionFactory, ISqlConnectionStringProvider sqlConnectionStringProvider, ILogger<SchemaInitializer> logger)
         {
             EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
             EnsureArg.IsNotNull(schemaUpgradeRunner, nameof(schemaUpgradeRunner));
             EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
             EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));
+            EnsureArg.IsNotNull(sqlConnectionStringProvider, nameof(sqlConnectionStringProvider));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _sqlServerDataStoreConfiguration = sqlServerDataStoreConfiguration;
             _schemaUpgradeRunner = schemaUpgradeRunner;
             _schemaInformation = schemaInformation;
             _sqlConnectionFactory = sqlConnectionFactory;
+            _sqlConnectionStringProvider = sqlConnectionStringProvider;
             _logger = logger;
         }
 
@@ -205,7 +208,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                 return false;
             }
 
-            var configuredConnectionBuilder = new SqlConnectionStringBuilder(_sqlServerDataStoreConfiguration.ConnectionString);
+            var configuredConnectionBuilder = new SqlConnectionStringBuilder(await _sqlConnectionStringProvider.GetSqlConnectionString());
             string databaseName = configuredConnectionBuilder.InitialCatalog;
 
             ValidateDatabaseName(databaseName);
@@ -253,7 +256,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            if (!string.IsNullOrWhiteSpace(_sqlServerDataStoreConfiguration.ConnectionString))
+            if (!string.IsNullOrWhiteSpace(await _sqlConnectionStringProvider.GetSqlConnectionString()))
             {
                 await InitializeAsync(cancellationToken: cancellationToken);
             }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                 return false;
             }
 
-            var configuredConnectionBuilder = new SqlConnectionStringBuilder(await _sqlConnectionStringProvider.GetSqlConnectionString());
+            var configuredConnectionBuilder = new SqlConnectionStringBuilder(await _sqlConnectionStringProvider.GetSqlConnectionString(cancellationToken));
             string databaseName = configuredConnectionBuilder.InitialCatalog;
 
             ValidateDatabaseName(databaseName);
@@ -256,7 +256,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            if (!string.IsNullOrWhiteSpace(await _sqlConnectionStringProvider.GetSqlConnectionString()))
+            if (!string.IsNullOrWhiteSpace(await _sqlConnectionStringProvider.GetSqlConnectionString(cancellationToken)))
             {
                 await InitializeAsync(cancellationToken: cancellationToken);
             }

--- a/src/Microsoft.Health.SqlServer/ISqlConnectionStringProvider.cs
+++ b/src/Microsoft.Health.SqlServer/ISqlConnectionStringProvider.cs
@@ -1,0 +1,18 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.SqlServer
+{
+    public interface ISqlConnectionStringProvider
+    {
+        /// <summary>
+        /// Get the SQL connection string.
+        /// </summary>
+        /// <returns>A SQL connection string.</returns>
+        Task<string> GetSqlConnectionString();
+    }
+}

--- a/src/Microsoft.Health.SqlServer/ISqlConnectionStringProvider.cs
+++ b/src/Microsoft.Health.SqlServer/ISqlConnectionStringProvider.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Health.SqlServer
@@ -12,7 +13,8 @@ namespace Microsoft.Health.SqlServer
         /// <summary>
         /// Get the SQL connection string.
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A SQL connection string.</returns>
-        Task<string> GetSqlConnectionString();
+        Task<string> GetSqlConnectionString(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.SqlServer/ManagedIdentitySqlConnectionFactory.cs
+++ b/src/Microsoft.Health.SqlServer/ManagedIdentitySqlConnectionFactory.cs
@@ -7,39 +7,37 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
-using Microsoft.Health.SqlServer.Configs;
 
 namespace Microsoft.Health.SqlServer
 {
     public class ManagedIdentitySqlConnectionFactory : ISqlConnectionFactory
     {
-        private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
+        private readonly ISqlConnectionStringProvider _sqlConnectionStringProvider;
         private readonly IAccessTokenHandler _accessTokenHandler;
         private readonly string _azureResource = "https://database.windows.net/";
 
-        public ManagedIdentitySqlConnectionFactory(SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration, IAccessTokenHandler accessTokenHandler)
+        public ManagedIdentitySqlConnectionFactory(ISqlConnectionStringProvider sqlConnectionStringProvider, IAccessTokenHandler accessTokenHandler)
         {
-            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+            EnsureArg.IsNotNull(sqlConnectionStringProvider, nameof(sqlConnectionStringProvider));
             EnsureArg.IsNotNull(accessTokenHandler, nameof(accessTokenHandler));
 
-            _sqlServerDataStoreConfiguration = sqlServerDataStoreConfiguration;
+            _sqlConnectionStringProvider = sqlConnectionStringProvider;
             _accessTokenHandler = accessTokenHandler;
         }
 
         /// <inheritdoc />
         public async Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, CancellationToken cancellationToken = default)
         {
-            EnsureArg.IsNotNullOrEmpty(_sqlServerDataStoreConfiguration.ConnectionString);
-
             SqlConnection sqlConnection;
+            string sqlConnectionString = await _sqlConnectionStringProvider.GetSqlConnectionString();
 
             if (initialCatalog == null)
             {
-                sqlConnection = new SqlConnection(_sqlServerDataStoreConfiguration.ConnectionString);
+                sqlConnection = new SqlConnection(sqlConnectionString);
             }
             else
             {
-                SqlConnectionStringBuilder connectionBuilder = new SqlConnectionStringBuilder(_sqlServerDataStoreConfiguration.ConnectionString) { InitialCatalog = initialCatalog };
+                SqlConnectionStringBuilder connectionBuilder = new SqlConnectionStringBuilder(sqlConnectionString) { InitialCatalog = initialCatalog };
                 sqlConnection = new SqlConnection(connectionBuilder.ToString());
             }
 

--- a/src/Microsoft.Health.SqlServer/ManagedIdentitySqlConnectionFactory.cs
+++ b/src/Microsoft.Health.SqlServer/ManagedIdentitySqlConnectionFactory.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -29,7 +30,11 @@ namespace Microsoft.Health.SqlServer
         public async Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, CancellationToken cancellationToken = default)
         {
             SqlConnection sqlConnection;
-            string sqlConnectionString = await _sqlConnectionStringProvider.GetSqlConnectionString();
+            string sqlConnectionString = await _sqlConnectionStringProvider.GetSqlConnectionString(cancellationToken);
+            if (string.IsNullOrEmpty(sqlConnectionString))
+            {
+                throw new InvalidOperationException("The SQL connection string cannot be null or empty.");
+            }
 
             if (initialCatalog == null)
             {

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -95,6 +95,8 @@ namespace Microsoft.Health.SqlServer.Registration
                 .AsSelf()
                 .AsImplementedInterfaces();
 
+            services.AddSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>();
+
             switch (config.AuthenticationType)
             {
                 case SqlServerAuthenticationType.ManagedIdentity:

--- a/tools/SchemaManager/Program.cs
+++ b/tools/SchemaManager/Program.cs
@@ -45,6 +45,7 @@ namespace SchemaManager
             // Add SqlServer services
             services.AddSingleton<SqlServerDataStoreConfiguration>();
             services.AddSingleton<ISqlConnectionFactory, DefaultSqlConnectionFactory>();
+            services.AddSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>();
             services.AddSingleton<BaseSchemaRunner>();
             services.AddSingleton<ISchemaManagerDataStore, SchemaManagerDataStore>();
             services.AddSingleton<ISchemaClient, SchemaClient>();


### PR DESCRIPTION
## Description
- Create a new interface that provides a method to get the SQL connection string
- Update usages of the SqlServerDataStoreConfiguration.ConnectionString to use this interface instead.
- Create a default implementation which reads the connection string from config

## Testing
- All automated tests passed.
