### PR TITLE
Execute paas schema by schema manager tool

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaClient.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaClient.cs
@@ -13,16 +13,48 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 {
     public interface ISchemaClient
     {
+        /// <summary>
+        /// Sets Uri to HttpClient base address
+        /// </summary>
+        /// <param name="uri">The uri to set</param>
         void SetUri(Uri uri);
 
+        /// <summary>
+        /// Gets the current schema version information
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token</param>
         Task<List<CurrentVersion>> GetCurrentVersionInformationAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Gets the complete script
+        /// </summary>
+        /// <param name="scriptUri">A url to fetch the script</param>
+        /// <param name="cancellationToken">A cancellation token</param>
         Task<string> GetScriptAsync(Uri scriptUri, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Gets the diff script
+        /// </summary>
+        /// <param name="diffScriptUri">A url to fetch the diff script</param>
+        /// <param name="cancellationToken">A cancellation token</param>
         Task<string> GetDiffScriptAsync(Uri diffScriptUri, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Gets the compatible min and max schema version
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token</param>
         Task<CompatibleVersion> GetCompatibilityAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Fetch the available schema versions
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token</param>
         Task<List<AvailableVersion>> GetAvailabilityAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Gets the list of Paas-specific script
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token</param>
+        Task<List<PaasSchema>> GetPaasScriptAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
         /// <param name="script">The script to execute</param>
         /// <param name="version">The version to update its status</param>
         /// <param name="cancellationToken">A cancellation token</param>
-        Task ExecuteScriptAndCompleteSchemaVersionAsync(string script, int version, CancellationToken cancellationToken);
+        /// <param name="isPaasScript">Sets to true if the executing script is Paas-specific</param>
+        Task ExecuteScriptAndCompleteSchemaVersionAsync(string script, int version, CancellationToken cancellationToken, bool isPaasScript = false);
 
         /// <summary>
         /// Deletes the row for given version and status in the SchemaVersion table
@@ -50,5 +51,28 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
         /// </summary>
         /// <param name="cancellationToken">A cancellation token</param>
         Task<bool> InstanceSchemaRecordExistsAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Create PaasSchemaVersion table if not exists.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task</returns>
+        Task CreatePaasSchemaTableIfNotExistsAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Returns true if the record for given version and status exists in PaasSchemaVersion table.
+        /// </summary>
+        /// <param name="version">The paas schema version.</param>
+        /// <param name="status">The paas schema status.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A boolean</returns>
+        Task<bool> ExistsPaasSchemaRecordAsync(int version, string status, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Deletes the row for given version and failed status from the PaasSchemaVersion table
+        /// </summary>
+        /// <param name="version">The schema version</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        Task DeletesPaasSchemaFailedRecordAsync(int version, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/Model/PaasSchema.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/Model/PaasSchema.cs
@@ -1,0 +1,25 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+
+namespace Microsoft.Health.SqlServer.Features.Schema.Manager.Model
+{
+    public class PaasSchema
+    {
+        public PaasSchema(int id, string scriptContent)
+        {
+            EnsureArg.IsGte(id, 1, nameof(id));
+            EnsureArg.IsNotNullOrWhiteSpace(scriptContent, nameof(scriptContent));
+
+            Id = id;
+            ScriptContent = scriptContent;
+        }
+
+        public int Id { get; }
+
+        public string ScriptContent { get; }
+    }
+}

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -41,11 +41,6 @@ namespace Microsoft.Health.SqlServer.Registration
                 .Singleton()
                 .AsSelf();
 
-            services.Add<SchemaManagerDataStore>()
-                .Scoped()
-                .AsSelf()
-                .AsImplementedInterfaces();
-
             services.Add<SqlServerSchemaDataStore>()
                 .Scoped()
                 .AsSelf()

--- a/tools/SchemaManager.Core/Resources.Designer.cs
+++ b/tools/SchemaManager.Core/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace SchemaManager.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Completed applying Paas schema..
+        /// </summary>
+        internal static string ApplyPaasSchemaCompleted {
+            get {
+                return ResourceManager.GetString("ApplyPaasSchemaCompleted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Applying Paas schema for version: {0}..
+        /// </summary>
+        internal static string ApplyPaasSchemaStarted {
+            get {
+                return ResourceManager.GetString("ApplyPaasSchemaStarted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are no available versions..
         /// </summary>
         internal static string AvailableVersionsDefaultErrorMessage {
@@ -79,11 +97,29 @@ namespace SchemaManager.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Creating PaaSchemaVersion table if not exists..
+        /// </summary>
+        internal static string CreatePaasSchemaVersionTableMessage {
+            get {
+                return ResourceManager.GetString("CreatePaasSchemaVersionTableMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The schema version {0} cannot be applied because all the instances are not running the previous version..
         /// </summary>
         internal static string InvalidVersionMessage {
             get {
                 return ResourceManager.GetString("InvalidVersionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Paas schema already exists for version: {0}..
+        /// </summary>
+        internal static string PaasSchemaAlreadyExists {
+            get {
+                return ResourceManager.GetString("PaasSchemaAlreadyExists", resourceCulture);
             }
         }
         

--- a/tools/SchemaManager.Core/Resources.resx
+++ b/tools/SchemaManager.Core/Resources.resx
@@ -117,14 +117,28 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ApplyPaasSchemaCompleted" xml:space="preserve">
+    <value>Completed applying Paas schema.</value>
+  </data>
+  <data name="ApplyPaasSchemaStarted" xml:space="preserve">
+    <value>Applying Paas schema for version: {0}.</value>
+    <comment>{0} is a version.</comment>
+  </data>
   <data name="AvailableVersionsDefaultErrorMessage" xml:space="preserve">
     <value>There are no available versions.</value>
   </data>
   <data name="AvailableVersionsErrorMessage" xml:space="preserve">
     <value>The available versions are not up-to-date.</value>
   </data>
+  <data name="CreatePaasSchemaVersionTableMessage" xml:space="preserve">
+    <value>Creating PaaSchemaVersion table if not exists.</value>
+  </data>
   <data name="InvalidVersionMessage" xml:space="preserve">
     <value>The schema version {0} cannot be applied because all the instances are not running the previous version.</value>
+    <comment>{0} is a version.</comment>
+  </data>
+  <data name="PaasSchemaAlreadyExists" xml:space="preserve">
+    <value>Paas schema already exists for version: {0}.</value>
     <comment>{0} is a version.</comment>
   </data>
   <data name="QueryExecutionErrorMessage" xml:space="preserve">


### PR DESCRIPTION
## Description
Adds the ability to execute paas-specific schema by schema manager tool, if exists.

## Related issues
Addresses [#AB78170](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=78170)

## Testing
Manually tested by running the schema manager tool apply command.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
