### PR TITLE
Handle exceptions when schema does not exist

### DIFF
--- a/src/Microsoft.Health.SqlServer.Api/Schema/SchemaJobWorkerBackgroundService.cs
+++ b/src/Microsoft.Health.SqlServer.Api/Schema/SchemaJobWorkerBackgroundService.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.SqlServer.Api.Features.Schema
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            if (!_sqlServerDataStoreConfiguration.SchemaOptions.AutomaticUpdatesEnabled)
+            if (!_sqlServerDataStoreConfiguration.SchemaOptions.AutomaticUpdatesEnabled && _schemaInformation.Current.HasValue)
             {
                 await _schemaJobWorker.ExecuteAsync(_schemaInformation, _instanceName, stoppingToken).ConfigureAwait(false);
             }

--- a/src/Microsoft.Health.SqlServer.Api/Schema/SchemaJobWorkerBackgroundService.cs
+++ b/src/Microsoft.Health.SqlServer.Api/Schema/SchemaJobWorkerBackgroundService.cs
@@ -21,8 +21,11 @@ namespace Microsoft.Health.SqlServer.Api.Features.Schema
     {
         private readonly string _instanceName;
         private readonly SchemaJobWorker _schemaJobWorker;
-        private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
         private readonly SchemaInformation _schemaInformation;
+
+#pragma warning disable IDE0052 // Remove unread private members
+        private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
+#pragma warning restore IDE0052 // Remove unread private members
 
         public SchemaJobWorkerBackgroundService(SchemaJobWorker schemaJobWorker, IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration, SchemaInformation schemaInformation)
         {

--- a/src/Microsoft.Health.SqlServer.Api/Schema/SchemaJobWorkerBackgroundService.cs
+++ b/src/Microsoft.Health.SqlServer.Api/Schema/SchemaJobWorkerBackgroundService.cs
@@ -42,10 +42,7 @@ namespace Microsoft.Health.SqlServer.Api.Features.Schema
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            if (!_sqlServerDataStoreConfiguration.SchemaOptions.AutomaticUpdatesEnabled && _schemaInformation.Current.HasValue)
-            {
-                await _schemaJobWorker.ExecuteAsync(_schemaInformation, _instanceName, stoppingToken).ConfigureAwait(false);
-            }
+             await _schemaJobWorker.ExecuteAsync(_schemaInformation, _instanceName, stoppingToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
                 object current = await selectCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
                 return (current == null || Convert.IsDBNull(current)) ? 0 : (int)current;
             }
-            catch (SqlException e) when (string.Equals(e.Message, Resources.CurrentSchemaVersionStoredProcedureNotFound, StringComparison.OrdinalIgnoreCase))
+            catch (SqlException e) when (string.Equals(e.Message, string.Format(Resources.CurrentSchemaVersionStoredProcedureNotFound, "dbo.SelectCurrentSchemaVersion"), StringComparison.OrdinalIgnoreCase))
             {
                 return 0;
             }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -81,6 +82,10 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                     {
                         _processTerminator.Terminate(cancellationToken);
                     }
+                }
+                catch (SqlException e) when (schemaInformation.Current is null && string.Equals(e.Message, string.Format(Resources.CurrentSchemaVersionStoredProcedureNotFound, "dbo.UpsertInstanceSchema"), StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning(e, "Schema is not initialized.");
                 }
                 catch (Exception ex)
                 {

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
@@ -93,7 +93,15 @@ namespace Microsoft.Health.SqlServer.Features.Storage
                 }
                 catch (SqlException e)
                 {
-                    _logger.LogError(e, "Error from SQL database on upserting InstanceSchema information");
+                    if (schemaInformation.Current is null && string.Equals(e.Message, string.Format(Resources.CurrentSchemaVersionStoredProcedureNotFound, "dbo.UpsertInstanceSchema"), StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogInformation(e, "Error from SQL database on upserting InstanceSchema information");
+                    }
+                    else
+                    {
+                        _logger.LogError(e, "Error from SQL database on upserting InstanceSchema information");
+                    }
+
                     throw;
                 }
             }

--- a/src/Microsoft.Health.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.SqlServer/Resources.Designer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Health.SqlServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not find stored procedure &apos;dbo.SelectCurrentSchemaVersion&apos;..
+        ///   Looks up a localized string similar to Could not find stored procedure &apos;{0}&apos;..
         /// </summary>
         internal static string CurrentSchemaVersionStoredProcedureNotFound {
             get {

--- a/src/Microsoft.Health.SqlServer/Resources.resx
+++ b/src/Microsoft.Health.SqlServer/Resources.resx
@@ -143,7 +143,7 @@
     <comment>{0} is the response statusCode.</comment>
   </data>
   <data name="CurrentSchemaVersionStoredProcedureNotFound" xml:space="preserve">
-    <value>Could not find stored procedure 'dbo.SelectCurrentSchemaVersion'.</value>
+    <value>Could not find stored procedure '{0}'.</value>
   </data>
   <data name="InstanceSchemaRecordErrorMessage" xml:space="preserve">
     <value>The current version information could not be fetched from the service. Please try again.</value>


### PR DESCRIPTION
## Description
When Schema is not initialized (SchemaOptions:AutomaticUpdatesEnabled : false), SchemaJob, ExportJob, Task hosting background services throw errors as they try to access stored procedure which do not exist. With this PR we are trying to avoid multiple exception loggings over and over by checking if schemaInformation.current version in null (implying Schema is not initialized). Instead we are logging warnings for the same issues.

## Related issues
Addresses [[81886](https://microsofthealth.visualstudio.com/Health/_workitems/edit/81886)].

## Testing
Manual Testing -

1. Set "SqlServer:SchemaOptions:AutomaticUpdatesEnabled" as false in launchSettings.cs.
 2. Run Fhir server
 3. Notice there are no errors are logged in console
 4. You should see warning loggings for Could not find stored procedure...

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
