### PR TITLE
Update SQL Server APIs

### DIFF
--- a/src/Microsoft.Health.SqlServer.Api/Schema/SchemaJobWorkerBackgroundService.cs
+++ b/src/Microsoft.Health.SqlServer.Api/Schema/SchemaJobWorkerBackgroundService.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema;
 
@@ -23,14 +24,14 @@ namespace Microsoft.Health.SqlServer.Api.Features.Schema
         private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
         private readonly SchemaInformation _schemaInformation;
 
-        public SchemaJobWorkerBackgroundService(SchemaJobWorker schemaJobWorker, SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration, SchemaInformation schemaInformation)
+        public SchemaJobWorkerBackgroundService(SchemaJobWorker schemaJobWorker, IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration, SchemaInformation schemaInformation)
         {
             EnsureArg.IsNotNull(schemaJobWorker, nameof(schemaJobWorker));
-            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
             EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
 
             _schemaJobWorker = schemaJobWorker;
-            _sqlServerDataStoreConfiguration = sqlServerDataStoreConfiguration;
+            _sqlServerDataStoreConfiguration = sqlServerDataStoreConfiguration.Value;
             _schemaInformation = schemaInformation;
 #if NET5_0_OR_GREATER
             _instanceName = Guid.NewGuid() + "-" + Environment.ProcessId;

--- a/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionStringProviderTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionStringProviderTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Xunit;
 
@@ -26,7 +27,7 @@ namespace Microsoft.Health.SqlServer.UnitTests.Features
         public async Task GivenValidSqlServerDataStoreConfiguration_GetSqlConnectionString_ReturnsConnectionString(string sqlConnectionString)
         {
             var sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration() { ConnectionString = sqlConnectionString };
-            ISqlConnectionStringProvider sqlConnectionStringProvider = new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration);
+            ISqlConnectionStringProvider sqlConnectionStringProvider = new DefaultSqlConnectionStringProvider(Options.Create(sqlServerDataStoreConfiguration));
 
             Assert.Equal(sqlConnectionString, await sqlConnectionStringProvider.GetSqlConnectionString(CancellationToken.None));
         }

--- a/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionTests.cs
@@ -5,6 +5,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Xunit;
 
@@ -25,7 +26,7 @@ namespace Microsoft.Health.SqlServer.UnitTests.Features
                 ConnectionString = $"server={ServerName};Initial Catalog={DatabaseName};Integrated Security=true",
             };
 
-            _sqlConnectionFactory = new DefaultSqlConnectionFactory(new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration));
+            _sqlConnectionFactory = new DefaultSqlConnectionFactory(new DefaultSqlConnectionStringProvider(Options.Create(sqlServerDataStoreConfiguration)));
         }
 
         [Fact]

--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Client/SqlServerTransientFaultRetryPolicyFactoryTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Client/SqlServerTransientFaultRetryPolicyFactoryTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Client;
 using NSubstitute;
@@ -43,7 +44,7 @@ namespace Microsoft.Health.SqlServer.UnitTests.Features.Client
             _pollyRetryLoggerFactory.Create().Returns(onRetryCapture);
 
             _sqlServerTransientFaultRetryPolicyFactory = new SqlServerTransientFaultRetryPolicyFactory(
-                _sqlServerDataStoreConfiguration,
+                Options.Create(_sqlServerDataStoreConfiguration),
                 _pollyRetryLoggerFactory);
 
             _asyncPolicy = _sqlServerTransientFaultRetryPolicyFactory.Create();

--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/SchemaJobWorkerTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/SchemaJobWorkerTests.cs
@@ -10,6 +10,7 @@ using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Control;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema;
@@ -44,7 +45,7 @@ namespace Microsoft.Health.SqlServer.UnitTests.Features.Schema
             _schemaDataStore.DeleteExpiredInstanceSchemaAsync(default).ReturnsForAnyArgs(Task.CompletedTask);
 
             _sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration { TerminateWhenSchemaVersionUpdatedTo = 2, SchemaOptions = new SqlServerSchemaOptions { JobPollingFrequencyInSeconds = 0 } };
-            _worker = new SchemaJobWorker(_serviceProvider, _sqlServerDataStoreConfiguration, _mediator, _processTerminator, _logger);
+            _worker = new SchemaJobWorker(_serviceProvider, Options.Create(_sqlServerDataStoreConfiguration), _mediator, _processTerminator, _logger);
         }
 
         [Fact]

--- a/src/Microsoft.Health.SqlServer.UnitTests/ManagedIdentitySqlConnectionTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/ManagedIdentitySqlConnectionTests.cs
@@ -5,6 +5,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using NSubstitute;
 using Xunit;
@@ -26,10 +27,14 @@ namespace Microsoft.Health.SqlServer.UnitTests
             var accessTokenHandler = Substitute.For<IAccessTokenHandler>();
             accessTokenHandler.GetAccessTokenAsync(AzureResource).Returns(Task.FromResult(TestAccessToken));
 
-            SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration();
-            sqlServerDataStoreConfiguration.ConnectionString = $"Server={ServerName};Database={DatabaseName};";
-            sqlServerDataStoreConfiguration.AuthenticationType = SqlServerAuthenticationType.ManagedIdentity;
-            _sqlConnectionFactory = new ManagedIdentitySqlConnectionFactory(new DefaultSqlConnectionStringProvider(sqlServerDataStoreConfiguration), accessTokenHandler);
+            SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration
+            {
+                ConnectionString = $"Server={ServerName};Database={DatabaseName};",
+                AuthenticationType = SqlServerAuthenticationType.ManagedIdentity,
+            };
+
+            _sqlConnectionFactory = new ManagedIdentitySqlConnectionFactory(
+                new DefaultSqlConnectionStringProvider(Options.Create(sqlServerDataStoreConfiguration)), accessTokenHandler);
         }
 
         [Fact]

--- a/src/Microsoft.Health.SqlServer.UnitTests/Microsoft.Health.SqlServer.UnitTests.csproj
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Microsoft.Health.SqlServer.UnitTests.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(SdkPackageVersion)" />

--- a/src/Microsoft.Health.SqlServer.UnitTests/Microsoft.Health.SqlServer.UnitTests.csproj
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Microsoft.Health.SqlServer.UnitTests.csproj
@@ -10,6 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Polly" Version="7.2.2" />

--- a/src/Microsoft.Health.SqlServer.UnitTests/Microsoft.Health.SqlServer.UnitTests.csproj
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Microsoft.Health.SqlServer.UnitTests.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(SdkPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />

--- a/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.SqlServer.UnitTests.Registration
             Assert.True(services.ContainsSingleton<IBaseScriptProvider, BaseScriptProvider>());
             Assert.True(services.ContainsSingleton<IHostedService, SchemaInitializer>());
             Assert.True(services.ContainsSingleton<IPollyRetryLoggerFactory, PollyRetryLoggerFactory>());
-            Assert.True(services.ContainsSingleton<ISchemaManagerDataStore, SchemaManagerDataStore>());
+            Assert.True(services.ContainsSingleton<ISchemaManagerDataStore>());
             Assert.True(services.ContainsSingleton<IScriptProvider, ScriptProvider<ExampleVersion>>());
             Assert.True(services.ContainsSingleton<ISqlConnectionFactory>());
             Assert.True(services.ContainsSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>());
@@ -79,19 +79,20 @@ namespace Microsoft.Health.SqlServer.UnitTests.Registration
             Assert.True(services.ContainsSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>());
             Assert.True(services.ContainsSingleton<ISqlServerTransientFaultRetryPolicyFactory, SqlServerTransientFaultRetryPolicyFactory>());
             Assert.True(services.ContainsSingleton<SqlCommandWrapperFactory, RetrySqlCommandWrapperFactory>());
+            Assert.True(services.ContainsSingleton<IReadOnlySchemaManagerDataStore, SchemaManagerDataStore>());
         }
 
         [Fact]
-        public void GivenEmptyServiceCollection_WhenAddingSqlServerVersioningService_ThenAddNewServices()
+        public void GivenEmptyServiceCollection_WhenAddingSqlServerManagement_ThenAddNewServices()
         {
             var services = new ServiceCollection();
-            services.AddSqlServerVersioningService<ExampleVersion>();
+            services.AddSqlServerManagement<ExampleVersion>();
 
             Assert.True(services.ContainsScoped<ISchemaDataStore, SqlServerSchemaDataStore>());
 
             Assert.True(services.ContainsSingleton<IBaseScriptProvider, BaseScriptProvider>());
             Assert.True(services.ContainsSingleton<IHostedService, SchemaInitializer>());
-            Assert.True(services.ContainsSingleton<ISchemaManagerDataStore, SchemaManagerDataStore>());
+            Assert.True(services.ContainsSingleton<ISchemaManagerDataStore>());
             Assert.True(services.ContainsSingleton<IScriptProvider, ScriptProvider<ExampleVersion>>());
             Assert.True(services.ContainsSingleton<SchemaJobWorker>());
             Assert.True(services.ContainsSingleton<SchemaUpgradeRunner>());

--- a/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
@@ -1,0 +1,100 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Health.Abstractions.Features.Transactions;
+using Microsoft.Health.SqlServer.Configs;
+using Microsoft.Health.SqlServer.Features.Client;
+using Microsoft.Health.SqlServer.Features.Schema;
+using Microsoft.Health.SqlServer.Features.Schema.Manager;
+using Microsoft.Health.SqlServer.Features.Storage;
+using Microsoft.Health.SqlServer.Registration;
+using Xunit;
+
+namespace Microsoft.Health.SqlServer.UnitTests.Registration
+{
+    public class SqlServerBaseRegistrationExtensionsTests
+    {
+        private enum ExampleVersion
+        {
+            V0,
+            V1,
+        }
+
+        [Fact]
+        [Obsolete]
+        public void GivenEmptyServiceCollection_WhenAddingSqlServerBase_ThenAddNewServices()
+        {
+            var services = new ServiceCollection();
+            services.AddSqlServerBase<ExampleVersion>(null);
+
+            Assert.True(services.ContainsScoped<ISchemaDataStore, SqlServerSchemaDataStore>());
+            Assert.True(services.ContainsScoped<ITransactionHandler, SqlTransactionHandler>());
+            Assert.True(services.ContainsScoped<SqlConnectionWrapperFactory>());
+            Assert.True(services.ContainsScoped<SqlServerSchemaDataStore>());
+            Assert.True(services.ContainsScoped<SqlTransactionHandler>());
+
+            Assert.True(services.ContainsSingleton<AzureServiceTokenProvider>());
+            Assert.True(services.ContainsSingleton<BaseScriptProvider>());
+            Assert.True(services.ContainsSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>());
+            Assert.True(services.ContainsSingleton<IBaseScriptProvider, BaseScriptProvider>());
+            Assert.True(services.ContainsSingleton<IHostedService, SchemaInitializer>());
+            Assert.True(services.ContainsSingleton<IPollyRetryLoggerFactory, PollyRetryLoggerFactory>());
+            Assert.True(services.ContainsSingleton<ISchemaManagerDataStore, SchemaManagerDataStore>());
+            Assert.True(services.ContainsSingleton<IScriptProvider, ScriptProvider<ExampleVersion>>());
+            Assert.True(services.ContainsSingleton<ISqlConnectionFactory>());
+            Assert.True(services.ContainsSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>());
+            Assert.True(services.ContainsSingleton<ISqlServerTransientFaultRetryPolicyFactory, SqlServerTransientFaultRetryPolicyFactory>());
+            Assert.True(services.ContainsSingleton<PollyRetryLoggerFactory>());
+            Assert.True(services.ContainsSingleton<RetrySqlCommandWrapperFactory>());
+            Assert.True(services.ContainsSingleton<SchemaInitializer>());
+            Assert.True(services.ContainsSingleton<SchemaJobWorker>());
+            Assert.True(services.ContainsSingleton<SchemaUpgradeRunner>());
+            Assert.True(services.ContainsSingleton<SchemaManagerDataStore>());
+            Assert.True(services.ContainsSingleton<ScriptProvider<ExampleVersion>>());
+            Assert.True(services.ContainsSingleton<SqlCommandWrapperFactory, RetrySqlCommandWrapperFactory>());
+            Assert.True(services.ContainsSingleton<SqlServerDataStoreConfiguration>());
+            Assert.True(services.ContainsSingleton<SqlServerTransientFaultRetryPolicyFactory>());
+        }
+
+        [Fact]
+        public void GivenEmptyServiceCollection_WhenAddingSqlServerConnection_ThenAddNewServices()
+        {
+            var services = new ServiceCollection();
+            services.AddSqlServerConnection();
+
+            Assert.True(services.ContainsScoped<SqlConnectionWrapperFactory>());
+            Assert.True(services.ContainsScoped<SqlTransactionHandler>());
+            Assert.True(services.ContainsScoped<ITransactionHandler, SqlTransactionHandler>());
+
+            Assert.True(services.ContainsSingleton<AzureServiceTokenProvider>());
+            Assert.True(services.ContainsSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>());
+            Assert.True(services.ContainsSingleton<IPollyRetryLoggerFactory, PollyRetryLoggerFactory>());
+            Assert.True(services.ContainsSingleton<ISqlConnectionFactory>());
+            Assert.True(services.ContainsSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>());
+            Assert.True(services.ContainsSingleton<ISqlServerTransientFaultRetryPolicyFactory, SqlServerTransientFaultRetryPolicyFactory>());
+            Assert.True(services.ContainsSingleton<SqlCommandWrapperFactory, RetrySqlCommandWrapperFactory>());
+        }
+
+        [Fact]
+        public void GivenEmptyServiceCollection_WhenAddingSqlServerVersioningService_ThenAddNewServices()
+        {
+            var services = new ServiceCollection();
+            services.AddSqlServerVersioningService<ExampleVersion>();
+
+            Assert.True(services.ContainsScoped<ISchemaDataStore, SqlServerSchemaDataStore>());
+
+            Assert.True(services.ContainsSingleton<IBaseScriptProvider, BaseScriptProvider>());
+            Assert.True(services.ContainsSingleton<IHostedService, SchemaInitializer>());
+            Assert.True(services.ContainsSingleton<ISchemaManagerDataStore, SchemaManagerDataStore>());
+            Assert.True(services.ContainsSingleton<IScriptProvider, ScriptProvider<ExampleVersion>>());
+            Assert.True(services.ContainsSingleton<SchemaJobWorker>());
+            Assert.True(services.ContainsSingleton<SchemaUpgradeRunner>());
+        }
+    }
+}

--- a/src/Microsoft.Health.SqlServer.UnitTests/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/ServiceCollectionExtensions.cs
@@ -1,0 +1,58 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using EnsureThat;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Health.SqlServer.UnitTests
+{
+    internal static class ServiceCollectionExtensions
+    {
+        public static bool ContainsScoped<TService>(this IServiceCollection services)
+            => services.ContainsService<TService>(ServiceLifetime.Scoped);
+
+        public static bool ContainsScoped<TService, TImplementation>(this IServiceCollection services)
+            => services.ContainsService<TService, TImplementation>(ServiceLifetime.Scoped);
+
+        public static bool ContainsSingleton<TService>(this IServiceCollection services)
+            => services.ContainsService<TService>(ServiceLifetime.Singleton);
+
+        public static bool ContainsSingleton<TService, TImplementation>(this IServiceCollection services)
+            => services.ContainsService<TService, TImplementation>(ServiceLifetime.Singleton);
+
+        private static bool ContainsService<TService>(this IServiceCollection services, ServiceLifetime serviceLifetime)
+            => services.ContainsService<TService, TService>(serviceLifetime);
+
+        private static bool ContainsService<TService, TImplementation>(this IServiceCollection services, ServiceLifetime serviceLifetime)
+        {
+            EnsureArg.IsNotNull(services);
+
+            return services.Any(x =>
+                x.Lifetime == serviceLifetime &&
+                x.ServiceType == typeof(TService) &&
+                GetImplementationType(x) == typeof(TImplementation));
+        }
+
+        private static Type GetImplementationType(ServiceDescriptor descriptor)
+        {
+            if (descriptor.ImplementationType != null)
+            {
+                return descriptor.ImplementationType;
+            }
+            else if (descriptor.ImplementationInstance != null)
+            {
+                return descriptor.ImplementationInstance.GetType();
+            }
+            else
+            {
+                // ImplementationFactory is Func<IServiceProvider, object>, so we'll need to
+                // inspect the type of the value at runtime to get the real type (instead of object)
+                return descriptor.ImplementationFactory.GetType().GetGenericArguments()[1];
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -7,6 +7,14 @@ namespace Microsoft.Health.SqlServer.Configs
 {
     public class SqlServerDataStoreConfiguration
     {
+        /// <summary>
+        /// The default section name used in configurations.
+        /// </summary>
+        public const string SectionName = "SqlServer";
+
+        /// <summary>
+        /// The SQL Server connection string.
+        /// </summary>
         public string ConnectionString { get; set; }
 
         /// <summary>

--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
@@ -6,6 +6,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 
 namespace Microsoft.Health.SqlServer
@@ -17,9 +18,9 @@ namespace Microsoft.Health.SqlServer
     {
         private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
 
-        public DefaultSqlConnectionStringProvider(SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration)
+        public DefaultSqlConnectionStringProvider(IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration)
         {
-            _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+            _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlServerTransientFaultRetryPolicyFactory.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlServerTransientFaultRetryPolicyFactory.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Extensions;
 using Polly;
@@ -22,13 +23,13 @@ namespace Microsoft.Health.SqlServer.Features.Client
         private readonly IAsyncPolicy _retryPolicy;
 
         public SqlServerTransientFaultRetryPolicyFactory(
-            SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration,
+            IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
             IPollyRetryLoggerFactory pollyRetryLoggerFactory)
         {
-            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
             EnsureArg.IsNotNull(pollyRetryLoggerFactory, nameof(pollyRetryLoggerFactory));
 
-            SqlServerTransientFaultRetryPolicyConfiguration transientFaultRetryPolicyConfiguration = sqlServerDataStoreConfiguration.TransientFaultRetryPolicy;
+            SqlServerTransientFaultRetryPolicyConfiguration transientFaultRetryPolicyConfiguration = sqlServerDataStoreConfiguration.Value.TransientFaultRetryPolicy;
 
             IEnumerable<TimeSpan> sleepDurations = Backoff.ExponentialBackoff(
                 transientFaultRetryPolicyConfiguration.InitialDelay,

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/IReadOnlySchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/IReadOnlySchemaManagerDataStore.cs
@@ -1,0 +1,31 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.SqlServer.Features.Schema.Manager
+{
+    /// <summary>
+    /// Represents a read-only interface for querying versioning information
+    /// </summary>
+    public interface IReadOnlySchemaManagerDataStore
+    {
+        /// <summary>
+        /// Asynchronously retrieves the current application database version whose status indicates completion.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
+        /// </param>
+        /// <returns>
+        /// A task representing the <see cref="GetCurrentSchemaVersionAsync(CancellationToken)"/> operation.
+        /// The value of its <see cref="Task{TResult}.Result"/> property contains the numeric version identifier
+        /// for the latest completed version, if found; otherwise ><c>0</c>.
+        /// </returns>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        Task<int> GetCurrentSchemaVersionAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 {
-    public interface ISchemaManagerDataStore
+    public interface ISchemaManagerDataStore : IReadOnlySchemaManagerDataStore
     {
         /// <summary>
         /// Execute the Sql script
@@ -25,12 +25,6 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
         /// <param name="status">The schema status</param>
         /// <param name="cancellationToken">A cancellation token</param>
         Task DeleteSchemaVersionAsync(int version, string status, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Retreives the current schema version information
-        /// </summary>
-        /// <param name="cancellationToken">A cancellation token</param>
-        Task<int> GetCurrentSchemaVersionAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Executes the given script

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -14,6 +14,7 @@ using MediatR;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema.Extensions;
 
@@ -34,9 +35,9 @@ namespace Microsoft.Health.SqlServer.Features.Schema
         private readonly ISqlConnectionStringProvider _sqlConnectionStringProvider;
         private readonly IMediator _mediator;
 
-        public SchemaInitializer(SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration, SchemaUpgradeRunner schemaUpgradeRunner, SchemaInformation schemaInformation, ISqlConnectionFactory sqlConnectionFactory, ISqlConnectionStringProvider sqlConnectionStringProvider, IMediator mediator, ILogger<SchemaInitializer> logger)
+        public SchemaInitializer(IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration, SchemaUpgradeRunner schemaUpgradeRunner, SchemaInformation schemaInformation, ISqlConnectionFactory sqlConnectionFactory, ISqlConnectionStringProvider sqlConnectionStringProvider, IMediator mediator, ILogger<SchemaInitializer> logger)
         {
-            _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+            _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
             _schemaUpgradeRunner = EnsureArg.IsNotNull(schemaUpgradeRunner, nameof(schemaUpgradeRunner));
             _schemaInformation = EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
             _sqlConnectionFactory = EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema.Extensions;
+using Microsoft.Health.SqlServer.Features.Schema.Manager;
 
 namespace Microsoft.Health.SqlServer.Features.Schema
 {
@@ -28,6 +29,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
     {
         private const string MasterDatabase = "master";
         private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
+        private readonly IReadOnlySchemaManagerDataStore _schemaManagerDataStore;
         private readonly SchemaUpgradeRunner _schemaUpgradeRunner;
         private readonly SchemaInformation _schemaInformation;
         private readonly ILogger<SchemaInitializer> _logger;
@@ -35,9 +37,18 @@ namespace Microsoft.Health.SqlServer.Features.Schema
         private readonly ISqlConnectionStringProvider _sqlConnectionStringProvider;
         private readonly IMediator _mediator;
 
-        public SchemaInitializer(IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration, SchemaUpgradeRunner schemaUpgradeRunner, SchemaInformation schemaInformation, ISqlConnectionFactory sqlConnectionFactory, ISqlConnectionStringProvider sqlConnectionStringProvider, IMediator mediator, ILogger<SchemaInitializer> logger)
+        public SchemaInitializer(
+            IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
+            IReadOnlySchemaManagerDataStore schemaManagerDataStore,
+            SchemaUpgradeRunner schemaUpgradeRunner,
+            SchemaInformation schemaInformation,
+            ISqlConnectionFactory sqlConnectionFactory,
+            ISqlConnectionStringProvider sqlConnectionStringProvider,
+            IMediator mediator,
+            ILogger<SchemaInitializer> logger)
         {
             _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
+            _schemaManagerDataStore = EnsureArg.IsNotNull(schemaManagerDataStore, nameof(schemaManagerDataStore));
             _schemaUpgradeRunner = EnsureArg.IsNotNull(schemaUpgradeRunner, nameof(schemaUpgradeRunner));
             _schemaInformation = EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
             _sqlConnectionFactory = EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));
@@ -102,22 +113,14 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
         private async Task GetCurrentSchemaVersionAsync(CancellationToken cancellationToken)
         {
-            using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
-            const string tableName = "dbo.SchemaVersion";
-
-            // Since now the status is made consistent as 'completed', we might have to check for 'complete' as well for the previous version's status
-            using SqlCommand selectCommand = connection.CreateCommand();
-            selectCommand.CommandText = "SELECT MAX(Version) FROM " + tableName + " WHERE Status = 'complete' OR Status = 'completed'";
-
-            try
+            int version = await _schemaManagerDataStore.GetCurrentSchemaVersionAsync(cancellationToken);
+            if (version != 0)
             {
-                _schemaInformation.Current = await selectCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) as int?;
+                _schemaInformation.Current = version;
             }
-            catch (SqlException e) when (e.Message is "Invalid object name 'dbo.SchemaVersion'.")
+            else
             {
-                _logger.LogInformation($"The table {tableName} does not exists. It must be new database");
+                _logger.LogInformation("No version found. It must be new database");
             }
         }
 

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
@@ -10,6 +10,7 @@ using EnsureThat;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Core;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema.Extensions;
@@ -30,17 +31,17 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
         public SchemaJobWorker(
             IServiceProvider services,
-            SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration,
+            IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
             IMediator mediator,
             ILogger<SchemaJobWorker> logger)
         {
             EnsureArg.IsNotNull(services, nameof(services));
-            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _serviceProvider = services;
-            _sqlServerDataStoreConfiguration = sqlServerDataStoreConfiguration;
+            _sqlServerDataStoreConfiguration = sqlServerDataStoreConfiguration.Value;
             _mediator = mediator;
             _logger = logger;
         }

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Exceptions;
@@ -27,15 +28,15 @@ namespace Microsoft.Health.SqlServer.Features.Storage
 
         public SqlServerSchemaDataStore(
             SqlConnectionWrapperFactory sqlConnectionWrapperFactory,
-            SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration,
+            IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
             ILogger<SqlServerSchemaDataStore> logger)
         {
             EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
-            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _sqlConnectionWrapperFactory = sqlConnectionWrapperFactory;
-            _configuration = sqlServerDataStoreConfiguration;
+            _configuration = sqlServerDataStoreConfiguration.Value;
             _logger = logger;
         }
 

--- a/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
+++ b/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.46367.54" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.2" />

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -4,11 +4,15 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Linq;
+using EnsureThat;
 using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Abstractions.Features.Transactions;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema;
@@ -19,96 +23,119 @@ namespace Microsoft.Health.SqlServer.Registration
 {
     public static class SqlServerBaseRegistrationExtensions
     {
+        [Obsolete("Please use " + nameof(AddSqlServerConnection) + " and " + nameof(AddSqlServerVersioningService) + " instead.")]
         public static IServiceCollection AddSqlServerBase<TSchemaVersionEnum>(
             this IServiceCollection services,
             IConfiguration configurationRoot,
             Action<SqlServerDataStoreConfiguration> configureAction = null)
             where TSchemaVersionEnum : Enum
         {
-            var config = new SqlServerDataStoreConfiguration();
-            configurationRoot?.GetSection("SqlServer").Bind(config);
-
-            services.Add(provider =>
+            services.AddSqlServerConnection(
+                config =>
                 {
+                    configurationRoot?.GetSection(SqlServerDataStoreConfiguration.SectionName).Bind(config);
                     configureAction?.Invoke(config);
+                });
 
-                    return config;
-                })
-                .Singleton()
-                .AsSelf();
+            services.AddSqlServerVersioningService<TSchemaVersionEnum>();
 
-            services.Add<SchemaUpgradeRunner>()
-                .Singleton()
-                .AsSelf();
+            // Add more services for backward compatibility
+            services.TryAddScoped(p => p.GetRequiredService<ISchemaDataStore>() as SqlServerSchemaDataStore);
+            services.TryAddSingleton(provider => provider.GetRequiredService<IOptions<SqlServerDataStoreConfiguration>>().Value);
+            services.TryAddSingleton(p => p.GetServices<IHostedService>().First(x => x is SchemaInitializer) as SchemaInitializer);
+            services.TryAddSingleton(p => p.GetRequiredService<IScriptProvider>() as ScriptProvider<TSchemaVersionEnum>);
+            services.TryAddSingleton(p => p.GetRequiredService<IBaseScriptProvider>() as BaseScriptProvider);
+            services.TryAddSingleton(p => p.GetRequiredService<ISchemaManagerDataStore>() as SchemaManagerDataStore);
+            services.TryAddSingleton(p => p.GetRequiredService<IPollyRetryLoggerFactory>() as PollyRetryLoggerFactory);
+            services.TryAddSingleton(p => p.GetRequiredService<SqlCommandWrapperFactory>() as RetrySqlCommandWrapperFactory);
+            services.TryAddSingleton(p => p.GetRequiredService<ISqlServerTransientFaultRetryPolicyFactory>() as SqlServerTransientFaultRetryPolicyFactory);
 
-            services.Add<SqlServerSchemaDataStore>()
-                .Scoped()
-                .AsSelf()
-                .AsImplementedInterfaces();
+            return services;
+        }
 
-            services.Add<SchemaJobWorker>()
-                .Singleton()
-                .AsSelf();
+        /// <summary>
+        ///  Adds a collection of services for connecting to SQL Server to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to be updated.</param>
+        /// <returns>The <paramref name="services"/> for additional method invocations.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceCollection AddSqlServerConnection(this IServiceCollection services)
+        {
+            EnsureArg.IsNotNull(services, nameof(services));
 
-            services.Add<SchemaInitializer>()
-                .Singleton()
-                .AsSelf()
-                .AsService<IHostedService>();
+            services.AddOptions();
+            services.TryAddSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>();
+            services.TryAddSingleton<ISqlConnectionFactory>(
+                p =>
+                {
+                    SqlServerDataStoreConfiguration config = p.GetRequiredService<IOptions<SqlServerDataStoreConfiguration>>().Value;
+                    ISqlConnectionStringProvider sqlConnectionStringProvider = p.GetRequiredService<ISqlConnectionStringProvider>();
+                    return config.AuthenticationType == SqlServerAuthenticationType.ManagedIdentity
+                        ? new ManagedIdentitySqlConnectionFactory(sqlConnectionStringProvider, p.GetRequiredService<IAccessTokenHandler>())
+                        : new DefaultSqlConnectionFactory(sqlConnectionStringProvider);
+                });
 
-            services.Add<ScriptProvider<TSchemaVersionEnum>>()
-                .Singleton()
-                .AsSelf()
-                .AsImplementedInterfaces();
+            // The following are only used in case of managed identity
+            services.AddSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>();
+            services.AddSingleton<AzureServiceTokenProvider>();
 
-            services.Add<BaseScriptProvider>()
-               .Singleton()
-               .AsSelf()
-               .AsImplementedInterfaces();
+            // Services to facilitate SQL connections
+            // TODO: Does SqlTransactionHandler need to be registered directly? Should usage change to ITransactionHandler?
+            Func<IServiceProvider, SqlTransactionHandler> handlerFactory = p => p.GetRequiredService<SqlTransactionHandler>();
 
-            services.Add<SqlTransactionHandler>()
-                .Scoped()
-                .AsSelf()
-                .AsImplementedInterfaces();
+            services.TryAddScoped<SqlConnectionWrapperFactory>();
+            services.TryAddScoped<SqlTransactionHandler>();
+            services.TryAddScoped<ITransactionHandler>(handlerFactory);
+            services.TryAddSingleton<IPollyRetryLoggerFactory, PollyRetryLoggerFactory>();
+            services.TryAddSingleton<ISqlServerTransientFaultRetryPolicyFactory, SqlServerTransientFaultRetryPolicyFactory>();
+            services.TryAddSingleton<SqlCommandWrapperFactory, RetrySqlCommandWrapperFactory>();
 
-            services.Add<SchemaManagerDataStore>()
-                .Singleton()
-                .AsSelf()
-                .AsImplementedInterfaces();
+            return services;
+        }
 
-            services.Add<PollyRetryLoggerFactory>()
-                .Singleton()
-                .AsSelf()
-                .AsImplementedInterfaces();
+        /// <summary>
+        ///  Adds a collection of services for connecting to SQL Server to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to be updated.</param>
+        /// <param name="configure">A delegate for configuring the <see cref="SqlServerDataStoreConfiguration"/>.</param>
+        /// <returns>The <paramref name="services"/> for additional method invocations.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceCollection AddSqlServerConnection(
+            this IServiceCollection services,
+            Action<SqlServerDataStoreConfiguration> configure)
+        {
+            EnsureArg.IsNotNull(configure, nameof(configure));
 
-            services.Add<SqlServerTransientFaultRetryPolicyFactory>()
-                .Singleton()
-                .AsSelf()
-                .AsImplementedInterfaces();
+            return services
+                .AddSqlServerConnection()
+                .Configure(configure);
+        }
 
-            services.Add<RetrySqlCommandWrapperFactory>()
-                .Singleton()
-                .AsSelf()
-                .AsService<SqlCommandWrapperFactory>();
+        /// <summary>
+        ///  Adds a hosted service for updating the application's SQL database to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <typeparam name="TVersion">The type of the version enumeration.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> to be updated.</param>
+        /// <returns>The <paramref name="services"/> for additional method invocations.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceCollection AddSqlServerVersioningService<TVersion>(this IServiceCollection services)
+            where TVersion : Enum
+        {
+            EnsureArg.IsNotNull(services, nameof(services));
 
-            services.Add<SqlConnectionWrapperFactory>()
-                .Scoped()
-                .AsSelf()
-                .AsImplementedInterfaces();
-
-            services.AddSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>();
-
-            switch (config.AuthenticationType)
-            {
-                case SqlServerAuthenticationType.ManagedIdentity:
-                    services.AddSingleton<ISqlConnectionFactory, ManagedIdentitySqlConnectionFactory>();
-                    services.AddSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>();
-                    services.AddSingleton<AzureServiceTokenProvider>();
-                    break;
-                case SqlServerAuthenticationType.ConnectionString:
-                default:
-                    services.AddSingleton<ISqlConnectionFactory, DefaultSqlConnectionFactory>();
-                    break;
-            }
+            services.TryAddScoped<ISchemaDataStore, SqlServerSchemaDataStore>();
+            services.TryAddSingleton<SchemaJobWorker>();
+            services.TryAddSingleton<IScriptProvider, ScriptProvider<TVersion>>();
+            services.TryAddSingleton<IBaseScriptProvider, BaseScriptProvider>();
+            services.TryAddSingleton<ISchemaManagerDataStore, SchemaManagerDataStore>();
+            services.TryAddSingleton<SchemaUpgradeRunner>();
+            services.AddHostedService<SchemaInitializer>();
 
             return services;
         }

--- a/test/Microsoft.Health.SqlServer.Web/Startup.cs
+++ b/test/Microsoft.Health.SqlServer.Web/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.SqlServer.Api.Features;
 using Microsoft.Health.SqlServer.Api.Registration;
+using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Registration;
 using Microsoft.Health.SqlServer.Web.Features.Schema;
@@ -32,8 +33,10 @@ namespace Microsoft.Health.SqlServer.Web
                 .AddMvc(options => { options.EnableEndpointRouting = false; })
                 .AddNewtonsoftJson();
 
-            services.AddSqlServerBase<SchemaVersion>(Configuration);
-            services.AddSqlServerApi();
+            services
+                .AddSqlServerConnection(c => Configuration.GetSection(SqlServerDataStoreConfiguration.SectionName).Bind(c))
+                .AddSqlServerVersioningService<SchemaVersion>()
+                .AddSqlServerApi();
 
             services.AddMediatR(typeof(CompatibilityVersionHandler).Assembly);
 

--- a/test/Microsoft.Health.SqlServer.Web/Startup.cs
+++ b/test/Microsoft.Health.SqlServer.Web/Startup.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.SqlServer.Web
 
             services
                 .AddSqlServerConnection(c => Configuration.GetSection(SqlServerDataStoreConfiguration.SectionName).Bind(c))
-                .AddSqlServerVersioningService<SchemaVersion>()
+                .AddSqlServerManagement<SchemaVersion>()
                 .AddSqlServerApi();
 
             services.AddMediatR(typeof(CompatibilityVersionHandler).Assembly);

--- a/test/SchemaManager.Core.UnitTests/SchemaManager.Core.UnitTests.csproj
+++ b/test/SchemaManager.Core.UnitTests/SchemaManager.Core.UnitTests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
+++ b/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Exceptions;
@@ -36,7 +37,7 @@ namespace SchemaManager.Core.UnitTests
 
             _baseSchemaRunner.EnsureBaseSchemaExistsAsync(default).ReturnsForAnyArgs(Task.FromResult(true));
             _baseSchemaRunner.EnsureInstanceSchemaRecordExistsAsync(default).ReturnsForAnyArgs(Task.FromResult(true));
-            _sqlSchemaManager = new SqlSchemaManager(_configuration, _baseSchemaRunner, _schemaManagerDataStore, _client, NullLogger<SqlSchemaManager>.Instance);
+            _sqlSchemaManager = new SqlSchemaManager(Options.Create(_configuration), _baseSchemaRunner, _schemaManagerDataStore, _client, NullLogger<SqlSchemaManager>.Instance);
         }
 
         [Fact]

--- a/tools/SchemaManager.Core/SchemaManager.Core.csproj
+++ b/tools/SchemaManager.Core/SchemaManager.Core.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.46367.54" />
     <PackageReference Include="Polly" Version="7.2.2" />
   </ItemGroup>

--- a/tools/SchemaManager.Core/SqlSchemaManager.cs
+++ b/tools/SchemaManager.Core/SqlSchemaManager.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
@@ -36,13 +37,13 @@ namespace SchemaManager.Core
         private const int RetryAttempts = 3;
 
         public SqlSchemaManager(
-            SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration,
+            IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
             IBaseSchemaRunner baseSchemaRunner,
             ISchemaManagerDataStore schemaManagerDataStore,
             ISchemaClient schemaClient,
             ILogger<SqlSchemaManager> logger)
         {
-            _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+            _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
             _baseSchemaRunner = EnsureArg.IsNotNull(baseSchemaRunner, nameof(baseSchemaRunner));
             _schemaManagerDataStore = EnsureArg.IsNotNull(schemaManagerDataStore, nameof(schemaManagerDataStore));
             _schemaClient = EnsureArg.IsNotNull(schemaClient, nameof(schemaClient));

--- a/tools/SchemaManager/Program.cs
+++ b/tools/SchemaManager/Program.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.SqlServer;
-using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using SchemaManager.Core;
 
@@ -45,7 +44,7 @@ namespace SchemaManager
             services.AddCliCommands();
 
             // Add SqlServer services
-            services.AddSingleton<SqlServerDataStoreConfiguration>();
+            services.AddOptions();
             services.AddSingleton<ISqlConnectionFactory, DefaultSqlConnectionFactory>();
             services.AddSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>();
             services.AddSingleton<IBaseSchemaRunner, BaseSchemaRunner>();

--- a/tools/SchemaManager/SchemaManager.csproj
+++ b/tools/SchemaManager/SchemaManager.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19174.3" />
     <PackageReference Include="System.CommandLine.Rendering" Version="0.2.0-alpha.19174.3" />
   </ItemGroup>


### PR DESCRIPTION
## Description
- Refactor the APIs for registering SQL-related services in the service container
  - Separate APIs for registering resilient SQL connections and the hosted service for upgrading application databases
- Expose `IReadOnlySchemaManagerDataStore` for querying the database version without any of the management capabilities
- Refactor configuration use to leverage `IOptions` for better DI integration
- `Obsolete` the previous API

## Related issues
[AB#83291](https://microsofthealth.visualstudio.com/Health/_workitems/edit/83291)

## Testing
Run unit and e2e tests

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Feature
