### PR TITLE
Add retries for httpRequestException on first request

### DIFF
--- a/tools/SchemaManager.Core/Resources.Designer.cs
+++ b/tools/SchemaManager.Core/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace SchemaManager.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Attempt {0} of {1} to wait for the server to get started..
+        /// </summary>
+        internal static string RetryHttpRequestException {
+            get {
+                return ResourceManager.GetString("RetryHttpRequestException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Schema migration is started for the version : {0}..
         /// </summary>
         internal static string SchemaMigrationStartedMessage {

--- a/tools/SchemaManager.Core/Resources.resx
+++ b/tools/SchemaManager.Core/Resources.resx
@@ -143,6 +143,10 @@
     <value>Attempt {0} of {1} to verify if all the instances are running the previous version.</value>
     <comment>(0) is retry attempt, {1} is total retries</comment>
   </data>
+  <data name="RetryHttpRequestException" xml:space="preserve">
+    <value>Attempt {0} of {1} to wait for the server to get started.</value>
+    <comment>(0) is retry attempt, {1} is total number of retries.</comment>
+  </data>
   <data name="SchemaMigrationStartedMessage" xml:space="preserve">
     <value>Schema migration is started for the version : {0}.</value>
     <comment>{0} is a version.</comment>

--- a/tools/SchemaManager.Core/SqlSchemaManager.cs
+++ b/tools/SchemaManager.Core/SqlSchemaManager.cs
@@ -80,7 +80,7 @@ namespace SchemaManager.Core
                     sleepDurationProvider: (retryCount) => TimeSpan.FromSeconds(10),
                     onRetry: (exception, retryCount) =>
                     {
-                        _logger.LogError(exception, string.Format(CultureInfo.InvariantCulture, Resources.RetryCurrentSchemaVersion, attemptCount++, retryCountForHttpRequestException));
+                        _logger.LogError(exception, string.Format(CultureInfo.InvariantCulture, Resources.RetryHttpRequestException, attemptCount++, retryCountForHttpRequestException));
                     })
                 .ExecuteAsync(token => GetAvailableSchema(server, token), token)
                 .ConfigureAwait(false);


### PR DESCRIPTION
## Description
This PR adds retries upto 3 mins to mitigate the scenarios where fhir/dicom service is not up and schema-manager starts making requests to the service.

## Related issues
Addresses [issue #].

## Testing
Manually tested

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
