### PR TITLE
Initiate schema upgrade notification after the current version is updated

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -89,12 +89,13 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                     for (int i = current + 1; i <= _schemaInformation.MaximumSupportedVersion; i++)
                     {
                         await _schemaUpgradeRunner.ApplySchemaAsync(version: i, applyFullSchemaSnapshot: false, cancellationToken).ConfigureAwait(false);
+
+                        // we need to ensure that the schema upgrade notification is sent after updating the _schemaInformation.Current for each upgraded version
+                        await GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
+
+                        await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, false);
                     }
                 }
-
-                await GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
-
-                await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, false);
             }
         }
 

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
@@ -7,11 +7,9 @@ using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
-using MediatR;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.SqlServer.Extensions;
-using Microsoft.Health.SqlServer.Features.Schema.Extensions;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 
 namespace Microsoft.Health.SqlServer.Features.Schema
@@ -20,7 +18,6 @@ namespace Microsoft.Health.SqlServer.Features.Schema
     {
         private readonly IScriptProvider _scriptProvider;
         private readonly IBaseScriptProvider _baseScriptProvider;
-        private readonly IMediator _mediator;
         private readonly ILogger<SchemaUpgradeRunner> _logger;
         private readonly ISqlConnectionFactory _sqlConnectionFactory;
         private ISchemaManagerDataStore _schemaManagerDataStore;
@@ -28,21 +25,18 @@ namespace Microsoft.Health.SqlServer.Features.Schema
         public SchemaUpgradeRunner(
             IScriptProvider scriptProvider,
             IBaseScriptProvider baseScriptProvider,
-            IMediator mediator,
             ILogger<SchemaUpgradeRunner> logger,
             ISqlConnectionFactory sqlConnectionFactory,
             ISchemaManagerDataStore schemaManagerDataStore)
         {
             EnsureArg.IsNotNull(scriptProvider, nameof(scriptProvider));
             EnsureArg.IsNotNull(baseScriptProvider, nameof(baseScriptProvider));
-            EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(logger, nameof(logger));
             EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));
             EnsureArg.IsNotNull(schemaManagerDataStore, nameof(schemaManagerDataStore));
 
             _scriptProvider = scriptProvider;
             _baseScriptProvider = baseScriptProvider;
-            _mediator = mediator;
             _logger = logger;
             _sqlConnectionFactory = sqlConnectionFactory;
             _schemaManagerDataStore = schemaManagerDataStore;
@@ -61,7 +55,6 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
             await CompleteSchemaVersionAsync(version, cancellationToken);
 
-            await _mediator.NotifySchemaUpgradedAsync(version, applyFullSchemaSnapshot);
             _logger.LogInformation("Completed applying schema {version}", version);
         }
 

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
@@ -5,7 +5,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
@@ -33,7 +32,7 @@ namespace Microsoft.Health.SqlServer.Tests.Integration.Features.Schema
             var connectionFactory = Substitute.For<ISqlConnectionFactory>();
             connectionFactory.GetSqlConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs((x) => GetSqlConnection());
             _schemaDataStore = new SchemaManagerDataStore(connectionFactory);
-            _runner = new SchemaUpgradeRunner(new ScriptProvider<SchemaVersion>(), new BaseScriptProvider(), Substitute.For<IMediator>(), NullLogger<SchemaUpgradeRunner>.Instance, connectionFactory, _schemaDataStore);
+            _runner = new SchemaUpgradeRunner(new ScriptProvider<SchemaVersion>(), new BaseScriptProvider(), NullLogger<SchemaUpgradeRunner>.Instance, connectionFactory, _schemaDataStore);
         }
 
         [Fact]


### PR DESCRIPTION
## Description
This PR updates the place to publish the schema upgrade notification. 
Prior to this change, the schema upgrade notification was published as soon as schema is initialized/upgraded but the SchemaInformation.current version was not updated to the upgraded schema version. So in the fhir service, when we listen to this schema upgrade notification, we did not get the latest current version.

Now, this PR publishes the notification once the schema is initialized/upgraded and SchemaInformation.current version is updated to the latest schema run.

## Related issues
Addresses [#AB81632](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=81632)

## Testing
Tested manually by updating the locally build nuget packages in the fhir server and covered scenarios-
1. Startup fhir-server for a new database with AutomaticUpdatesEnabled=true
2. Startup fhir-server for a new database with AutomaticUpdatesEnabled = false and ran tool to perform schema upgrade
3. Startup fhir-server with exisiting database

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
