### PR TITLE
Removed GetResourceTypeMapAsync function

### DIFF
--- a/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
+++ b/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Abstractions.Data
         /// <param name="pageSize">Page Size of records to fetch.</param>
         /// <param name="cancellationToken">Cancellation Token.</param>
         /// <returns>IReadOnlyCollection of T.</returns>
-        Task<IReadOnlyCollection<T>> GetRecordsAsync(long startId, int pageSize, CancellationToken cancellationToken);
+        Task<IReadOnlyCollection<T>> GetRecordsAsync(long startId, short pageSize, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get resource types as a dictionary.

--- a/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
+++ b/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Abstractions.Data
         /// <param name="pageSize">Page Size of records to fetch.</param>
         /// <param name="cancellationToken">Cancellation Token.</param>
         /// <returns>IReadOnlyCollection of T.</returns>
-        Task<IReadOnlyCollection<T>> GetRecordsAsync(long startId, short pageSize, CancellationToken cancellationToken);
+        Task<IReadOnlyCollection<T>> GetRecordsAsync(long startId, int pageSize, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get resource types as a dictionary.

--- a/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
+++ b/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
@@ -23,12 +23,5 @@ namespace Microsoft.Health.Abstractions.Data
         /// <param name="cancellationToken">Cancellation Token.</param>
         /// <returns>IReadOnlyCollection of T.</returns>
         Task<IReadOnlyCollection<T>> GetRecordsAsync(long startId, short pageSize, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Get resource types as a dictionary.
-        /// </summary>
-        /// <param name="cancellationToken">Cancellation Token.</param>
-        /// <returns>Returns a resource type map.</returns>
-        Task<IDictionary<short, string>> GetResourceTypeMapAsync(CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
## Description
Removed GetResourceTypeMapAsync function from IChangeFeedSource.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
