### PR TITLE
Adds missing registration for SchemaManagerDataStore

### DIFF
--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -75,6 +75,11 @@ namespace Microsoft.Health.SqlServer.Registration
                 .AsSelf()
                 .AsImplementedInterfaces();
 
+            services.Add<SchemaManagerDataStore>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
             services.Add<PollyRetryLoggerFactory>()
                 .Singleton()
                 .AsSelf()


### PR DESCRIPTION
## Description
Adds missing registration for SchemaManagerDataStore

## Related issues
Addresses [issue #].

## Testing
Tested locally by referring the updated nugets in fhir-server
