### PR TITLE
Allow specifying an app id for authenticating using MI to SQL server and Blob storage

### DIFF
--- a/src/Microsoft.Health.Blob/Configs/BlobDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobDataStoreConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Health.Blob.Configs
         public BlobDataStoreRequestOptions RequestOptions { get; } = new BlobDataStoreRequestOptions();
 
         /// <summary>
-        /// If set, the managed identity client ID of the user assigned managed identity to use when connecting to azure storage, if AuthenticationType == ManagedIdentity.
+        /// If set, the client id of the managed identity to use when connecting to azure storage, if AuthenticationType == ManagedIdentity.
         /// </summary>
         public string ManagedIdentityClientId { get; set; }
     }

--- a/src/Microsoft.Health.Blob/Configs/BlobDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobDataStoreConfiguration.cs
@@ -14,5 +14,10 @@ namespace Microsoft.Health.Blob.Configs
         public BlobDataStoreAuthenticationType AuthenticationType { get; set; } = BlobDataStoreAuthenticationType.ConnectionString;
 
         public BlobDataStoreRequestOptions RequestOptions { get; } = new BlobDataStoreRequestOptions();
+
+        /// <summary>
+        /// If set, the app ID of the user assigned managed identity to use when connecting to azure storage, if AUthenticationType == ManagedIdentity.
+        /// </summary>
+        public string UserAssignedManagedIdentityAppId { get; set; }
     }
 }

--- a/src/Microsoft.Health.Blob/Configs/BlobDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobDataStoreConfiguration.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Health.Blob.Configs
         public BlobDataStoreRequestOptions RequestOptions { get; } = new BlobDataStoreRequestOptions();
 
         /// <summary>
-        /// If set, the app ID of the user assigned managed identity to use when connecting to azure storage, if AUthenticationType == ManagedIdentity.
+        /// If set, the managed identity client ID of the user assigned managed identity to use when connecting to azure storage, if AuthenticationType == ManagedIdentity.
         /// </summary>
-        public string UserAssignedManagedIdentityAppId { get; set; }
+        public string ManagedIdentityClientId { get; set; }
     }
 }

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Health.Blob.Features.Storage
 
             if (configuration.AuthenticationType == BlobDataStoreAuthenticationType.ManagedIdentity)
             {
-                var defaultCredentials = new DefaultAzureCredential();
-                return new BlobServiceClient(new Uri(configuration.ConnectionString), defaultCredentials, blobClientOptions);
+                var managedIdentityCredential = new ManagedIdentityCredential(clientId: configuration.UserAssignedManagedIdentityAppId);
+                return new BlobServiceClient(new Uri(configuration.ConnectionString), managedIdentityCredential, blobClientOptions);
             }
 
             return new BlobServiceClient(configuration.ConnectionString, blobClientOptions);

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Blob.Features.Storage
 
             if (configuration.AuthenticationType == BlobDataStoreAuthenticationType.ManagedIdentity)
             {
-                var managedIdentityCredential = new ManagedIdentityCredential(clientId: configuration.UserAssignedManagedIdentityAppId);
+                var managedIdentityCredential = new ManagedIdentityCredential(clientId: configuration.ManagedIdentityClientId);
                 return new BlobServiceClient(new Uri(configuration.ConnectionString), managedIdentityCredential, blobClientOptions);
             }
 

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
@@ -26,8 +26,9 @@ namespace Microsoft.Health.Blob.Features.Storage
 
             if (configuration.AuthenticationType == BlobDataStoreAuthenticationType.ManagedIdentity)
             {
-                var managedIdentityCredential = new ManagedIdentityCredential(clientId: configuration.ManagedIdentityClientId);
-                return new BlobServiceClient(new Uri(configuration.ConnectionString), managedIdentityCredential, blobClientOptions);
+                DefaultAzureCredential credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = configuration.ManagedIdentityClientId });
+
+                return new BlobServiceClient(new Uri(configuration.ConnectionString), credential, blobClientOptions);
             }
 
             return new BlobServiceClient(configuration.ConnectionString, blobClientOptions);

--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -46,5 +46,10 @@ namespace Microsoft.Health.SqlServer.Configs
         /// If set, Instructs the service to terminate when its schema reaches the specified version.
         /// </summary>
         public int? TerminateWhenSchemaVersionUpdatedTo { get; set; }
+
+        /// <summary>
+        /// If set, the app ID of the user assigned managed identity to use when connecting to SQL, if AUthenticationType == ManagedIdentity.
+        /// </summary>
+        public string UserAssignedManagedIdentityAppId { get; set; }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Health.SqlServer.Configs
         public int? TerminateWhenSchemaVersionUpdatedTo { get; set; }
 
         /// <summary>
-        /// If set, the app ID of the user assigned managed identity to use when connecting to SQL, if AUthenticationType == ManagedIdentity.
+        /// If set, the client id of the managed identity to use when connecting to SQL, if AuthenticationType == ManagedIdentity.
         /// </summary>
-        public string UserAssignedManagedIdentityAppId { get; set; }
+        public string ManagedIdentityClientId { get; set; }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -81,7 +81,19 @@ namespace Microsoft.Health.SqlServer.Registration
 
             // The following are only used in case of managed identity
             services.AddSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>();
-            services.AddSingleton<AzureServiceTokenProvider>();
+            services.AddSingleton<AzureServiceTokenProvider>(p =>
+            {
+                SqlServerDataStoreConfiguration config = p.GetRequiredService<IOptions<SqlServerDataStoreConfiguration>>().Value;
+
+                string tokenProviderConnectionString = null;
+
+                if (!string.IsNullOrEmpty(config.UserAssignedManagedIdentityAppId))
+                {
+                    tokenProviderConnectionString = $"RunAs=App;AppId={config.UserAssignedManagedIdentityAppId}";
+                }
+
+                return new AzureServiceTokenProvider(connectionString: tokenProviderConnectionString);
+            });
 
             // Services to facilitate SQL connections
             // TODO: Does SqlTransactionHandler need to be registered directly? Should usage change to ITransactionHandler?

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -87,9 +87,9 @@ namespace Microsoft.Health.SqlServer.Registration
 
                 string tokenProviderConnectionString = null;
 
-                if (!string.IsNullOrEmpty(config.UserAssignedManagedIdentityAppId))
+                if (!string.IsNullOrEmpty(config.ManagedIdentityClientId))
                 {
-                    tokenProviderConnectionString = $"RunAs=App;AppId={config.UserAssignedManagedIdentityAppId}";
+                    tokenProviderConnectionString = $"RunAs=App;AppId={config.ManagedIdentityClientId}";
                 }
 
                 return new AzureServiceTokenProvider(connectionString: tokenProviderConnectionString);


### PR DESCRIPTION
## Description
Allow specifying an app id for authenticating using MI to SQL server and Blob storage

## Related issues
Addresses [issue #].

## Testing
Tested by deploying a personal DICOM oss instance