### PR TITLE
Control the HttpClient connection setup timeout for BlobClient

### DIFF
--- a/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
@@ -64,8 +64,10 @@ namespace Microsoft.Health.Blob.Configs
         public BlobOperationOptions Operations { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum time it waits for the connection to be established.
+        /// Gets or sets the options for configuring the <see cref="Azure.Core.ClientOptions.Transport"/>
+        /// via a collection of settings.
         /// </summary>
-        public int ConnectionTimeoutInSeconds { get; set; } = 2;
+        /// <value>The settings for configuring the underlying HTTP transport.</value>
+        public TransportOverrideOptions TransportOverride { get; set; }
     }
 }

--- a/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
@@ -62,5 +62,10 @@ namespace Microsoft.Health.Blob.Configs
         /// </summary>
         /// <value>The operation settings.</value>
         public BlobOperationOptions Operations { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum time it waits for the connection to be established.
+        /// </summary>
+        public int ConnectionTimeoutInSeconds { get; set; } = 2;
     }
 }

--- a/src/Microsoft.Health.Blob/Configs/TransportOverrideOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/TransportOverrideOptions.cs
@@ -1,0 +1,32 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Threading;
+using Azure.Core.Pipeline;
+
+namespace Microsoft.Health.Blob.Configs
+{
+    /// <summary>
+    /// Represents a collection of settings used to configure the underlying HTTP transport.
+    /// </summary>
+    public class TransportOverrideOptions
+    {
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Used internally to create singleton client.")]
+        internal HttpPipelineTransport Transport
+        {
+            // Singleton, called only during app initialization, and should be available during the lifetime of the app
+            // Creating our own HttpClient to handle connection timeout. We are seeing intermittent socketexceptions in
+            // QIDO where we can send up to 200 concurrent Azure blob requests. This waits for 22 seconds. #85137
+            // Azure SDK code that does this https://github.com/Azure/azure-sdk-for-net/blob/99f5a87233b397fb9992031300cd61fe2c4baa5c/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs#L143-L144
+            get => new HttpClientTransport(new SocketsHttpHandler { ConnectTimeout = ConnectTimeout });
+        }
+
+        /// <inheritdoc cref="SocketsHttpHandler.ConnectTimeout"/>
+        public TimeSpan ConnectTimeout { get; set; } = Timeout.InfiniteTimeSpan;
+    }
+}

--- a/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
@@ -5,9 +5,7 @@
 
 using System;
 using System.Linq;
-using System.Net.Http;
 using Azure.Core.Extensions;
-using Azure.Core.Pipeline;
 using Azure.Identity;
 using Azure.Storage.Blobs;
 using EnsureThat;
@@ -123,21 +121,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.ConnectionString = BlobLocalEmulator.ConnectionString;
             }
 
-            // Singleton, called only during app initialization, and should be available during the lifetime of the app
-            // Creating our own HttpClient to handle connection timeout. We are seeing intermittent socketexceptions in
-            // QIDO where we can send upto 200 concurrent Azure blob requests. This waits for 22 seconds. #85137
-            // Azure SDK code that does this https://github.com/Azure/azure-sdk-for-net/blob/99f5a87233b397fb9992031300cd61fe2c4baa5c/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs#L143-L144
-            #pragma warning disable CA2000 // Dispose objects before losing scope
-            var socketsHandler = new SocketsHttpHandler
-            {
-                ConnectTimeout = new TimeSpan(0, 0, options.ConnectionTimeoutInSeconds),
-            };
-
-            // HttpClient initialized here to be used by the Blob client SDK
-            var client = new HttpClient(socketsHandler);
-#pragma warning restore CA2000 // Dispose objects before losing scope
-            options.Transport = new HttpClientTransport(client);
-
             services.AddAzureClients(
                 builder =>
                 {
@@ -164,6 +147,14 @@ namespace Microsoft.Extensions.DependencyInjection
                         clientBuilder = clientBuilder.ConfigureOptions(configure);
                     }
                 });
+
+            // While users can configure the Transport using the "configure" parameter,
+            // the TransportOverride provides a more configuration-friendly mechanism
+            if (options.TransportOverride != null)
+            {
+                services.TryAddEnumerable(
+                    ServiceDescriptor.Singleton<IConfigureOptions<BlobClientOptions>>(new TransportConfigure(options.TransportOverride)));
+            }
 
             return services;
         }

--- a/src/Microsoft.Health.Blob/Registration/TransportConfigure.cs
+++ b/src/Microsoft.Health.Blob/Registration/TransportConfigure.cs
@@ -1,0 +1,23 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Azure.Storage.Blobs;
+using EnsureThat;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Blob.Configs;
+
+namespace Microsoft.Health.Blob.Registration
+{
+    internal class TransportConfigure : IConfigureOptions<BlobClientOptions>
+    {
+        private readonly TransportOverrideOptions _desiredOptions;
+
+        public TransportConfigure(TransportOverrideOptions options)
+            => _desiredOptions = EnsureArg.IsNotNull(options, nameof(options));
+
+        public void Configure(BlobClientOptions options)
+            => options.Transport = _desiredOptions.Transport;
+    }
+}


### PR DESCRIPTION
## Description
Currently Blob service connection timesout after 22 seconds if it cannot establish a connection.
We will reduce it to 2 seconds. Expected time for a TLS handshake is 250ms to 500ms.

## Related issues
[AB#85137](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/85137)

## Testing
Potential fix based on recommendation from xstore team. Will do more testing in dicom-server code

