### PR TITLE
Add uploadmaximumConcurrency

### DIFF
--- a/src/Microsoft.Health.Blob/Configs/BlobDataStoreRequestOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobDataStoreRequestOptions.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Health.Blob.Configs
 
         public int ServerTimeoutInMinutes { get; set; } = 2;
 
-        public int DownloadMaximumConcurrency { get; set; } = 1;
+        public int DownloadMaximumConcurrency { get; set; } = 5;
+
+        public int UploadMaximumConcurrency { get; set; } = 5;
     }
 }


### PR DESCRIPTION
## Description
Add the upload concurrency setting, now that this setting can be used in uploadAsync.
Reaction to issue fixed https://github.com/Azure/azure-sdk-for-net/issues/12445

## Related issues
[AB#80301](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80301)

## Testing
Just added a new configuration setting. Testing will be done in dicom-server, that consumes this setting
