### PR TITLE
Execute idempotent schema upgrades without transaction

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
     public interface ISchemaManagerDataStore
     {
         /// <summary>
-        /// Execute the script and status update of the given version in SchemaVersion table under a transaction
+        /// Execute the Sql script in a transaction
         /// </summary>
         /// <param name="script">The script to execute</param>
         /// <param name="version">The version to update its status</param>
@@ -19,7 +19,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
         Task ExecuteScriptAndCompleteSchemaVersionTransactionAsync(string script, int version, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Execute the script and status update of the given version in SchemaVersion table in a transaction
+        /// Execute the Sql script
         /// </summary>
         /// <param name="script">The script to execute</param>
         /// <param name="version">The version to update its status</param>

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
@@ -16,6 +16,14 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
         /// <param name="script">The script to execute</param>
         /// <param name="version">The version to update its status</param>
         /// <param name="cancellationToken">A cancellation token</param>
+        Task ExecuteScriptAndCompleteSchemaVersionTransactionAsync(string script, int version, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Execute the script and status update of the given version in SchemaVersion table in a transaction
+        /// </summary>
+        /// <param name="script">The script to execute</param>
+        /// <param name="version">The version to update its status</param>
+        /// <param name="cancellationToken">A cancellation token</param>
         Task ExecuteScriptAndCompleteSchemaVersionAsync(string script, int version, CancellationToken cancellationToken);
 
         /// <summary>

--- a/tools/SchemaManager.Core/SqlSchemaManager.cs
+++ b/tools/SchemaManager.Core/SqlSchemaManager.cs
@@ -117,7 +117,7 @@ namespace SchemaManager.Core
                     _logger.LogInformation(string.Format(CultureInfo.InvariantCulture, Resources.SchemaMigrationStartedMessage, availableVersions.Last().Id));
 
                     string script = await GetScriptAsync(1, availableVersions.Last().ScriptUri, token).ConfigureAwait(false);
-                    await UpgradeSchemaAsync(availableVersions.Last().Id, script, token).ConfigureAwait(false);
+                    await InitializeSchemaAsync(availableVersions.Last().Id, script, token).ConfigureAwait(false);
                     return;
                 }
 
@@ -270,7 +270,7 @@ namespace SchemaManager.Core
             return await _schemaClient.GetDiffScriptAsync(new Uri(diffUri, UriKind.Relative), cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task UpgradeSchemaAsync(int version, string script, CancellationToken cancellationToken)
+        private async Task InitializeSchemaAsync(int version, string script, CancellationToken cancellationToken)
         {
             // check if the record for given version exists in started or failed status
             await _schemaManagerDataStore.DeleteSchemaVersionAsync(version, SchemaVersionStatus.Failed.ToString(), cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Description
This PR updates the Sql schema upgrade scripts to execute without transaction. Because the transactions are blocking and the schema upgrade script are now idempotent, we can get the improved performance with this change. And if the schema upgrade script is failed halfway through, we will be able to re-run it.

## Related issues
Addresses [#AB81399](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=81399)

## Testing
Unit tests are added and tested manually.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
