### PR TITLE
Update the Schema Status to lowercase to be consistent with the statu…

### DIFF
--- a/src/Microsoft.Health.SqlServer.Api.UnitTests/Features/CurrentVersionHandlerTests.cs
+++ b/src/Microsoft.Health.SqlServer.Api.UnitTests/Features/CurrentVersionHandlerTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Health.SqlServer.Api.UnitTests.Features
 
             Assert.Equal(mockCurrentVersions.Count, currentVersionsResponse.Count);
             Assert.Equal(1, currentVersionsResponse[0].Id);
-            Assert.Equal(SchemaVersionStatus.Completed, currentVersionsResponse[0].Status);
+            Assert.Equal(SchemaVersionStatus.completed, currentVersionsResponse[0].Status);
             Assert.Equal(2, currentVersionsResponse[0].Servers.Count);
         }
 

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -42,11 +42,11 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 
                 server.ConnectionContext.ExecuteNonQuery(script);
 
-                await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.Completed.ToString(), cancellationToken).ConfigureAwait(false);
+                await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
             {
-                await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.Failed.ToString(), cancellationToken).ConfigureAwait(false);
+                await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.failed.ToString(), cancellationToken).ConfigureAwait(false);
                 throw;
             }
         }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaVersionStatus.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaVersionStatus.cs
@@ -11,8 +11,16 @@ namespace Microsoft.Health.SqlServer.Features.Schema
     [JsonConverter(typeof(StringEnumConverter))]
     public enum SchemaVersionStatus
     {
-        Started,
-        Completed,
-        Failed,
+        // Note - Updating SchemaVersionStatus to lower case to be consistent with the statuses applied when schema AutomaticUpdates is set to true
+
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+        started,
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+        completed,
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+        failed,
+#pragma warning restore SA1300 // Element should begin with upper-case letter
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaVersionStatus.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaVersionStatus.cs
@@ -11,15 +11,11 @@ namespace Microsoft.Health.SqlServer.Features.Schema
     [JsonConverter(typeof(StringEnumConverter))]
     public enum SchemaVersionStatus
     {
-        // Note - Updating SchemaVersionStatus to lower case to be consistent with the statuses applied when schema AutomaticUpdates is set to true
+        // Note - Updating SchemaVersionStatus to lower case to be consistent with the statuses applied when SchemaOptions:AutomaticUpdatesEnabled is set to true
 
 #pragma warning disable SA1300 // Element should begin with upper-case letter
         started,
-#pragma warning restore SA1300 // Element should begin with upper-case letter
-#pragma warning disable SA1300 // Element should begin with upper-case letter
         completed,
-#pragma warning restore SA1300 // Element should begin with upper-case letter
-#pragma warning disable SA1300 // Element should begin with upper-case letter
         failed,
 #pragma warning restore SA1300 // Element should begin with upper-case letter
     }

--- a/tools/SchemaManager.Core/SqlSchemaManager.cs
+++ b/tools/SchemaManager.Core/SqlSchemaManager.cs
@@ -286,7 +286,7 @@ namespace SchemaManager.Core
         private async Task ApplySchemaInternalAsync(int version, string script, CancellationToken cancellationToken)
         {
             // check if the record for given version exists in started or failed status
-            await _schemaManagerDataStore.DeleteSchemaVersionAsync(version, SchemaVersionStatus.Failed.ToString(), cancellationToken).ConfigureAwait(false);
+            await _schemaManagerDataStore.DeleteSchemaVersionAsync(version, SchemaVersionStatus.failed.ToString(), cancellationToken).ConfigureAwait(false);
 
             await _schemaManagerDataStore.ExecuteScriptAndCompleteSchemaVersionAsync(script, version, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION

## Description
Update the Schema Status to lowercase to be consistent with the statuses applied when AutomaticUpdates is turned on

## Related issues
Addresses [issue [81910](https://microsofthealth.visualstudio.com/Health/_workitems/edit/81910)].

## Testing
Manual Testing

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
