### PR TITLE
Makes RetrySqlCommandWrapper public

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Client/IPollyRetryLoggerFactory.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/IPollyRetryLoggerFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.SqlServer.Features.Client
     /// <summary>
     /// Provides functionality for creating a logger for the <see cref="Polly"/> retry policy.
     /// </summary>
-    internal interface IPollyRetryLoggerFactory
+    public interface IPollyRetryLoggerFactory
     {
         /// <summary>
         /// Creates a logger.

--- a/src/Microsoft.Health.SqlServer/Features/Client/RetrySqlCommandWrapper.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/RetrySqlCommandWrapper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.SqlServer.Features.Client
     /// <summary>
     /// A wrapper around <see cref="SqlCommand"/> to provide automatic retries for transient errors.
     /// </summary>
-    internal class RetrySqlCommandWrapper : SqlCommandWrapper
+    public class RetrySqlCommandWrapper : SqlCommandWrapper
     {
         private readonly SqlCommandWrapper _sqlCommandWrapper;
         private readonly IAsyncPolicy _retryPolicy;


### PR DESCRIPTION
## Description
In PR #22, support for retrying SQL transient errors was added.

I am looking to use this in the implementation of reindexing for SQL in the[ fhir-server repo](https://github.com/Microsoft/fhir-server), to catch transient errors that occur when updating reindex job records.

## Related issues
Addresses [AB#80852](https://microsofthealth.visualstudio.com/Health/_workitems/edit/80852).

## Testing
All tests pass as before.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Minor (adding functionality)
