### PR TITLE
Adds codegen for `CREATE VIEW` statements

### DIFF
--- a/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.diff.sql
+++ b/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.diff.sql
@@ -11,3 +11,43 @@ CREATE PROCEDURE dbo.MyProcedure_2
 AS
     SELECT 1
 GO
+
+CREATE TABLE dbo.Table1
+(
+    Id int,
+    Name nvarchar(20)
+)
+
+CREATE TABLE dbo.Table2
+(
+    Id int,
+    City nvarchar(20)
+)
+
+GO
+
+CREATE VIEW dbo.MyView
+	WITH SCHEMABINDING
+	AS
+
+	SELECT 
+        t1.Id, 
+        t1.Name, 
+        t2.City AS TheCity
+	FROM dbo.Table1 t1
+	INNER JOIN dbo.Table2 t2 ON t1.Id = t2.Id
+GO
+
+CREATE UNIQUE CLUSTERED INDEX IXC_View12 ON dbo.MyView
+(
+    Id,
+    Name,
+    City
+)
+WITH (DATA_COMPRESSION = PAGE)
+
+CREATE NONCLUSTERED INDEX IX_View12_City ON dbo.MyView
+(	
+    City
+)
+WITH (DATA_COMPRESSION = PAGE)

--- a/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.diff.sql
+++ b/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.diff.sql
@@ -42,12 +42,12 @@ CREATE UNIQUE CLUSTERED INDEX IXC_View12 ON dbo.MyView
 (
     Id,
     Name,
-    City
+    TheCity
 )
 WITH (DATA_COMPRESSION = PAGE)
 
 CREATE NONCLUSTERED INDEX IX_View12_City ON dbo.MyView
 (	
-    City
+    TheCity
 )
 WITH (DATA_COMPRESSION = PAGE)

--- a/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.sql
+++ b/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.sql
@@ -66,12 +66,12 @@ CREATE UNIQUE CLUSTERED INDEX IXC_View12 ON dbo.MyView
 (
     Id,
     Name,
-    City
+    TheCity
 )
 WITH (DATA_COMPRESSION = PAGE)
 
 CREATE NONCLUSTERED INDEX IX_View12_City ON dbo.MyView
 (	
-    City
+    TheCity
 )
 WITH (DATA_COMPRESSION = PAGE)

--- a/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.sql
+++ b/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.sql
@@ -35,3 +35,43 @@ CREATE PROCEDURE dbo.InsertNumbers
 AS
     SELECT 1
 GO
+
+CREATE TABLE dbo.Table1
+(
+    Id int,
+    Name nvarchar(20)
+)
+
+CREATE TABLE dbo.Table2
+(
+    Id int,
+    City nvarchar(20)
+)
+
+GO
+
+CREATE VIEW dbo.MyView
+	WITH SCHEMABINDING
+	AS
+
+	SELECT 
+        t1.Id, 
+        t1.Name, 
+        t2.City AS TheCity
+	FROM dbo.Table1 t1
+	INNER JOIN dbo.Table2 t2 ON t1.Id = t2.Id
+GO
+
+CREATE UNIQUE CLUSTERED INDEX IXC_View12 ON dbo.MyView
+(
+    Id,
+    Name,
+    City
+)
+WITH (DATA_COMPRESSION = PAGE)
+
+CREATE NONCLUSTERED INDEX IX_View12_City ON dbo.MyView
+(	
+    City
+)
+WITH (DATA_COMPRESSION = PAGE)

--- a/test/Microsoft.Health.SqlServer.Web/Features/Schema/Model/VLatest.Generated.cs
+++ b/test/Microsoft.Health.SqlServer.Web/Features/Schema/Model/VLatest.Generated.cs
@@ -13,8 +13,44 @@ namespace Microsoft.Health.SqlServer.Web.Features.Schema.Model
 
     internal class VLatest
     {
+        internal readonly static MyViewView MyView = new MyViewView();
+        internal readonly static Table1Table Table1 = new Table1Table();
+        internal readonly static Table2Table Table2 = new Table2Table();
         internal readonly static InsertNumbersProcedure InsertNumbers = new InsertNumbersProcedure();
         internal readonly static MyProcedureProcedure MyProcedure = new MyProcedureProcedure();
+
+        internal class MyViewView : Table
+        {
+            internal MyViewView() : base("dbo.MyView")
+            {
+            }
+
+            internal readonly IntColumn Id = new IntColumn("Id");
+            internal readonly NVarCharColumn Name = new NVarCharColumn("Name", 20);
+            internal readonly NVarCharColumn TheCity = new NVarCharColumn("TheCity", 20);
+            internal readonly Index IXC_View12 = new Index("IXC_View12");
+            internal readonly Index IX_View12_City = new Index("IX_View12_City");
+        }
+
+        internal class Table1Table : Table
+        {
+            internal Table1Table() : base("dbo.Table1")
+            {
+            }
+
+            internal readonly IntColumn Id = new IntColumn("Id");
+            internal readonly NVarCharColumn Name = new NVarCharColumn("Name", 20);
+        }
+
+        internal class Table2Table : Table
+        {
+            internal Table2Table() : base("dbo.Table2")
+            {
+            }
+
+            internal readonly IntColumn Id = new IntColumn("Id");
+            internal readonly NVarCharColumn City = new NVarCharColumn("City", 20);
+        }
 
         internal class InsertNumbersProcedure : StoredProcedure
         {

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/CreateTableTypeVisitor.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/CreateTableTypeVisitor.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
                                                 Literal(schemaQualifiedTableTypeName))),
                                     }))))
                             .WithBody(Block()))
-                    .AddMembers(node.Definition.ColumnDefinitions.Select(CreatePropertyForColumn).ToArray())
+                    .AddMembers(node.Definition.ColumnDefinitions.Select(CreatePropertyForTableColumn).ToArray())
 
                     // Add Columns property override
                     .AddMembers(

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/CreateTableVisitor.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/CreateTableVisitor.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
 
             // find the class we generated for the table
             var tableDeclaration = (ClassDeclarationSyntax)MembersToAdd.FirstOrDefault(m => m is ClassDeclarationSyntax c && c.Identifier.ValueText == classNameForTable)
-                                   ?? throw new InvalidOperationException($"table not found");
+                                   ?? throw new InvalidOperationException($"Table '{classNameForTable}' was not found");
 
             // find the field we generated for the column
             var columnDeclaration = (FieldDeclarationSyntax)tableDeclaration.Members.FirstOrDefault(m => m is FieldDeclarationSyntax fd && fd.Declaration.Variables[0].Identifier.ValueText == tableColumnName)

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/CreateTableVisitor.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/CreateTableVisitor.cs
@@ -4,7 +4,9 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
@@ -13,7 +15,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
 {
     /// <summary>
-    /// Visits a SQL AST, created a class for each CREATE TABLE statement.
+    /// Visits a SQL AST and creates a class for each CREATE TABLE, CREATE VIEW, and CREATE INDEX statement.
     /// </summary>
     internal class CreateTableVisitor : SqlVisitor
     {
@@ -26,30 +28,8 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
             string className = GetClassNameForTable(tableName);
 
             ClassDeclarationSyntax classDeclarationSyntax =
-                ClassDeclaration(className)
-                    .WithModifiers(TokenList(Token(SyntaxKind.InternalKeyword)))
-                    .WithBaseList(
-                        BaseList(
-                            SingletonSeparatedList<BaseTypeSyntax>(
-                                SimpleBaseType(
-                                    IdentifierName("Table")))))
-                    .AddMembers(
-                        ConstructorDeclaration(
-                                Identifier(className))
-                            .WithModifiers(
-                                TokenList(
-                                    Token(SyntaxKind.InternalKeyword)))
-                            .WithInitializer(
-                                ConstructorInitializer(
-                                    SyntaxKind.BaseConstructorInitializer,
-                                    ArgumentList(
-                                        SingletonSeparatedList(
-                                            Argument(
-                                                LiteralExpression(
-                                                    SyntaxKind.StringLiteralExpression,
-                                                    Literal(schemaQualifiedTableName)))))))
-                            .WithBody(Block()))
-                    .AddMembers(node.Definition.ColumnDefinitions.Select(CreatePropertyForColumn).ToArray());
+                CreateSkeletalClass(className, schemaQualifiedTableName)
+                    .AddMembers(node.Definition.ColumnDefinitions.Select(CreatePropertyForTableColumn).ToArray());
 
             FieldDeclarationSyntax field = CreateStaticFieldForClass(className, tableName);
 
@@ -57,6 +37,140 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
             MembersToAdd.Add(classDeclarationSyntax.AddSortingKey(this, tableName));
 
             base.Visit(node);
+        }
+
+        private static ClassDeclarationSyntax CreateSkeletalClass(string className, string schemaQualifiedTableName)
+        {
+            return ClassDeclaration(className)
+                .WithModifiers(TokenList(Token(SyntaxKind.InternalKeyword)))
+                .WithBaseList(
+                    BaseList(
+                        SingletonSeparatedList<BaseTypeSyntax>(
+                            SimpleBaseType(
+                                IdentifierName("Table")))))
+                .AddMembers(
+                    ConstructorDeclaration(
+                            Identifier(className))
+                        .WithModifiers(
+                            TokenList(
+                                Token(SyntaxKind.InternalKeyword)))
+                        .WithInitializer(
+                            ConstructorInitializer(
+                                SyntaxKind.BaseConstructorInitializer,
+                                ArgumentList(
+                                    SingletonSeparatedList(
+                                        Argument(
+                                            LiteralExpression(
+                                                SyntaxKind.StringLiteralExpression,
+                                                Literal(schemaQualifiedTableName)))))))
+                        .WithBody(Block()));
+        }
+
+        public override void Visit(CreateViewStatement node)
+        {
+            // Determining the column types of a view is a bit more involved.
+            // We need to determine which tables are being queried and look up the
+            // columns that the query references.
+
+            // This is a basic implementation that can be enhanced as needed to accomodate more scenarios.
+            // It assumes that any table referenced in the view are declared before the view.
+
+            string viewName = node.SchemaObjectName.BaseIdentifier.Value;
+            string schemaQualifiedViewName = $"{node.SchemaObjectName.SchemaIdentifier.Value}.{viewName}";
+            string className = GetClassNameForView(viewName);
+
+            var querySpecification = (QuerySpecification)node.SelectStatement.QueryExpression;
+            IList<SelectElement> selectElements = querySpecification.SelectElements;
+
+            List<(string name, string alias)> tables =
+                querySpecification.FromClause.TableReferences
+                    .SelectMany(tr => tr switch
+                    {
+                        JoinTableReference @join => new[] { @join.FirstTableReference, @join.SecondTableReference },
+                        _ => new[] { tr },
+                    })
+                    .Select(tr => tr switch
+                    {
+                        NamedTableReference ntr => (ntr.SchemaObject.BaseIdentifier.Value, ntr.Alias.Value),
+                        _ => throw new NotSupportedException($"Unrecognized table type '{tr.GetType().Name}' in view.")
+                    }).ToList();
+
+            ClassDeclarationSyntax classDeclarationSyntax =
+                CreateSkeletalClass(className, schemaQualifiedViewName)
+                    .AddMembers(selectElements.Select(selectElement => CreatePropertyForViewColumn(selectElement, tables)).ToArray());
+
+            FieldDeclarationSyntax field = CreateStaticFieldForClass(className, viewName);
+
+            MembersToAdd.Add(field.AddSortingKey(this, viewName));
+            MembersToAdd.Add(classDeclarationSyntax.AddSortingKey(this, viewName));
+
+            base.Visit(node);
+        }
+
+        private IEnumerable<(string name, string alias)> GetTablesReferencedInView(IList<TableReference> tableReferences)
+        {
+            return tableReferences
+                .SelectMany(tr => tr switch
+                {
+                    JoinTableReference join => new[] { join.FirstTableReference, join.SecondTableReference },
+                    _ => new[] { tr },
+                })
+                .Select(tr => tr switch
+                {
+                    NamedTableReference ntr => (ntr.SchemaObject.BaseIdentifier.Value, ntr.Alias.Value),
+                    _ => throw new NotSupportedException($"Unrecognized table type '{tr.GetType().Name}' in view.")
+                });
+        }
+
+        private MemberDeclarationSyntax CreatePropertyForViewColumn(SelectElement selectElement, List<(string name, string alias)> tablesInScope)
+        {
+            if (selectElement is not SelectScalarExpression exp)
+            {
+                // notably SELECT * is not supported
+                throw new NotSupportedException($"Select element {selectElement.GetType().Name} is not supported");
+            }
+
+            if (exp.Expression is not ColumnReferenceExpression columnReference)
+            {
+                throw new NotSupportedException($"{exp.Expression.GetType().Name} is not supported.");
+            }
+
+            if (columnReference.MultiPartIdentifier.Count != 2)
+            {
+                throw new NotSupportedException("Please qualify column references with the table's alias");
+            }
+
+            string tableAliasName = columnReference.MultiPartIdentifier[0].Value;
+            string tableColumnName = columnReference.MultiPartIdentifier[1].Value;
+
+            string tableName = tablesInScope.Where(t => t.alias == tableAliasName).Select(t => t.name).FirstOrDefault() ?? throw new InvalidOperationException($"Unable to resolve table alias '{tableAliasName}'.");
+
+            string classNameForTable = GetClassNameForTable(tableName);
+
+            // find the class we generated for the table
+            var tableDeclaration = (ClassDeclarationSyntax)MembersToAdd.FirstOrDefault(m => m is ClassDeclarationSyntax c && c.Identifier.ValueText == classNameForTable)
+                                   ?? throw new InvalidOperationException($"table not found");
+
+            // find the field we generated for the column
+            var columnDeclaration = (FieldDeclarationSyntax)tableDeclaration.Members.FirstOrDefault(m => m is FieldDeclarationSyntax fd && fd.Declaration.Variables[0].Identifier.ValueText == tableColumnName)
+                                    ?? throw new InvalidOperationException($"Unable to find member for column '{tableColumnName}'");
+
+            if (exp.ColumnName == null)
+            {
+                // we can reuse the same declaration for the view.
+                return columnDeclaration;
+            }
+
+            // In this scenario, we have a SELECT t.MyCol AS Abc. We need to change the column from "MyCol" to "Abc"
+
+            return columnDeclaration.ReplaceNodes(
+                columnDeclaration.DescendantNodes(),
+                (original, updated) => original switch
+                {
+                    VariableDeclaratorSyntax v when v.Identifier.ValueText == tableColumnName => ((VariableDeclaratorSyntax)updated).WithIdentifier(Identifier(exp.ColumnName.Value)),
+                    LiteralExpressionSyntax l when l.Token.ValueText == tableColumnName => ((LiteralExpressionSyntax)updated).Update(Literal(exp.ColumnName.Value)),
+                    _ => updated,
+                });
         }
 
         public override void Visit(CreateIndexStatement node)
@@ -79,8 +193,9 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
                     .AddModifiers(Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.ReadOnlyKeyword));
 
             string tableClassName = GetClassNameForTable(node.OnName.BaseIdentifier.Value);
+            string viewClassName = GetClassNameForView(node.OnName.BaseIdentifier.Value);
 
-            var memberIndex = MembersToAdd.FindIndex(m => m is ClassDeclarationSyntax c && c.Identifier.ValueText == tableClassName);
+            var memberIndex = MembersToAdd.FindIndex(m => m is ClassDeclarationSyntax c && (c.Identifier.ValueText == tableClassName || c.Identifier.ValueText == viewClassName));
 
             if (memberIndex < 0)
             {
@@ -93,5 +208,7 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
         }
 
         private static string GetClassNameForTable(string tableName) => $"{tableName}Table";
+
+        private static string GetClassNameForView(string viewName) => $"{viewName}View";
     }
 }

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/CreateTableVisitor.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/CreateTableVisitor.cs
@@ -107,21 +107,6 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
             base.Visit(node);
         }
 
-        private IEnumerable<(string name, string alias)> GetTablesReferencedInView(IList<TableReference> tableReferences)
-        {
-            return tableReferences
-                .SelectMany(tr => tr switch
-                {
-                    JoinTableReference join => new[] { join.FirstTableReference, join.SecondTableReference },
-                    _ => new[] { tr },
-                })
-                .Select(tr => tr switch
-                {
-                    NamedTableReference ntr => (ntr.SchemaObject.BaseIdentifier.Value, ntr.Alias.Value),
-                    _ => throw new NotSupportedException($"Unrecognized table type '{tr.GetType().Name}' in view.")
-                });
-        }
-
         private MemberDeclarationSyntax CreatePropertyForViewColumn(SelectElement selectElement, List<(string name, string alias)> tablesInScope)
         {
             if (selectElement is not SelectScalarExpression exp)

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/SqlVisitor.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/SqlVisitor.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
             return Regex.Replace(objectName.BaseIdentifier.Value, @"_\d+$", string.Empty);
         }
 
-        protected MemberDeclarationSyntax CreatePropertyForColumn(ColumnDefinition column)
+        protected MemberDeclarationSyntax CreatePropertyForTableColumn(ColumnDefinition column)
         {
             string normalizedSqlDbType = null;
 


### PR DESCRIPTION
## Description
Support generating code for `CREATE VIEW` statements, like we do today for `CREATE TABLE` statements. View declarations require a little more work to determine the schema. We need to walk the definition and figure out the type of each column in the select statement based on the existing tables.

## Testing
I added a sample view to the sample web project.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch
