### PR TITLE
Adds an overload of GetRecordsAsync.

### DIFF
--- a/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
+++ b/src/Microsoft.Health.Abstractions/Data/IChangeFeedSource.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,5 +24,15 @@ namespace Microsoft.Health.Abstractions.Data
         /// <param name="cancellationToken">Cancellation Token.</param>
         /// <returns>IReadOnlyCollection of T.</returns>
         Task<IReadOnlyCollection<T>> GetRecordsAsync(long startId, short pageSize, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Read records from underlying source that matches type T.
+        /// </summary>
+        /// <param name="startId">Start Index of records.</param>
+        /// <param name="lastProcessedDateTime ">The last checkpoint datetime.</param>
+        /// <param name="pageSize">Page Size of records to fetch.</param>
+        /// <param name="cancellationToken">Cancellation Token.</param>
+        /// <returns>IReadOnlyCollection of T.</returns>
+        Task<IReadOnlyCollection<T>> GetRecordsAsync(long startId, DateTime lastProcessedDateTime, short pageSize, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
## Description
Adds an overload of GetRecordsAsync.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
