### PR TITLE
Not throw exception when current schema version is greater than or equals to the target version

### DIFF
--- a/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
+++ b/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
@@ -147,5 +147,20 @@ namespace SchemaManager.Core.UnitTests
             _client.GetDiffScriptAsync(Arg.Is<Uri>(new Uri("_script/2.diff.sql", UriKind.Relative)), Arg.Any<CancellationToken>()).Returns("script");
             await Assert.ThrowsAsync<InvalidOperationException>(() => _sqlSchemaManager.ApplySchema("connectionString", new Uri("https://localhost/"), new MutuallyExclusiveType { Latest = false, Version = 2, Next = false }));
         }
+
+        [Fact]
+        public async Task ApplySchema_TargetVersionIsLessThanOrEqualsToTheTheCurrentSchemaVersion_ShouldNotThrowException()
+        {
+            _schemaManagerDataStore.GetCurrentSchemaVersionAsync(default).ReturnsForAnyArgs(Task.FromResult(2));
+            _client.GetCurrentVersionInformationAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new List<CurrentVersion> { new CurrentVersion(2, "completed", new List<string> { "2323" }) });
+            _client.GetAvailabilityAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new List<AvailableVersion> { new AvailableVersion(2, "_script/2.sql", "_script/2.diff.sql"), new AvailableVersion(3, "_script/3.sql", "_script/3.diff.sql") });
+            _client.GetCompatibilityAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new CompatibleVersion(1, 3));
+            _client.GetDiffScriptAsync(Arg.Is<Uri>(new Uri("_script/2.diff.sql", UriKind.Relative)), Arg.Any<CancellationToken>()).Returns("script");
+
+            await _sqlSchemaManager.ApplySchema("connectionString", new Uri("https://localhost/"), new MutuallyExclusiveType { Latest = false, Version = 2, Next = false });
+
+            await _schemaManagerDataStore.DidNotReceive().ExecuteScriptAndCompleteSchemaVersionTransactionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
+            await _schemaManagerDataStore.DidNotReceive().ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
+        }
     }
 }

--- a/tools/SchemaManager.Core/Resources.Designer.cs
+++ b/tools/SchemaManager.Core/Resources.Designer.cs
@@ -151,6 +151,15 @@ namespace SchemaManager.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The current schema version is already greater than or equals to the target schema version..
+        /// </summary>
+        internal static string TargetVersionLesserThanCurrentVersion {
+            get {
+                return ResourceManager.GetString("TargetVersionLesserThanCurrentVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The schema version &quot;{0}&quot; is not compatible..
         /// </summary>
         internal static string VersionIncompatibilityMessage {

--- a/tools/SchemaManager.Core/Resources.resx
+++ b/tools/SchemaManager.Core/Resources.resx
@@ -155,6 +155,9 @@
     <value>The specified schema version "{0}" is not available.</value>
     <comment>{0} is a version.</comment>
   </data>
+  <data name="TargetVersionLesserThanCurrentVersion" xml:space="preserve">
+    <value>The current schema version is already greater than or equals to the target schema version.</value>
+  </data>
   <data name="VersionIncompatibilityMessage" xml:space="preserve">
     <value>The schema version "{0}" is not compatible.</value>
     <comment>{0} is a version.</comment>

--- a/tools/SchemaManager.Core/SqlSchemaManager.cs
+++ b/tools/SchemaManager.Core/SqlSchemaManager.cs
@@ -99,6 +99,11 @@ namespace SchemaManager.Core
                 var targetVersion = type.Next == true ? availableVersions.First().Id :
                                                                  type.Latest == true ? availableVersions.Last().Id :
                                                                                                         type.Version;
+                if (availableVersions.First().Id > targetVersion)
+                {
+                    _logger.LogError(Resources.TargetVersionLesserThanCurrentVersion);
+                    return;
+                }
 
                 availableVersions = availableVersions.Where(availableVersion => availableVersion.Id <= targetVersion)
                     .ToList();


### PR DESCRIPTION
## Description
Fixes the code to not throw exception when current schema version >= target version. Rather just log the message and return success.

## Related issues
Addresses bug[#82066](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=82066)

## Testing
Unit test is added and tested manuall as well

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
