### PR TITLE
Allow register specific module to support DicomFunctions

### DIFF
--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/ServiceControllerExtensionsTests.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/ServiceControllerExtensionsTests.cs
@@ -27,5 +27,13 @@ namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests
             var collection = Substitute.For<IServiceCollection>();
             Assert.Throws<ArgumentNullException>(() => collection.RegisterAssemblyModules(null));
         }
+
+        [Fact]
+        public void GivenNonNullModuleFilter_WhenScanningForModules_ThenItShouldBeRespected()
+        {
+            var collection = Substitute.For<IServiceCollection>();
+            collection.RegisterAssemblyModules(GetType().Assembly, moduleTypeFilter: x => x != typeof(TestModule));
+            collection.DidNotReceive().Add(Arg.Is<ServiceDescriptor>(descriptor => descriptor.ServiceType == typeof(TestComponent)));
+        }
     }
 }

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/ServiceControllerExtensionsTests.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/ServiceControllerExtensionsTests.cs
@@ -27,13 +27,5 @@ namespace Microsoft.Health.Extensions.DependencyInjection.UnitTests
             var collection = Substitute.For<IServiceCollection>();
             Assert.Throws<ArgumentNullException>(() => collection.RegisterAssemblyModules(null));
         }
-
-        [Fact]
-        public void GivenNonNullModuleFilter_WhenScanningForModules_ThenItShouldBeRespected()
-        {
-            var collection = Substitute.For<IServiceCollection>();
-            collection.RegisterAssemblyModules(GetType().Assembly, moduleTypeFilter: x => x != typeof(TestModule));
-            collection.DidNotReceive().Add(Arg.Is<ServiceDescriptor>(descriptor => descriptor.ServiceType == typeof(TestComponent)));
-        }
     }
 }

--- a/src/Microsoft.Health.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -24,11 +24,23 @@ namespace Microsoft.Health.Extensions.DependencyInjection
         /// <param name="constructorParams">An array of constructor parameters that can be injected into IStartupModule on creation.</param>
         public static void RegisterAssemblyModules(this IServiceCollection collection, Assembly assembly, params object[] constructorParams)
         {
+            collection.RegisterAssemblyModules(assembly: assembly, moduleTypeFilter: null, constructorParams: constructorParams);
+        }
+
+        /// <summary>
+        /// Registers assembly modules.
+        /// </summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="moduleTypeFilter">Filter out modules that are not be registered.</param>
+        /// <param name="constructorParams">An array of constructor parameters that can be injected into IStartupModule on creation.</param>
+        public static void RegisterAssemblyModules(this IServiceCollection collection, Assembly assembly, Func<Type, bool> moduleTypeFilter, params object[] constructorParams)
+        {
             EnsureArg.IsNotNull(collection, nameof(collection));
             EnsureArg.IsNotNull(assembly, nameof(assembly));
 
             foreach (var moduleType in assembly.GetTypes()
-                .Where(x => typeof(IStartupModule).IsAssignableFrom(x) && x.IsClass && !x.IsAbstract))
+                .Where(x => typeof(IStartupModule).IsAssignableFrom(x) && x.IsClass && !x.IsAbstract && (moduleTypeFilter == null || moduleTypeFilter.Invoke(x))))
             {
                 // For simplicity, only a single Module constructor is supported
                 var constructor = moduleType


### PR DESCRIPTION
## Description
DicomFunctions  only need register small subset of modules in assembly, add RegistryModule to support it.

## Related issues
Addresses [AB#84056](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/84056)

## Testing
* All existing automated tests pass.
