### PR TITLE
Clear old value before setting varbinary column

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/ColumnsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/ColumnsTests.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Data.SqlTypes;
+using System.IO;
+using Microsoft.Data.SqlClient.Server;
+using Microsoft.Health.SqlServer.Features.Schema.Model;
+using Xunit;
+
+namespace Microsoft.Health.SqlServer.UnitTests.Features.Schema
+{
+    public class ColumnsTests
+    {
+        [Fact]
+        public void GivenSqlDataRecordWithVarBinaryColumn_WhenSetVarBinaryValueTwice_ThenFirstValueShouldBeCleaned()
+        {
+            VarBinaryColumn varBinaryColumn = new VarBinaryColumn("Col1", -1);
+            SqlDataRecord record = new SqlDataRecord(varBinaryColumn.Metadata);
+
+            byte[] data1 = new byte[] { 1, 1, 1, 1 };
+            byte[] data2 = new byte[] { 1, 1 };
+            using Stream input1 = new MemoryStream(data1);
+            using Stream input2 = new MemoryStream(data2);
+
+            varBinaryColumn.Set(record, 0, input1);
+            Assert.Equal(data1, ((SqlBinary)record.GetSqlValue(0)).Value);
+            varBinaryColumn.Set(record, 0, input2);
+            Assert.Equal(data2, ((SqlBinary)record.GetSqlValue(0)).Value);
+        }
+    }
+}

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -749,11 +749,14 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
         {
             EnsureArg.IsNotNull(record, nameof(record));
 
-            // Clear old value before setting new value.
-            record.SetDBNull(ordinal);
-
             if (value != null)
             {
+                if (!record.IsDBNull(ordinal))
+                {
+                    // Clear old value before setting new value.
+                    record.SetDBNull(ordinal);
+                }
+
                 int length = (int)value.Length;
                 byte[] bytes = ArrayPool<byte>.Shared.Rent(length);
 
@@ -770,6 +773,10 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
                 {
                     ArrayPool<byte>.Shared.Return(bytes);
                 }
+            }
+            else
+            {
+                record.SetDBNull(ordinal);
             }
         }
     }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -749,7 +749,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
         {
             EnsureArg.IsNotNull(record, nameof(record));
 
-            // Clear old before setting new value.
+            // Clear old value before setting new value.
             record.SetDBNull(ordinal);
 
             if (value != null)

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -749,6 +749,9 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
         {
             EnsureArg.IsNotNull(record, nameof(record));
 
+            // Clear old before setting new value.
+            record.SetDBNull(ordinal);
+
             if (value != null)
             {
                 int length = (int)value.Length;
@@ -767,10 +770,6 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Model
                 {
                     ArrayPool<byte>.Shared.Return(bytes);
                 }
-            }
-            else
-            {
-                record.SetDBNull(ordinal);
             }
         }
     }


### PR DESCRIPTION
## Description
Clear old value before setting varbinary column to fix the issue #282 

## Related issues
Addresses [issue #282 ].

## Testing
Describe how this change was tested.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
