### PR TITLE
Use DefaultAzureCredential Instead of ManagedIdentityCredential

### DIFF
--- a/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     if (string.Equals(options.Credential, "managedidentity", StringComparison.OrdinalIgnoreCase))
                     {
-                        clientBuilder.WithCredential(new ManagedIdentityCredential(options.ClientId));
+                        clientBuilder.WithCredential(new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = options.ClientId }));
                     }
                 });
 


### PR DESCRIPTION
## Description
- Use `DefaultAzureCredential` Instead of `ManagedIdentityCredential` to backward compatibility

## Related issues
[AB#84923](https://microsofthealth.visualstudio.com/Health/_workitems/edit/84923)

## Testing
Tested via pipeline

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch
