### PR TITLE
Adds a function in change feed for resource types

### DIFF
--- a/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
+++ b/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Abstractions.Data
         /// <param name="pageSize">Page Size of records to fetch.</param>
         /// <param name="cancellationToken">Cancellation Token.</param>
         /// <returns>IReadOnlyCollection of T.</returns>
-        Task<IReadOnlyCollection<T>> GetRecordsAsync(long startId, int pageSize, CancellationToken cancellationToken);
+        Task<IReadOnlyCollection<T>> GetRecordsAsync(long startId, short pageSize, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get resource types as a dictionary.

--- a/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
+++ b/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
@@ -23,5 +23,12 @@ namespace Microsoft.Health.Abstractions.Data
         /// <param name="cancellationToken">Cancellation Token.</param>
         /// <returns>IReadOnlyCollection of T.</returns>
         Task<IReadOnlyCollection<T>> GetRecordsAsync(long startId, int pageSize, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get resource types as a dictionary.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token.</param>
+        /// <returns>Returns a resource type map.</returns>
+        Task<IDictionary<short, string>> GetResourceTypeMapAsync(CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
## Description
Adding a function for getting resource types as a dictionary in an IChangeFeedSource interface for getting resource types.

## Related issues
Addresses [#83328](https://microsofthealth.visualstudio.com/Health/_workitems/edit/83328).

## Testing
Implemented the function locally and validated using an integration test. A test would be added to an integration test in the FHIR application.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
