### PR TITLE
Created an injection dependency of the HttpClient class in the SchemaClient class constructor

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaClient.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaClient.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
     {
         private readonly HttpClient _httpClient;
 
-        public SchemaClient(HttpClient httpClient)
+        public SchemaClient(IHttpClientFactory httpClientFactory)
         {
-            _httpClient = httpClient;
+            _httpClient = httpClientFactory.CreateClient();
         }
 
         public void SetUri(Uri uri)
@@ -118,20 +118,6 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
             else
             {
                 throw new SchemaManagerException(string.Format(CultureInfo.InvariantCulture, Resources.ScriptNotFound, response.StatusCode));
-            }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                _httpClient?.Dispose();
             }
         }
     }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaClient.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaClient.cs
@@ -16,13 +16,13 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 {
-    public class SchemaClient : ISchemaClient, IDisposable
+    public class SchemaClient : ISchemaClient
     {
         private readonly HttpClient _httpClient;
 
-        public SchemaClient()
+        public SchemaClient(HttpClient httpClient)
         {
-            _httpClient = new HttpClient();
+            _httpClient = httpClient;
         }
 
         public void SetUri(Uri uri)

--- a/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
+++ b/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(SdkPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.46437.65" />

--- a/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
+++ b/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.16" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.46437.65" />

--- a/tools/SchemaManager/Program.cs
+++ b/tools/SchemaManager/Program.cs
@@ -45,6 +45,7 @@ namespace SchemaManager
 
             // Add SqlServer services
             services.AddOptions();
+            services.AddHttpClient();
             services.AddSingleton<ISqlConnectionFactory, DefaultSqlConnectionFactory>();
             services.AddSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>();
             services.AddSingleton<IBaseSchemaRunner, BaseSchemaRunner>();


### PR DESCRIPTION
## Description
- Removed IDisposable inheritance
- Changed the constructor implementation to add an injection dependency HttpClient class, to avoid errors using a new instance of this class in every call

## Related issues
Addresses [#317].

## Testing
I ran tests on the SqlSchemaManagerTests class, which uses the ISchemaClient interface, and I didn't find any errors.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
