### PR TITLE
Install .net 3.1 with global.json

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -1,13 +1,6 @@
 parameters:
   packageArtifacts: true
 
-steps:
-- task: UseDotNet@2
-  displayName: 'Use .NET Core 3.1.x SDK'
-  inputs:
-    packageType: sdk
-    version: 3.1.x
-
 - task: UseDotNet@2
   displayName: 'Use .NET (global.json)'
   inputs:

--- a/netcore3.1/global.json
+++ b/netcore3.1/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.406",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
## Description
Even though the netcore3.1/global.json doesn't have any project files, all global.json files are picked up by the `Use Dotnet` build task and installed. This should work for both external and internal builds.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Skip (build script)
