### PR TITLE
Implements IBaseSchemaRunner interface

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/BaseSchemaRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/BaseSchemaRunner.cs
@@ -14,7 +14,7 @@ using Polly;
 
 namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 {
-    public class BaseSchemaRunner
+    public class BaseSchemaRunner : IBaseSchemaRunner
     {
         private static readonly TimeSpan RetrySleepDuration = TimeSpan.FromSeconds(20);
         private const int RetryAttempts = 3;

--- a/tools/SchemaManager/Program.cs
+++ b/tools/SchemaManager/Program.cs
@@ -48,7 +48,7 @@ namespace SchemaManager
             services.AddSingleton<SqlServerDataStoreConfiguration>();
             services.AddSingleton<ISqlConnectionFactory, DefaultSqlConnectionFactory>();
             services.AddSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>();
-            services.AddSingleton<BaseSchemaRunner>();
+            services.AddSingleton<IBaseSchemaRunner, BaseSchemaRunner>();
             services.AddSingleton<ISchemaManagerDataStore, SchemaManagerDataStore>();
             services.AddSingleton<ISchemaClient, SchemaClient>();
             services.AddSingleton<ISchemaManager, SqlSchemaManager>();


### PR DESCRIPTION
## Description
SchemaManager tool is throwing an error on startup
Unable to resolve service for type 'Microsoft.Health.SqlServer.Features.Schema.Manager.IBaseSchemaRunner' while attempting to activate 'SchemaManager.Core.SqlSchemaManager'.

To fix, this PR implements IBaseSchemaRunner interface and configured for DI

## Related issues
Addresses [issue #].

## Testing
Existing tests pass and SchemaManager tool starts and executes successfully

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
