### PR TITLE
Update version references to use SdkPackageVersion

### DIFF
--- a/test/Microsoft.Health.SqlServer.Tests.E2E/Microsoft.Health.SqlServer.Tests.E2E.csproj
+++ b/test/Microsoft.Health.SqlServer.Tests.E2E/Microsoft.Health.SqlServer.Tests.E2E.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(SdkPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Health.SqlServer.Web/Microsoft.Health.SqlServer.Web.csproj
+++ b/test/Microsoft.Health.SqlServer.Web/Microsoft.Health.SqlServer.Web.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(SdkPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
A couple of package references weren't correctly making use of the variable SdkPackageVersion.

## Related issues
Addresses none.

## Testing
Tests continue to pass

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
