### PR TITLE
Add uniqueidentifier Column Support

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -301,6 +301,25 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
         }
     }
 
+    public class UniqueIdentifierColumn : Column<Guid>
+    {
+        public UniqueIdentifierColumn(string name)
+            : base(name, SqlDbType.UniqueIdentifier, false)
+        {
+        }
+
+        public override Guid Read(SqlDataReader reader, int ordinal)
+        {
+            return reader.GetGuid(Metadata.Name, ordinal);
+        }
+
+        public override void Set(SqlDataRecord record, int ordinal, Guid value)
+        {
+            EnsureArg.IsNotNull(record, nameof(record));
+            record.SetGuid(ordinal, value);
+        }
+    }
+
     public class NullableIntColumn : Column<int?>
     {
         public NullableIntColumn(string name)
@@ -542,6 +561,33 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
             if (value.HasValue)
             {
                 record.SetByte(ordinal, value.Value);
+            }
+            else
+            {
+                record.SetDBNull(ordinal);
+            }
+        }
+    }
+
+    public class NullableUniqueIdentifierColumn : Column<Guid?>
+    {
+        public NullableUniqueIdentifierColumn(string name)
+            : base(name, SqlDbType.UniqueIdentifier, true)
+        {
+        }
+
+        public override Guid? Read(SqlDataReader reader, int ordinal)
+        {
+            return reader.IsDBNull(Metadata.Name, ordinal) ? default(Guid?) : reader.GetGuid(Metadata.Name, ordinal);
+        }
+
+        public override void Set(SqlDataRecord record, int ordinal, Guid? value)
+        {
+            EnsureArg.IsNotNull(record, nameof(record));
+
+            if (value.HasValue)
+            {
+                record.SetGuid(ordinal, value.Value);
             }
             else
             {


### PR DESCRIPTION
## Description
- Add `UniqueIdentifierColumn` and `NullableUniqueIdentifierColumn` to better support code-gen for `uniqueidentifier`

## Related issues
[AB#83611](https://microsofthealth.visualstudio.com/Health/_workitems/edit/83611)

## Testing
Pass unit tests

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Feature
