### PR TITLE
Added FhirAnonymousOperationAttribute to catch FhirOperation linked to anonymous calls

### DIFF
--- a/src/Microsoft.Health.Api/Features/AnonymousOperations/FhirAnonymousOperationAttribute.cs
+++ b/src/Microsoft.Health.Api/Features/AnonymousOperations/FhirAnonymousOperationAttribute.cs
@@ -1,0 +1,23 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Microsoft.Health.Api.Features.AnonymousOperation
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class FhirAnonymousOperationAttribute : AllowAnonymousAttribute
+    {
+        public FhirAnonymousOperationAttribute(string fhirOperation)
+        {
+            EnsureArg.IsNotNull(fhirOperation, nameof(fhirOperation));
+            FhirOperation = fhirOperation;
+        }
+
+        public string FhirOperation { get; }
+    }
+}

--- a/src/Microsoft.Health.Api/Features/Audit/AuditEventTypeMapping.cs
+++ b/src/Microsoft.Health.Api/Features/Audit/AuditEventTypeMapping.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Api.Extensions;
+using Microsoft.Health.Api.Features.AnonymousOperation;
 
 namespace Microsoft.Health.Api.Features.Audit
 {
@@ -59,6 +60,11 @@ namespace Microsoft.Health.Api.Features.Audit
                 return auditEventTypeAttribute.AuditEventType;
             }
 
+            if (attribute is FhirAnonymousOperationAttribute fhirAnonymousOperationAttribute)
+            {
+                return fhirAnonymousOperationAttribute.FhirOperation;
+            }
+
             return null;
         }
 
@@ -70,7 +76,8 @@ namespace Microsoft.Health.Api.Features.Audit
                 .Select(ad =>
                 {
                     Attribute attribute = ad.MethodInfo?.GetCustomAttributes<AllowAnonymousAttribute>().FirstOrDefault() ??
-                                          (Attribute)ad.MethodInfo?.GetCustomAttributes<AuditEventTypeAttribute>().FirstOrDefault();
+                                            ad.MethodInfo?.GetCustomAttributes<FhirAnonymousOperationAttribute>().FirstOrDefault() ??
+                                                (Attribute)ad.MethodInfo?.GetCustomAttributes<AuditEventTypeAttribute>().FirstOrDefault();
 
                     return (ad.ControllerName, ad.ActionName, Attribute: attribute);
                 })

--- a/src/Microsoft.Health.Core/Features/Context/IRequestContext.cs
+++ b/src/Microsoft.Health.Core/Features/Context/IRequestContext.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Health.Core.Features.Context
 
         string RouteName { get; set; }
 
+        // We want to log anonymous calls (FhirAnonymousOperationType) in RequestMetric with valid operation type e.g. Metadata and Versions and not just limit to standard AuditEventTypes
+        // This property holds value for both the AuditEventTypes and FhirAnonymousOperationType
+        // We will still continue to log audit logs for AuditEventTypes only. This change is made in AuditHelper class
         string AuditEventType { get; set; }
 
         ClaimsPrincipal Principal { get; set; }


### PR DESCRIPTION
## Description
Today, we log AuditEventType as FhirOperation in RequestMetrics. For anonymous endpoint calls like Metadata or Versions we log {"Authentication":"","Operation":"","ResourceType":""}. With this change we added  FhirAnonymousOperationAttribute which extends AllowAnonymousAttribute and can retrieve the Fhir operation. For metadata call, in request metric we should see an entry as {"Authentication":"","Operation":"metadata","ResourceType":""}.

## Related issues
Addresses [[74172](https://microsofthealth.visualstudio.com/Health/_workitems/edit/74172)].

## Testing
Deploy personal environment to DF. Make anonymous calls. Check RequestMetric logs for the respective endpoint call,

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
