### PR TITLE
Log Audit CustomHeaders added after the requested is executed

### DIFF
--- a/src/Microsoft.Health.Api/Features/Audit/AuditHeaderReader.cs
+++ b/src/Microsoft.Health.Api/Features/Audit/AuditHeaderReader.cs
@@ -29,13 +29,11 @@ namespace Microsoft.Health.Api.Features.Audit
             EnsureArg.IsNotNull(httpContext, nameof(httpContext));
 
             object cachedCustomHeaders;
-
+            var customHeaders = new Dictionary<string, string>();
             if (httpContext.Items.TryGetValue(AuditConstants.CustomAuditHeaderKeyValue, out cachedCustomHeaders))
             {
-                return cachedCustomHeaders as IReadOnlyDictionary<string, string>;
+                customHeaders = (Dictionary<string, string>)cachedCustomHeaders;
             }
-
-            var customHeaders = new Dictionary<string, string>();
 
             foreach (KeyValuePair<string, StringValues> header in httpContext.Request.Headers)
             {


### PR DESCRIPTION
## Description
Grab the auditing-custom headers added after the request is executed from the context

## Related issues
Addresses [[77729](https://microsofthealth.visualstudio.com/Health/_workitems/edit/77729)].

## Testing
Manual Testing

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
