### PR TITLE
Uses a DistributedSqlLock to perform Schema Upgrades when using SchemaOptions.AutomaticUpdatesEnabled

### DIFF
--- a/src/Microsoft.Health.SqlServer.Api/Schema/SchemaJobWorkerBackgroundService.cs
+++ b/src/Microsoft.Health.SqlServer.Api/Schema/SchemaJobWorkerBackgroundService.cs
@@ -8,8 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
-using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema;
 
 namespace Microsoft.Health.SqlServer.Api.Features.Schema
@@ -21,17 +19,14 @@ namespace Microsoft.Health.SqlServer.Api.Features.Schema
     {
         private readonly string _instanceName;
         private readonly SchemaJobWorker _schemaJobWorker;
-        private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
         private readonly SchemaInformation _schemaInformation;
 
-        public SchemaJobWorkerBackgroundService(SchemaJobWorker schemaJobWorker, IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration, SchemaInformation schemaInformation)
+        public SchemaJobWorkerBackgroundService(SchemaJobWorker schemaJobWorker, SchemaInformation schemaInformation)
         {
             EnsureArg.IsNotNull(schemaJobWorker, nameof(schemaJobWorker));
-            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
             EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
 
             _schemaJobWorker = schemaJobWorker;
-            _sqlServerDataStoreConfiguration = sqlServerDataStoreConfiguration.Value;
             _schemaInformation = schemaInformation;
 #if NET5_0_OR_GREATER
             _instanceName = Guid.NewGuid() + "-" + Environment.ProcessId;
@@ -42,10 +37,7 @@ namespace Microsoft.Health.SqlServer.Api.Features.Schema
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            if (!_sqlServerDataStoreConfiguration.SchemaOptions.AutomaticUpdatesEnabled)
-            {
-                await _schemaJobWorker.ExecuteAsync(_schemaInformation, _instanceName, stoppingToken).ConfigureAwait(false);
-            }
+            await _schemaJobWorker.ExecuteAsync(_schemaInformation, _instanceName, stoppingToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
+++ b/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+    <PackageReference Include="DistributedLock.SqlServer" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
* Uses a DistributedSqlLock to perform Schema Upgrades when using SchemaOptions.AutomaticUpdatesEnabled.
* If a lock isn't acquired the background SchemaVersion checker should update the instance once available.

This package uses [sp_getapplock (Transact-SQL)](https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql?view=sql-server-ver15) which looks like its available in all versions of SQL Server.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch
