### PR TITLE
Refactor to use SqlConnectionFactory

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/BaseSchemaRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/BaseSchemaRunner.cs
@@ -102,30 +102,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 
             SchemaInitializer.ValidateDatabaseName(databaseName);
 
-            SqlConnectionStringBuilder connectionBuilder = new SqlConnectionStringBuilder(sqlConnectionString);
-            using (var connection = new SqlConnection(connectionBuilder.ToString()))
-            {
-                bool doesDatabaseExist = await SchemaInitializer.DoesDatabaseExistAsync(connection, databaseName, cancellationToken);
-
-                // database creation is allowed
-                if (!doesDatabaseExist)
-                {
-                    _logger.LogInformation("The database does not exists.");
-
-                    bool created = await SchemaInitializer.CreateDatabaseAsync(connection, databaseName, cancellationToken);
-
-                    if (created)
-                    {
-                        _logger.LogInformation("The database is created.");
-                    }
-                    else
-                    {
-                        throw new SchemaManagerException(Resources.InsufficientDatabasePermissionsMessage);
-                    }
-
-                    connection.Close();
-                }
-            }
+            await _schemaManagerDataStore.CreateDatabaseIfNotExists(databaseName, cancellationToken);
 
             bool canInitialize = false;
 

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
@@ -50,12 +50,5 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
         /// </summary>
         /// <param name="cancellationToken">A cancellation token</param>
         Task<bool> InstanceSchemaRecordExistsAsync(CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Creates database if not exists. It needs required permissions.
-        /// </summary>
-        /// <param name="database">A database name.</param>
-        /// <param name="cancellationToken">A cancellation token</param>
-        Task CreateDatabaseIfNotExists(string database, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
@@ -50,5 +50,12 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
         /// </summary>
         /// <param name="cancellationToken">A cancellation token</param>
         Task<bool> InstanceSchemaRecordExistsAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Creates database if not exists. It needs required permissions.
+        /// </summary>
+        /// <param name="database">A database name.</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        Task CreateDatabaseIfNotExists(string database, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -191,8 +191,6 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
                     {
                         throw new SchemaManagerException(Resources.InsufficientDatabasePermissionsMessage);
                     }
-
-                    connection.Close();
                 }
             }
         }


### PR DESCRIPTION
## Description
Refactor code in BaseSchemaRunner to create database and use SqlConnectionFactory to create the SqlConnection.

## Related issues
Addresses [issue #].

## Testing
Existing tests passed.
Tested manually by integrating with paas schema manager.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
