### PR TITLE
Refactor Blob Initialization

### DIFF
--- a/src/Microsoft.Health.Blob.UnitTests/Microsoft.Health.Blob.UnitTests.csproj
+++ b/src/Microsoft.Health.Blob.UnitTests/Microsoft.Health.Blob.UnitTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.1.3" />

--- a/src/Microsoft.Health.Blob.UnitTests/Registration/BlobClientRegistrationExtensionsTest.cs
+++ b/src/Microsoft.Health.Blob.UnitTests/Registration/BlobClientRegistrationExtensionsTest.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Health.Blob.UnitTests.Registration
         }
 
         [Fact]
-        public void GivenBlobDataStoreConfiguration_WhenConfiguringInitializer_ThenMapSettings()
+        public void GivenBlobDataStoreConfiguration_WhenAddingBlobDataStore_ThenMapInitializerSettings()
         {
             var services = new ServiceCollection();
             services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection().Build());
@@ -146,6 +146,29 @@ namespace Microsoft.Health.Blob.UnitTests.Registration
             var options = provider.GetRequiredService<IOptions<BlobInitializerOptions>>();
             Assert.Equal(TimeSpan.FromSeconds(4567), options.Value.RetryDelay);
             Assert.Equal(TimeSpan.FromMinutes(123), options.Value.Timeout);
+        }
+
+        [Fact]
+        public void GivenNoConnectionString_WhenAddingBlobServiceClient_ThenUseDefault()
+        {
+            IConfiguration config = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    new KeyValuePair<string, string>[]
+                    {
+                        KeyValuePair.Create("ConnectionString", (string)null),
+                        KeyValuePair.Create("Operations:Download:MaximumConcurrency", "12"),
+                    })
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton(config);
+            services.AddBlobServiceClient(config);
+
+            BlobServiceClient actual = services
+                .BuildServiceProvider()
+                .GetRequiredService<BlobServiceClient>();
+
+            Assert.Equal("devstoreaccount1", actual.AccountName);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Blob/Configs/BlobInitializerOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobInitializerOptions.cs
@@ -7,10 +7,21 @@ using System;
 
 namespace Microsoft.Health.Blob.Configs
 {
+    /// <summary>
+    /// Represents a collection of settings used to configure the initialization of blob containers.
+    /// </summary>
     public class BlobInitializerOptions
     {
+        /// <summary>
+        /// Gets or sets the delay between initialization retries.
+        /// </summary>
+        /// <value>The amount of time between retries.</value>
         public TimeSpan RetryDelay { get; set; } = TimeSpan.FromSeconds(15);
 
+        /// <summary>
+        /// Gets or sets the maximum amount of time to spend initializing containers.
+        /// </summary>
+        /// <value>The maximum amount of time that initialization may take before an exception is thrown.</value>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(6);
     }
 }

--- a/src/Microsoft.Health.Blob/Configs/BlobInitializerOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobInitializerOptions.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Health.Blob.Configs
     public class BlobInitializerOptions
     {
         /// <summary>
+        /// A default configuration section name that may be used for binding.
+        /// </summary>
+        public const string DefaultSectionName = "Initialization";
+
+        /// <summary>
         /// Gets or sets the delay between initialization retries.
         /// </summary>
         /// <value>The amount of time between retries.</value>

--- a/src/Microsoft.Health.Blob/Configs/BlobOperationOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobOperationOptions.cs
@@ -7,10 +7,21 @@ using Azure.Storage;
 
 namespace Microsoft.Health.Blob.Configs
 {
+    /// <summary>
+    /// Represents a collection of settings used to configure blob operations.
+    /// </summary>
     public class BlobOperationOptions
     {
+        /// <summary>
+        /// Gets or sets the storage transfer settings for downloading blobs.
+        /// </summary>
+        /// <value>The <see cref="StorageTransferOptions"/> used when reading a blob.</value>
         public StorageTransferOptions Download { get; set; }
 
+        /// <summary>
+        /// Gets or sets the storage transfer settings for uploading blobs.
+        /// </summary>
+        /// <value>The <see cref="StorageTransferOptions"/> used when writing a blob.</value>
         public StorageTransferOptions Upload { get; set; }
     }
 }

--- a/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
@@ -7,14 +7,53 @@ using Azure.Storage.Blobs;
 
 namespace Microsoft.Health.Blob.Configs
 {
+    /// <summary>
+    /// Represents a collection of settings used to configure a <see cref="BlobServiceClient"/> and its operations.
+    /// </summary>
     public class BlobServiceClientOptions : BlobClientOptions
     {
+        /// <summary>
+        /// A default configuration section name that may be used for binding.
+        /// </summary>
+        public const string DefaultSectionName = "BlobStore";
+
+        /// <summary>
+        /// Gets or sets the Azure Blob Storage connection string.
+        /// </summary>
+        /// <remarks>
+        /// Note that Azure Storage connection strings are not URLs. Instead they are semicolon-delimited (;)
+        /// key-value pairs that describe different aspects of the connection including <c>"DefaultEndpointsProtocol"</c>,
+        /// <c>"AccountName"</c>, and <c>"AccountKey"</c>. Each pair has its key and value separated by an equal sign
+        /// (=) like in the following example: <c>"DefaultEndpointsProtocol=https"</c>.
+        /// </remarks>
+        /// <value>The connection string key-value pairs.</value>
         public string ConnectionString { get; set; }
 
+        /// <summary>
+        /// Gets or sets the type of credential used to authenticate the client.
+        /// </summary>
+        /// <remarks>
+        /// Currently only <c>"managedidentity"</c> or <see langword="null"/> is supported.
+        /// </remarks>
+        /// <value>
+        /// The type of credential or <see langword="null"/> if using an
+        /// account key in the <see cref="ConnectionString"/>.
+        /// </value>
         public string Credential { get; set; }
 
+        /// <summary>
+        /// Gets or sets the managed identity client identifier.
+        /// </summary>
+        /// <remarks>
+        /// This setting should only be set if <see cref="Credential"/> contains the value <c>"managedidentity"</c>.
+        /// </remarks>
+        /// <value>The client id if using managed identity to authenticate; otherwise, <see langword="null"/>.</value>
         public string ClientId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the options for <see cref="BlobServiceClient"/> operations.
+        /// </summary>
+        /// <value>The operation settings.</value>
         public BlobOperationOptions Operations { get; set; }
     }
 }

--- a/src/Microsoft.Health.Blob/Registration/BlobContainerInitializationBuilder.cs
+++ b/src/Microsoft.Health.Blob/Registration/BlobContainerInitializationBuilder.cs
@@ -1,0 +1,32 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Health.Blob.Registration
+{
+    /// <summary>
+    /// Represents a builder for configuring Azure Blob Storage container initialization.
+    /// </summary>
+    public sealed class BlobContainerInitializationBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BlobContainerInitializationBuilder"/> class
+        /// which the specified services.
+        /// </summary>
+        /// <param name="services">A collection of services.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="services"/> is <see langword="null"/>.</exception>
+        public BlobContainerInitializationBuilder(IServiceCollection services)
+            => Services = EnsureArg.IsNotNull(services, nameof(services));
+
+        /// <summary>
+        /// Gets or sets the collection of services being configured.
+        /// </summary>
+        /// <value>The collection of services, including those necessary for container initialization.</value>
+        public IServiceCollection Services { get; }
+    }
+}

--- a/src/Microsoft.Health.Blob/Registration/BlobDataStorePostConfigure.cs
+++ b/src/Microsoft.Health.Blob/Registration/BlobDataStorePostConfigure.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Blob.Configs;
+using Microsoft.Health.Blob.Features.Storage;
+
+namespace Microsoft.Health.Blob.Registration
+{
+    internal class BlobDataStorePostConfigure : IPostConfigureOptions<BlobDataStoreConfiguration>
+    {
+        public void PostConfigure(string name, BlobDataStoreConfiguration options)
+        {
+            if (string.IsNullOrEmpty(options.ConnectionString) && options.AuthenticationType == BlobDataStoreAuthenticationType.ConnectionString)
+            {
+                options.ConnectionString = BlobLocalEmulator.ConnectionString;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Move code that adds instances of `BlobContainerInitializer` into the service container into the core libraries using the builder pattern, similar to `OptionsBuilder`.

You can see we repeat this logic in DICOM:
- [BlobStore](https://github.com/microsoft/dicom-server/blob/606b53e250029ad593b858f5c7cc9fac758d12ce/src/Microsoft.Health.Dicom.Blob/Registration/DicomServerBuilderBlobRegistrationExtensions.cs#L62)
- [MetadataStore](https://github.com/microsoft/dicom-server/blob/606b53e250029ad593b858f5c7cc9fac758d12ce/src/Microsoft.Health.Dicom.Metadata/Registration/DicomServerBuilderMetadataRegistrationExtensions.cs#L52)

## Related issues
[AB#84923](https://microsofthealth.visualstudio.com/Health/_workitems/edit/84923)

## Testing
Tested via pipeline

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch
(Although it is actually breaking, but the previous breaking change 3.2 was unlisted for blob)
