### PR TITLE
Fix schema upgrade lock

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema.Extensions;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
+using Microsoft.Health.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.SqlServer.Features.Schema
 {
@@ -75,52 +76,58 @@ namespace Microsoft.Health.SqlServer.Features.Schema
             if (_sqlServerDataStoreConfiguration.SchemaOptions.AutomaticUpdatesEnabled)
             {
                 IDistributedLock sqlLock = new SqlDistributedLock(SchemaUpgradeLockName, await _sqlConnectionStringProvider.GetSqlConnectionString(cancellationToken));
+
                 try
                 {
-                    await using IDistributedSynchronizationHandle lockHandle = await sqlLock.TryAcquireAsync(TimeSpan.FromSeconds(30), cancellationToken);
-
-                    if (lockHandle == null)
+                    await using (IDistributedSynchronizationHandle lockHandle = await sqlLock.TryAcquireAsync(TimeSpan.FromSeconds(30), cancellationToken))
                     {
-                        _logger.LogInformation("Schema upgrade lock was not acquired, skipping");
-                        return;
+                        if (lockHandle == null)
+                        {
+                            _logger.LogInformation("Schema upgrade lock was not acquired, skipping");
+                            return;
+                        }
+
+                        _logger.LogInformation("Schema upgrade lock acquired");
+
+                        // Recheck the version with lock
+                        await GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
+                        _logger.LogInformation("Schema version is {version}", _schemaInformation.Current?.ToString(CultureInfo.InvariantCulture) ?? "NULL");
+
+                        // If the stored procedure to get the current schema version doesn't exist
+                        if (_schemaInformation.Current == null)
+                        {
+                            // Apply base schema
+                            await _schemaUpgradeRunner.ApplyBaseSchemaAsync(cancellationToken).ConfigureAwait(false);
+
+                            // This is for tests purpose only
+                            if (forceIncrementalSchemaUpgrade)
+                            {
+                                // Run version 1 and and apply .diff.sql files to upgrade the schema version.
+                                await _schemaUpgradeRunner.ApplySchemaAsync(_schemaInformation.MinimumSupportedVersion, applyFullSchemaSnapshot: true, cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                // Apply the maximum supported version. This won't consider the .diff.sql files.
+                                await _schemaUpgradeRunner.ApplySchemaAsync(_schemaInformation.MaximumSupportedVersion, applyFullSchemaSnapshot: true, cancellationToken).ConfigureAwait(false);
+                            }
+
+                            await GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
+
+                            await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, true);
+                        }
                     }
                 }
-
-                // 596 is the error code for Cannot continue the execution because the session is in the kill state.
-                // https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors?view=sql-server-ver15
-                catch (SqlException e) when (e.ErrorCode == 596)
+                catch (SqlException e) when (e.Number == SqlErrorCodes.KilledSessionState)
                 {
-                    _logger.LogInformation("Schema upgrade lock was not acquired because the session is in the kill state, skipping");
+                    _logger.LogWarning("Schema upgrade lock was not acquired because the session is in the kill state, skipping");
                     return;
                 }
 
-                _logger.LogInformation("Schema upgrade lock acquired");
-
-                // Recheck the version with lock
-                await GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
-                _logger.LogInformation("Schema version is {version}", _schemaInformation.Current?.ToString(CultureInfo.InvariantCulture) ?? "NULL");
-
-                // If the stored procedure to get the current schema version doesn't exist
-                if (_schemaInformation.Current == null)
+                // This exception sometimes occurs at Medallion.Threading.Internal.Data.MultiplexedConnectionLock.ReleaseAsync
+                catch (SqlException e) when (e.Message.Contains("The connection is broken and recovery is not possible.", StringComparison.OrdinalIgnoreCase))
                 {
-                    // Apply base schema
-                    await _schemaUpgradeRunner.ApplyBaseSchemaAsync(cancellationToken).ConfigureAwait(false);
-
-                    // This is for tests purpose only
-                    if (forceIncrementalSchemaUpgrade)
-                    {
-                        // Run version 1 and and apply .diff.sql files to upgrade the schema version.
-                        await _schemaUpgradeRunner.ApplySchemaAsync(_schemaInformation.MinimumSupportedVersion, applyFullSchemaSnapshot: true, cancellationToken).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        // Apply the maximum supported version. This won't consider the .diff.sql files.
-                        await _schemaUpgradeRunner.ApplySchemaAsync(_schemaInformation.MaximumSupportedVersion, applyFullSchemaSnapshot: true, cancellationToken).ConfigureAwait(false);
-                    }
-
-                    await GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
-
-                    await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, true);
+                    _logger.LogWarning($"Error occurred during multiplexed release lock");
+                    return;
                 }
 
                 // If the current schema version needs to be upgraded

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorCodes.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorCodes.cs
@@ -39,5 +39,10 @@ namespace Microsoft.Health.SqlServer.Features.Storage
         /// DBNetlib error value for timeout
         /// </summary>
         public const short TimeoutExpired = -2;
+
+        /// <summary>
+        /// Cannot continue the execution because the session is in the kill state.
+        /// </summary>
+        public const short KilledSessionState = 596;
     }
 }


### PR DESCRIPTION
## Description
Fixing the logic to hold the lock for complete duration of schema initialization.

## Related issues
Addresses [issue #].

## Testing
The change is tested by updating nugets in fhir-server and spinning up two fhir instances to ensure one aquires lock and other instance wait and return(without getting hold for lock)

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
