### PR TITLE
Personal/apurvabhale/schema initialization migration schema version issue

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
@@ -15,8 +15,9 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
         /// </summary>
         /// <param name="script">The script to execute</param>
         /// <param name="version">The version to update its status</param>
+        /// <param name="applyFullSchemaSnapshot">A flag to know if its a full schema snapshot</param>
         /// <param name="cancellationToken">A cancellation token</param>
-        Task ExecuteScriptAndCompleteSchemaVersionAsync(string script, int version, CancellationToken cancellationToken);
+        Task ExecuteScriptAndCompleteSchemaVersionAsync(string script, int version, bool applyFullSchemaSnapshot, CancellationToken cancellationToken);
 
         /// <summary>
         /// Deletes the row for given version and status in the SchemaVersion table

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManagerDataStore.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
         /// </summary>
         /// <param name="script">The script to execute</param>
         /// <param name="version">The version to update its status</param>
-        /// <param name="applyFullSchemaSnapshot">A flag to know if its a full schema snapshot</param>
+        /// <param name="applyFullSchemaSnapshot">A flag to identify if the applying script is snapshot script or diff script</param>
         /// <param name="cancellationToken">A cancellation token</param>
         Task ExecuteScriptAndCompleteSchemaVersionAsync(string script, int version, bool applyFullSchemaSnapshot, CancellationToken cancellationToken);
 

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 
             try
             {
-                // FullSchemaSnapshot script Inserts into SchemaVersion table with stated status
+                // FullSchemaSnapshot script(x.sql) inserts 'started' status into the SchemaVersion table itself.
                 if (!applyFullSchemaSnapshot)
                 {
                     await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.started.ToString(), cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
             }
             catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
             {
+                _logger.LogError("Failed applying schema {version}", version);
                 await FailSchemaVersionAsync(version, cancellationToken);
                 throw;
             }

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
@@ -5,6 +5,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
@@ -47,8 +48,8 @@ namespace Microsoft.Health.SqlServer.Tests.Integration.Features.Schema
         public async Task ApplySchema_BaseSchemaDoesNotExist_Fails()
         {
             Assert.False(await _schemaDataStore.BaseSchemaExistsAsync(CancellationToken.None));
-            var outerException = await Assert.ThrowsAsync<ExecutionFailureException>(() => _runner.ApplySchemaAsync(1, true, CancellationToken.None));
-            Assert.Contains("Invalid object name 'dbo.SchemaVersion'", outerException.InnerException.Message);
+            var outerException = await Assert.ThrowsAsync<SqlException>(() => _runner.ApplySchemaAsync(1, true, CancellationToken.None));
+            Assert.Contains("Could not find stored procedure 'dbo.UpsertSchemaVersion'.", outerException.Message);
         }
 
         [Fact]

--- a/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
+++ b/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
@@ -102,7 +102,7 @@ namespace SchemaManager.Core.UnitTests
             _client.GetCompatibilityAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new CompatibleVersion(1, 2));
             _client.GetDiffScriptAsync(Arg.Is<Uri>(new Uri("_script/2.diff.sql", UriKind.Relative)), Arg.Any<CancellationToken>()).Returns("script");
             await _sqlSchemaManager.ApplySchema("connectionString", new Uri("https://localhost/"), new MutuallyExclusiveType { Latest = false, Version = 2, Next = false });
-            await _schemaManagerDataStore.Received(1).ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
+            await _schemaManagerDataStore.Received(1).ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Is(false), Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace SchemaManager.Core.UnitTests
 
             await _sqlSchemaManager.ApplySchema("connectionString", new Uri("https://localhost/"), new MutuallyExclusiveType { Version = 2 });
 
-            await _schemaManagerDataStore.Received(1).ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
+            await _schemaManagerDataStore.Received(1).ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Is(true), Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -158,7 +158,7 @@ namespace SchemaManager.Core.UnitTests
 
             await _sqlSchemaManager.ApplySchema("connectionString", new Uri("https://localhost/"), new MutuallyExclusiveType { Latest = false, Version = 2, Next = false });
 
-            await _schemaManagerDataStore.DidNotReceive().ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Any<CancellationToken>());
+            await _schemaManagerDataStore.DidNotReceive().ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Is(false), Arg.Any<CancellationToken>());
         }
     }
 }


### PR DESCRIPTION
## Description
Schema manager - SchemaVersion status fixes
Added 'failed' status when Schema Initialization/Upgrade fails for Fhir Server.
Added 'started' status into schemaVersion table for diff script

For Testing -
(For testing can add project reference of MicrosoftHelath.SqlServer and Microsoft.Health.SqlServer.Api to FHIR server
While debugging add breakpoints to -
1. SchemaManagerDataStore.cs (42) -> ExecuteScriptAndCompleteSchemaVersionAsync -> if (!applyFullSchemaSnapshot)
2. SchemaUpgradeRunner .cs(51 and 66)-> ApplySchemaAsync -> if (!applyFullSchemaSnapshot) & await FailSchemaVersionAsync)

Scenario A -
   1. Set the SchemaVersionConstants.Max to 15 in FHIR server
   2. Set "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true"
   3. To generate the error -> Update 15.sql to Insert the 'started' status in SchemaVersion table after end of the last transaction -> this will result into entry into SchemaVersion table with 'started' status and then will throw an error
   4. Now run the server
   5. In the DB you should see an entry with 'failed' status in SchemaVersion table

Scenario B -
   1. Set the SchemaVersionConstants.Max to 15 in FHIR server
   2. Set "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "false"
   3. Now run the server -> Schema will not be created
   4. Now run the tool from path -> ..\healthcare-shared-components\tools\SchemaManager\bin\Debug\netcoreapp3.1 to apply latest schema
   5. Since schema was not created, this will try to run fullSchema script ->15.sql (which already has 'started' status insert statement)
   6. SP which tries to Insert 'started' status should not execute in this case and tool should run without any issues
   7. Schema should be created with 15 - completed
   
Scenario C -
   1. Set the SchemaVersionConstants.Max to 13 in FHIR server
   2. Set "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true"
   3. Now run the server -> Schema should be created and you will see an entry in SchemaVersion table as 13 - completed
   4. stop the server and set Set the SchemaVersionConstants.Max to 15 in FHIR server
   5. Set "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "false"
   6. Now run the tool from path -> ..\healthcare-shared-components\tools\SchemaManager\bin\Debug\netcoreapp3.1 to apply latest schema
   7. Since schema for 13 already exists tool will try to run diff scripts for higher versions in this case v=14 and v=15
   8. Should insert an entry in SchemaVersion table with 14 - started via SP
   9. Then will run 14.diff.sql script -> once done mark it as completed
   10. Should insert an entry in SchemaVersion table with 15 - started via SP
   11. Then will run 15.diff.sql script -> once done mark it as completed
   12. You should see three entries in SchemaVersion table with status as completed for versions 13, 14 and 15

## Related issues
Addresses [[83917](https://microsofthealth.visualstudio.com/Health/_workitems/edit/83917)].

## Testing
Manual Testing

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
