### PR TITLE
Supporting optional CancellationToken parameters in blob storage library

### DIFF
--- a/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobClientReadWriteTestProviderTests.cs
+++ b/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobClientReadWriteTestProviderTests.cs
@@ -1,0 +1,55 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Threading;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Blob.Features.Storage;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Blob.UnitTests.Features.Storage
+{
+    public class BlobClientReadWriteTestProviderTests
+    {
+        private readonly NullLogger<BlobClientReadWriteTestProvider> _logger;
+        private readonly BlobServiceClient _blobClient;
+
+        public BlobClientReadWriteTestProviderTests()
+        {
+            _logger = new NullLogger<BlobClientReadWriteTestProvider>();
+
+            var blockBlobClient = Substitute.For<BlockBlobClient>();
+            blockBlobClient.UploadAsync(Arg.Any<MemoryStream>(), Arg.Any<BlobHttpHeaders>(), null, null, null, null, Arg.Any<CancellationToken>())
+                .Returns(x =>
+                {
+                    x.Arg<CancellationToken>().ThrowIfCancellationRequested();
+                    return Substitute.For<Response<BlobContentInfo>>();
+                });
+
+            var blobContainerClient1 = Substitute.For<BlobContainerClient>(new Uri("https://www.microsoft.com/"), new BlobClientOptions());
+            blobContainerClient1.GetBlockBlobClient(Arg.Any<string>()).Returns(blockBlobClient);
+
+            _blobClient = Substitute.For<BlobServiceClient>(new Uri("https://www.microsoft.com/"), null);
+            _blobClient.GetBlobContainerClient(Arg.Any<string>()).Returns(blobContainerClient1);
+        }
+
+        [Fact]
+        public async void GivenCancellation_WhenPerformingTest_ThenExceptionIsHandled()
+        {
+            var testProvider = new BlobClientReadWriteTestProvider(new IO.RecyclableMemoryStreamManager(), _logger);
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            var exception = await Record.ExceptionAsync(() => testProvider.PerformTestAsync(_blobClient, new Configs.BlobContainerConfiguration(), cancellationTokenSource.Token));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobClientReadWriteTestProviderTests.cs
+++ b/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobClientReadWriteTestProviderTests.cs
@@ -43,14 +43,13 @@ namespace Microsoft.Health.Blob.UnitTests.Features.Storage
         }
 
         [Fact]
-        public async void GivenCancellation_WhenPerformingTest_ThenExceptionIsHandled()
+        public async void GivenCancelation_WhenPerformingTest_ThenOperationCanceledExceptionIsThrown()
         {
             var testProvider = new BlobClientReadWriteTestProvider(new RecyclableMemoryStreamManager(), _logger);
             using var cancellationTokenSource = new CancellationTokenSource();
             cancellationTokenSource.Cancel();
 
-            var exception = await Record.ExceptionAsync(() => testProvider.PerformTestAsync(_blobClient, new Configs.BlobContainerConfiguration(), cancellationTokenSource.Token));
-            Assert.Null(exception);
+            await Assert.ThrowsAsync<OperationCanceledException>(() => testProvider.PerformTestAsync(_blobClient, new Configs.BlobContainerConfiguration(), cancellationTokenSource.Token));
         }
     }
 }

--- a/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobContainerInitializerTests.cs
+++ b/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobContainerInitializerTests.cs
@@ -1,0 +1,52 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Blob.Features.Storage;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Blob.UnitTests.Features.Storage
+{
+    public class BlobContainerInitializerTests
+    {
+        private const string TestContainerName1 = "testcontainer1";
+        private readonly NullLogger<BlobContainerInitializer> _logger;
+        private readonly BlobServiceClient _blobClient;
+
+        public BlobContainerInitializerTests()
+        {
+            _logger = new NullLogger<BlobContainerInitializer>();
+
+            var blobContainerClient1 = Substitute.For<BlobContainerClient>(new Uri("https://www.microsoft.com/"), new BlobClientOptions());
+            blobContainerClient1.CreateIfNotExistsAsync(cancellationToken: Arg.Any<CancellationToken>())
+                .Returns(x =>
+                {
+                    x.Arg<CancellationToken>().ThrowIfCancellationRequested();
+                    return Substitute.For<Task<Response<BlobContainerInfo>>>();
+                });
+
+            _blobClient = Substitute.For<BlobServiceClient>(new Uri("https://www.microsoft.com/"), null);
+            _blobClient.GetBlobContainerClient(TestContainerName1).Returns(blobContainerClient1);
+        }
+
+        [Fact]
+        public async void GivenCancellation_WhenInitializingContainer_ThenExceptionIsHandled()
+        {
+            var blobContainerInitializer = new BlobContainerInitializer(TestContainerName1, _logger);
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
+            cancellationTokenSource.Cancel();
+
+            var exception = await Record.ExceptionAsync(() => blobContainerInitializer.InitializeContainerAsync(_blobClient, cancellationTokenSource.Token));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobContainerInitializerTests.cs
+++ b/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobContainerInitializerTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Blob.UnitTests.Features.Storage
 {
     public class BlobContainerInitializerTests
     {
-        private const string TestContainerName1 = "testcontainer1";
+        private const string TestContainerName = "testcontainer1";
         private readonly NullLogger<BlobContainerInitializer> _logger;
         private readonly BlobServiceClient _blobClient;
 
@@ -26,8 +26,8 @@ namespace Microsoft.Health.Blob.UnitTests.Features.Storage
         {
             _logger = new NullLogger<BlobContainerInitializer>();
 
-            var blobContainerClient1 = Substitute.For<BlobContainerClient>(new Uri("https://www.microsoft.com/"), new BlobClientOptions());
-            blobContainerClient1.CreateIfNotExistsAsync(cancellationToken: Arg.Any<CancellationToken>())
+            var blobContainerClient = Substitute.For<BlobContainerClient>(new Uri("https://www.microsoft.com/"), new BlobClientOptions());
+            blobContainerClient.CreateIfNotExistsAsync(cancellationToken: Arg.Any<CancellationToken>())
                 .Returns(x =>
                 {
                     x.Arg<CancellationToken>().ThrowIfCancellationRequested();
@@ -35,14 +35,14 @@ namespace Microsoft.Health.Blob.UnitTests.Features.Storage
                 });
 
             _blobClient = Substitute.For<BlobServiceClient>(new Uri("https://www.microsoft.com/"), null);
-            _blobClient.GetBlobContainerClient(TestContainerName1).Returns(blobContainerClient1);
+            _blobClient.GetBlobContainerClient(TestContainerName).Returns(blobContainerClient);
         }
 
         [Fact]
         public async void GivenCancellation_WhenInitializingContainer_ThenExceptionIsHandled()
         {
-            var blobContainerInitializer = new BlobContainerInitializer(TestContainerName1, _logger);
-            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
+            var blobContainerInitializer = new BlobContainerInitializer(TestContainerName, _logger);
+            using var cancellationTokenSource = new CancellationTokenSource();
             cancellationTokenSource.Cancel();
 
             var exception = await Record.ExceptionAsync(() => blobContainerInitializer.InitializeContainerAsync(_blobClient, cancellationTokenSource.Token));

--- a/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobContainerInitializerTests.cs
+++ b/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobContainerInitializerTests.cs
@@ -39,14 +39,13 @@ namespace Microsoft.Health.Blob.UnitTests.Features.Storage
         }
 
         [Fact]
-        public async void GivenCancellation_WhenInitializingContainer_ThenExceptionIsHandled()
+        public async void GivenCancelation_WhenInitializingContainer_ThenOperationCanceledExceptionIsThrown()
         {
             var blobContainerInitializer = new BlobContainerInitializer(TestContainerName, _logger);
             using var cancellationTokenSource = new CancellationTokenSource();
             cancellationTokenSource.Cancel();
 
-            var exception = await Record.ExceptionAsync(() => blobContainerInitializer.InitializeContainerAsync(_blobClient, cancellationTokenSource.Token));
-            Assert.Null(exception);
+            await Assert.ThrowsAsync<OperationCanceledException>(() => blobContainerInitializer.InitializeContainerAsync(_blobClient, cancellationTokenSource.Token));
         }
     }
 }

--- a/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobHostedServiceTests.cs
+++ b/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobHostedServiceTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Blob.UnitTests.Features.Storage
         }
 
         [Fact]
-        public async void GivenCancellation_WhenStartingService_ThenInitializationIsCancelled()
+        public async void GivenCancelation_WhenStartingService_ThenOperationCanceledExceptionIsThrown()
         {
             var blobHostedService = new BlobHostedService(_blobInitializer, _options, NullLogger<BlobHostedService>.Instance, _collectionInitializers);
             using var cancellationTokenSource = new CancellationTokenSource();

--- a/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobHostedServiceTests.cs
+++ b/src/Microsoft.Health.Blob.UnitTests/Features/Storage/BlobHostedServiceTests.cs
@@ -1,0 +1,52 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Blob.Configs;
+using Microsoft.Health.Blob.Features.Storage;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Blob.UnitTests.Features.Storage
+{
+    public class BlobHostedServiceTests
+    {
+        private readonly IBlobInitializer _blobInitializer;
+        private readonly List<IBlobContainerInitializer> _collectionInitializers;
+
+        private readonly IOptions<BlobDataStoreConfiguration> _options;
+
+        public BlobHostedServiceTests()
+        {
+            _blobInitializer = Substitute.For<IBlobInitializer>();
+
+            _options = Substitute.For<IOptionsSnapshot<BlobDataStoreConfiguration>>();
+            _options.Value.Returns(new BlobDataStoreConfiguration());
+
+            _collectionInitializers = Substitute.For<List<IBlobContainerInitializer>>();
+        }
+
+        [Fact]
+        public async void GivenCancellation_WhenStartingService_ThenInitializationIsCancelled()
+        {
+            _blobInitializer.InitializeDataStoreAsync(Arg.Any<List<IBlobContainerInitializer>>(), Arg.Any<CancellationToken>())
+                .Returns(async x =>
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(1000));
+                    x.Arg<CancellationToken>().ThrowIfCancellationRequested();
+                });
+
+            var blobHostedService = new BlobHostedService(_blobInitializer, _options, NullLogger<BlobHostedService>.Instance, _collectionInitializers);
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => blobHostedService.StartAsync(cancellationTokenSource.Token));
+        }
+    }
+}

--- a/src/Microsoft.Health.Blob/Features/Health/BlobHealthCheck.cs
+++ b/src/Microsoft.Health.Blob/Features/Health/BlobHealthCheck.cs
@@ -16,6 +16,9 @@ using Microsoft.Health.Blob.Features.Storage;
 
 namespace Microsoft.Health.Blob.Features.Health
 {
+    /// <summary>
+    /// Performs health checks on blob storage.
+    /// </summary>
     public class BlobHealthCheck : IHealthCheck
     {
         private readonly BlobServiceClient _client;

--- a/src/Microsoft.Health.Blob/Features/Health/BlobHealthCheck.cs
+++ b/src/Microsoft.Health.Blob/Features/Health/BlobHealthCheck.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
@@ -55,18 +54,9 @@ namespace Microsoft.Health.Blob.Features.Health
 
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
-            try
-            {
-                await _testProvider.PerformTestAsync(_client, _blobContainerConfiguration, cancellationToken).ConfigureAwait(false);
-
-                return HealthCheckResult.Healthy("Successfully connected.");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to connect to the blob data store.");
-
-                return HealthCheckResult.Unhealthy("Failed to connect.");
-            }
+            _logger.LogInformation("Performing health check.");
+            await _testProvider.PerformTestAsync(_client, _blobContainerConfiguration, cancellationToken).ConfigureAwait(false);
+            return HealthCheckResult.Healthy("Successfully connected.");
         }
     }
 }

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobClientReadWriteTestProvider.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobClientReadWriteTestProvider.cs
@@ -16,6 +16,9 @@ using Microsoft.IO;
 
 namespace Microsoft.Health.Blob.Features.Storage
 {
+    /// <summary>
+    /// Verifies read and write operations on a blob storage container.
+    /// </summary>
     public class BlobClientReadWriteTestProvider : IBlobClientTestProvider
     {
         private const string TestBlobName = "_testblob_";
@@ -29,6 +32,7 @@ namespace Microsoft.Health.Blob.Features.Storage
             _recyclableMemoryStreamManager = recyclableMemoryStreamManager;
         }
 
+        /// <inheritdoc/>
         public async Task PerformTestAsync(BlobServiceClient client, BlobContainerConfiguration blobContainerConfiguration, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(client, nameof(client));

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobClientReadWriteTestProvider.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobClientReadWriteTestProvider.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -46,20 +45,13 @@ namespace Microsoft.Health.Blob.Features.Storage
             BlobContainerClient blobContainer = client.GetBlobContainerClient(blobContainerConfiguration.ContainerName);
             BlockBlobClient blob = blobContainer.GetBlockBlobClient(TestBlobName);
 
-            try
-            {
-                _logger.LogInformation("Reading and writing blob: {container}/{blob}", blobContainerConfiguration.ContainerName, TestBlobName);
-                using var content = new MemoryStream(Encoding.UTF8.GetBytes(TestBlobContent));
-                await blob.UploadAsync(
-                    content,
-                    new BlobHttpHeaders { ContentType = "text/plain" },
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-                await DownloadBlobContentAsync(blob, cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException ex)
-            {
-                _logger.LogCritical(ex, "Reading and writing cancelled for blob: {container}/{blob}", blobContainerConfiguration.ContainerName, TestBlobName);
-            }
+            _logger.LogInformation("Reading and writing blob: {container}/{blob}", blobContainerConfiguration.ContainerName, TestBlobName);
+            using var content = new MemoryStream(Encoding.UTF8.GetBytes(TestBlobContent));
+            await blob.UploadAsync(
+                content,
+                new BlobHttpHeaders { ContentType = "text/plain" },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            await DownloadBlobContentAsync(blob, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<byte[]> DownloadBlobContentAsync(BlockBlobClient blob, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobClientReadWriteTestProvider.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobClientReadWriteTestProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Blob.Features.Storage
             _recyclableMemoryStreamManager = recyclableMemoryStreamManager;
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public async Task PerformTestAsync(BlobServiceClient client, BlobContainerConfiguration blobContainerConfiguration, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(client, nameof(client));

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobContainerInitializer.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobContainerInitializer.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using EnsureThat;
@@ -10,6 +11,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Health.Blob.Features.Storage
 {
+    /// <summary>
+    /// Provides methods for initializing blob storage containers.
+    /// </summary>
     public class BlobContainerInitializer : IBlobContainerInitializer
     {
         private readonly string _containerName;
@@ -25,14 +29,14 @@ namespace Microsoft.Health.Blob.Features.Storage
         }
 
         /// <inheritdoc />
-        public async Task<BlobContainerClient> InitializeContainerAsync(BlobServiceClient client)
+        public async Task<BlobContainerClient> InitializeContainerAsync(BlobServiceClient client, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(client, nameof(client));
 
             BlobContainerClient container = client.GetBlobContainerClient(_containerName);
 
-            _logger.LogDebug("Creating blob container if not exits: {containerName}", _containerName);
-            await container.CreateIfNotExistsAsync();
+            _logger.LogDebug("Creating blob container if not exists: {containerName}", _containerName);
+            await container.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
 
             return container;
         }

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobContainerInitializer.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobContainerInitializer.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
@@ -37,15 +36,7 @@ namespace Microsoft.Health.Blob.Features.Storage
             BlobContainerClient container = client.GetBlobContainerClient(_containerName);
 
             _logger.LogDebug("Creating blob container if not exists: {containerName}", _containerName);
-
-            try
-            {
-                await container.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
-            }
-            catch (OperationCanceledException ex)
-            {
-                _logger.LogCritical(ex, "Blob container initialization cancelled: {containerName}", _containerName);
-            }
+            await container.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
 
             return container;
         }

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobContainerInitializer.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobContainerInitializer.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
@@ -36,7 +37,15 @@ namespace Microsoft.Health.Blob.Features.Storage
             BlobContainerClient container = client.GetBlobContainerClient(_containerName);
 
             _logger.LogDebug("Creating blob container if not exists: {containerName}", _containerName);
-            await container.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+
+            try
+            {
+                await container.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogCritical(ex, "Blob container initialization cancelled: {containerName}", _containerName);
+            }
 
             return container;
         }

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobHostedService.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobHostedService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Health.Blob.Features.Storage
 
             await timeoutPolicy
                    .WrapAsync(retryPolicy)
-                   .ExecuteAsync((token) => _blobInitializer.InitializeDataStoreAsync(_collectionInitializers), cancellationToken)
+                   .ExecuteAsync((token) => _blobInitializer.InitializeDataStoreAsync(_collectionInitializers, token), cancellationToken)
                    .ConfigureAwait(false);
 
             _logger.LogInformation("Blob containers initialized");

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobHostedService.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobHostedService.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Health.Blob.Features.Storage
             _collectionInitializers = collectionInitializers;
         }
 
+        /// <inheritdoc />
         public async Task StartAsync(CancellationToken cancellationToken)
         {
             var sleepTime = TimeSpan.FromSeconds(_blobDataStoreConfiguration.RequestOptions.InitialConnectWaitBeforeRetryInSeconds);
@@ -62,6 +63,7 @@ namespace Microsoft.Health.Blob.Features.Storage
             _logger.LogInformation("Blob containers initialized");
         }
 
+        /// <inheritdoc />
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 }

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobInitializer.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobInitializer.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using EnsureThat;
@@ -30,7 +31,7 @@ namespace Microsoft.Health.Blob.Features.Storage
         }
 
         /// <inheritdoc />
-        public async Task InitializeDataStoreAsync(IEnumerable<IBlobContainerInitializer> containerInitializers)
+        public async Task InitializeDataStoreAsync(IEnumerable<IBlobContainerInitializer> containerInitializers, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(containerInitializers, nameof(containerInitializers));
 
@@ -40,7 +41,7 @@ namespace Microsoft.Health.Blob.Features.Storage
 
                 foreach (IBlobContainerInitializer collectionInitializer in containerInitializers)
                 {
-                    await collectionInitializer.InitializeContainerAsync(_client);
+                    await collectionInitializer.InitializeContainerAsync(_client, cancellationToken);
                 }
 
                 _logger.LogInformation("Blob Storage and containers successfully initialized");
@@ -53,7 +54,7 @@ namespace Microsoft.Health.Blob.Features.Storage
         }
 
         /// <inheritdoc />
-        public async Task OpenBlobClientAsync(BlobContainerConfiguration blobContainerConfiguration)
+        public async Task OpenBlobClientAsync(BlobContainerConfiguration blobContainerConfiguration, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(blobContainerConfiguration, nameof(blobContainerConfiguration));
 
@@ -61,7 +62,7 @@ namespace Microsoft.Health.Blob.Features.Storage
 
             try
             {
-                await _testProvider.PerformTestAsync(_client, blobContainerConfiguration);
+                await _testProvider.PerformTestAsync(_client, blobContainerConfiguration, cancellationToken);
 
                 _logger.LogInformation("Established blob client connection to container {containerName}", blobContainerConfiguration.ContainerName);
             }

--- a/src/Microsoft.Health.Blob/Features/Storage/IBlobClientTestProvider.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/IBlobClientTestProvider.cs
@@ -10,8 +10,18 @@ using Microsoft.Health.Blob.Configs;
 
 namespace Microsoft.Health.Blob.Features.Storage
 {
+    /// <summary>
+    /// Provides methods for performing tests against blob storage.
+    /// </summary>
     public interface IBlobClientTestProvider
     {
+        /// <summary>
+        /// Performs a test against blob storage.
+        /// </summary>
+        /// <param name="client">Client to connect to blob storage.</param>
+        /// <param name="blobContainerConfiguration">Configuration specific to one container.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        /// <returns>A <see cref="Task"/>.</returns>
         Task PerformTestAsync(BlobServiceClient client, BlobContainerConfiguration blobContainerConfiguration, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Blob/Features/Storage/IBlobContainerInitializer.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/IBlobContainerInitializer.cs
@@ -3,13 +3,23 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 
 namespace Microsoft.Health.Blob.Features.Storage
 {
+    /// <summary>
+    /// Provides methods for initializing blob storage containers.
+    /// </summary>
     public interface IBlobContainerInitializer
     {
-        Task<BlobContainerClient> InitializeContainerAsync(BlobServiceClient client);
+        /// <summary>
+        /// Initializes a blob storage container.
+        /// </summary>
+        /// <param name="client">The blob storage client.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        /// <returns>A <see cref="Task"/>.</returns>
+        Task<BlobContainerClient> InitializeContainerAsync(BlobServiceClient client, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Blob/Features/Storage/IBlobInitializer.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/IBlobInitializer.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Blob.Configs;
 
@@ -15,16 +16,19 @@ namespace Microsoft.Health.Blob.Features.Storage
     public interface IBlobInitializer
     {
         /// <summary>
-        /// Open blobservice client
+        /// Open blobservice client.
         /// </summary>
-        /// <param name="blobContainerConfiguration">The container configuration to use for validating the blob client is open</param>
-        Task OpenBlobClientAsync(BlobContainerConfiguration blobContainerConfiguration);
+        /// <param name="blobContainerConfiguration">The container configuration to use for validating the blob client is open.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        /// <returns>A <see cref="Task"/>.</returns>
+        Task OpenBlobClientAsync(BlobContainerConfiguration blobContainerConfiguration, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Initialize data store
+        /// Initialize data store.
         /// </summary>
         /// <param name="containerInitializers">The blob container initializers.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
         /// <returns>A <see cref="Task"/>.</returns>
-        Task InitializeDataStoreAsync(IEnumerable<IBlobContainerInitializer> containerInitializers);
+        Task InitializeDataStoreAsync(IEnumerable<IBlobContainerInitializer> containerInitializers, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
## Description
Adds optional `CancellationToken` support throughout the blob storage library. The main scenario this affects is the host cancelling `BlobHostedService` as part of the hosted service lifecycle - cancellation is propagated to every blob client call that can be cancelled.

Exceptions were being silently handled in `BlobHealthCheck`, but now exceptions are thrown, as this is the [recommended pattern.](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-5.0#create-health-checks).

Also added / cleaned up some documentation.

Small note: the cancellation token library uses the double `l` spelling throughout, but throws a single `l` `OperationCanceledException`. Apparently, [both are acceptable.](https://www.dictionary.com/e/canceled-vs-cancelled/) 

## Testing
This change was tested against existing unit tests. Unit tests were added to test cancellation handling.
