### PR TITLE
Reverts making RetrySqlCommandWrapper and IPollyRetryLoggerFactory public

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Client/IPollyRetryLoggerFactory.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/IPollyRetryLoggerFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.SqlServer.Features.Client
     /// <summary>
     /// Provides functionality for creating a logger for the <see cref="Polly"/> retry policy.
     /// </summary>
-    public interface IPollyRetryLoggerFactory
+    internal interface IPollyRetryLoggerFactory
     {
         /// <summary>
         /// Creates a logger.

--- a/src/Microsoft.Health.SqlServer/Features/Client/RetrySqlCommandWrapper.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/RetrySqlCommandWrapper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.SqlServer.Features.Client
     /// <summary>
     /// A wrapper around <see cref="SqlCommand"/> to provide automatic retries for transient errors.
     /// </summary>
-    public class RetrySqlCommandWrapper : SqlCommandWrapper
+    internal class RetrySqlCommandWrapper : SqlCommandWrapper
     {
         private readonly SqlCommandWrapper _sqlCommandWrapper;
         private readonly IAsyncPolicy _retryPolicy;


### PR DESCRIPTION
## Description
This PR reverts the changes made in #197, since we no longer need retry logic to be accessible in the FHIR server (see closing comment [here](https://github.com/microsoft/fhir-server/pull/1811#issuecomment-821733971)).

## Related issues
Addresses [AB#81418](https://microsofthealth.visualstudio.com/Health/_workitems/edit/81418).

## Testing
All tests pass as before.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch
