### PR TITLE
Fix CVE-2021-26701

### DIFF
--- a/src/Microsoft.Health.Development.IdentityProvider/Microsoft.Health.Development.IdentityProvider.csproj
+++ b/src/Microsoft.Health.Development.IdentityProvider/Microsoft.Health.Development.IdentityProvider.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Fix CVE-2021-26701 by updating System.Text.Encodings.Web

## Related issues
Addresses [AB#80816](https://microsofthealth.visualstudio.com/Health/_workitems/edit/80816)

## Testing
Pipeline passes

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch
