### PR TITLE
Not to wrap transaction explicitly for schema initialization scripts

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
@@ -11,14 +11,6 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
     public interface ISchemaManagerDataStore
     {
         /// <summary>
-        /// Execute the Sql script in a transaction
-        /// </summary>
-        /// <param name="script">The script to execute</param>
-        /// <param name="version">The version to update its status</param>
-        /// <param name="cancellationToken">A cancellation token</param>
-        Task ExecuteScriptAndCompleteSchemaVersionTransactionAsync(string script, int version, CancellationToken cancellationToken);
-
-        /// <summary>
         /// Execute the Sql script
         /// </summary>
         /// <param name="script">The script to execute</param>

--- a/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
+++ b/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
@@ -157,7 +157,6 @@ namespace SchemaManager.Core.UnitTests
 
             await _sqlSchemaManager.ApplySchema("connectionString", new Uri("https://localhost/"), new MutuallyExclusiveType { Latest = false, Version = 2, Next = false });
 
-            await _schemaManagerDataStore.DidNotReceive().ExecuteScriptAndCompleteSchemaVersionTransactionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
             await _schemaManagerDataStore.DidNotReceive().ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
         }
     }

--- a/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
+++ b/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
@@ -101,7 +101,6 @@ namespace SchemaManager.Core.UnitTests
             _client.GetCompatibilityAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new CompatibleVersion(1, 2));
             _client.GetDiffScriptAsync(Arg.Is<Uri>(new Uri("_script/2.diff.sql", UriKind.Relative)), Arg.Any<CancellationToken>()).Returns("script");
             await _sqlSchemaManager.ApplySchema("connectionString", new Uri("https://localhost/"), new MutuallyExclusiveType { Latest = false, Version = 2, Next = false });
-            await _schemaManagerDataStore.DidNotReceive().ExecuteScriptAndCompleteSchemaVersionTransactionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
             await _schemaManagerDataStore.Received(1).ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
         }
 
@@ -118,8 +117,7 @@ namespace SchemaManager.Core.UnitTests
 
             await _sqlSchemaManager.ApplySchema("connectionString", new Uri("https://localhost/"), new MutuallyExclusiveType { Version = 2 });
 
-            await _schemaManagerDataStore.Received(1).ExecuteScriptAndCompleteSchemaVersionTransactionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
-            await _schemaManagerDataStore.DidNotReceive().ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
+            await _schemaManagerDataStore.Received(1).ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
         }
 
         [Fact]

--- a/tools/SchemaManager.Core/SqlSchemaManager.cs
+++ b/tools/SchemaManager.Core/SqlSchemaManager.cs
@@ -117,7 +117,7 @@ namespace SchemaManager.Core
                     _logger.LogInformation(string.Format(CultureInfo.InvariantCulture, Resources.SchemaMigrationStartedMessage, availableVersions.Last().Id));
 
                     string script = await GetScriptAsync(1, availableVersions.Last().ScriptUri, token).ConfigureAwait(false);
-                    await InitializeSchemaAsync(availableVersions.Last().Id, script, token).ConfigureAwait(false);
+                    await UpgradeSchemaAsync(availableVersions.Last().Id, script, token).ConfigureAwait(false);
                     return;
                 }
 
@@ -142,7 +142,7 @@ namespace SchemaManager.Core
 
                     string script = await GetScriptAsync(executingVersion, availableVersion.ScriptUri, token, availableVersion.DiffUri).ConfigureAwait(false);
 
-                    await InitializeSchemaAsync(executingVersion, script, token).ConfigureAwait(false);
+                    await UpgradeSchemaAsync(executingVersion, script, token).ConfigureAwait(false);
                 }
             }
             catch (Exception ex) when (ex is SchemaManagerException || ex is InvalidOperationException)
@@ -265,7 +265,7 @@ namespace SchemaManager.Core
             return await _schemaClient.GetDiffScriptAsync(new Uri(diffUri, UriKind.Relative), cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task InitializeSchemaAsync(int version, string script, CancellationToken cancellationToken)
+        private async Task UpgradeSchemaAsync(int version, string script, CancellationToken cancellationToken)
         {
             // check if the record for given version exists in started or failed status
             await _schemaManagerDataStore.DeleteSchemaVersionAsync(version, SchemaVersionStatus.Failed.ToString(), cancellationToken).ConfigureAwait(false);

--- a/tools/SchemaManager.Core/SqlSchemaManager.cs
+++ b/tools/SchemaManager.Core/SqlSchemaManager.cs
@@ -142,12 +142,7 @@ namespace SchemaManager.Core
 
                     string script = await GetScriptAsync(executingVersion, availableVersion.ScriptUri, token, availableVersion.DiffUri).ConfigureAwait(false);
 
-                    // check if the record for given version exists in failed status
-                    await _schemaManagerDataStore.DeleteSchemaVersionAsync(executingVersion, SchemaVersionStatus.Failed.ToString(), token).ConfigureAwait(false);
-
-                    await _schemaManagerDataStore.ExecuteScriptAndCompleteSchemaVersionAsync(script, executingVersion, token).ConfigureAwait(false);
-
-                    _logger.LogInformation(string.Format(CultureInfo.InvariantCulture, Resources.SchemaMigrationSuccessMessage, executingVersion));
+                    await InitializeSchemaAsync(executingVersion, script, token).ConfigureAwait(false);
                 }
             }
             catch (Exception ex) when (ex is SchemaManagerException || ex is InvalidOperationException)
@@ -275,7 +270,7 @@ namespace SchemaManager.Core
             // check if the record for given version exists in started or failed status
             await _schemaManagerDataStore.DeleteSchemaVersionAsync(version, SchemaVersionStatus.Failed.ToString(), cancellationToken).ConfigureAwait(false);
 
-            await _schemaManagerDataStore.ExecuteScriptAndCompleteSchemaVersionTransactionAsync(script, version, cancellationToken).ConfigureAwait(false);
+            await _schemaManagerDataStore.ExecuteScriptAndCompleteSchemaVersionAsync(script, version, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(string.Format(CultureInfo.InvariantCulture, Resources.SchemaMigrationSuccessMessage, version));
         }

--- a/tools/SchemaManager.Core/SqlSchemaManager.cs
+++ b/tools/SchemaManager.Core/SqlSchemaManager.cs
@@ -122,7 +122,7 @@ namespace SchemaManager.Core
                     _logger.LogInformation(string.Format(CultureInfo.InvariantCulture, Resources.SchemaMigrationStartedMessage, availableVersions.Last().Id));
 
                     string script = await GetScriptAsync(1, availableVersions.Last().ScriptUri, token).ConfigureAwait(false);
-                    await UpgradeSchemaAsync(availableVersions.Last().Id, script, token).ConfigureAwait(false);
+                    await ApplySchemaInternalAsync(availableVersions.Last().Id, script, token).ConfigureAwait(false);
                     return;
                 }
 
@@ -147,7 +147,7 @@ namespace SchemaManager.Core
 
                     string script = await GetScriptAsync(executingVersion, availableVersion.ScriptUri, token, availableVersion.DiffUri).ConfigureAwait(false);
 
-                    await UpgradeSchemaAsync(executingVersion, script, token).ConfigureAwait(false);
+                    await ApplySchemaInternalAsync(executingVersion, script, token).ConfigureAwait(false);
                 }
             }
             catch (Exception ex) when (ex is SchemaManagerException || ex is InvalidOperationException)
@@ -270,7 +270,7 @@ namespace SchemaManager.Core
             return await _schemaClient.GetDiffScriptAsync(new Uri(diffUri, UriKind.Relative), cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task UpgradeSchemaAsync(int version, string script, CancellationToken cancellationToken)
+        private async Task ApplySchemaInternalAsync(int version, string script, CancellationToken cancellationToken)
         {
             // check if the record for given version exists in started or failed status
             await _schemaManagerDataStore.DeleteSchemaVersionAsync(version, SchemaVersionStatus.Failed.ToString(), cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Description
Since SQLServer schema initialization script could have non transactional script(i.e. which can't run in a transaction), so we don't want schema-manager to wrap initialization scripts in a transaction explicitly.
Instead, we would update the latest initialization scripts(x.sql) to include transaction in itself.

## Related issues
Addresses [#82137](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=82137)

## Testing
Unit tests are updated

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Breaking
