### PR TITLE
Rethrow SchemaManagerExceptions and InvalidOperationExceptions in SqlSchemaManager::ApplySchema

### DIFF
--- a/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
+++ b/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
@@ -127,7 +127,7 @@ namespace SchemaManager.Core.UnitTests
             _client.GetAvailabilityAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new List<AvailableVersion> { new AvailableVersion(1, "_script/1.sql", "_script/1.diff.sql"), new AvailableVersion(2, "_script/2.sql", "_script/2.diff.sql") });
             _client.GetCompatibilityAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new CompatibleVersion(1, 2));
             _client.GetDiffScriptAsync(Arg.Is<Uri>(new Uri("_script/2.diff.sql", UriKind.Relative)), Arg.Any<CancellationToken>()).Returns("script");
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _sqlSchemaManager.ApplySchema("connectionString", new Uri("https://localhost/"), new MutuallyExclusiveType { Latest = false, Version = 2, Next = false }));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _sqlSchemaManager.ApplySchema("connectionString", new Uri("https://localhost/"), new MutuallyExclusiveType { Latest = false, Version = 2, Next = false }));
         }
     }
 }


### PR DESCRIPTION
## Description
Rethrow SchemaManagerExceptions and InvalidOperationExceptions in SqlSchemaManager::ApplySchema to prevent false successes in integrated/managed environments.

## Related issues
DevOps bug #81336 - "Service Fabric Schema Job reports success even when it fails"

## Testing
- Added unit tests
- Validated schema upgrade failure detected in managed/integrated environments.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Skip
