### PR TITLE
Increase timeout on Sql serverConnection

### DIFF
--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -51,5 +51,10 @@ namespace Microsoft.Health.SqlServer.Configs
         /// If set, the client id of the managed identity to use when connecting to SQL, if AuthenticationType == ManagedIdentity.
         /// </summary>
         public string ManagedIdentityClientId { get; set; }
+
+        /// <summary>
+        /// Specifies the statement timeout to set on ServerConnection.
+        /// </summary>
+        public int StatementTimeoutInSecs { get; set; } = 14400;
     }
 }

--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.Health.SqlServer.Configs
 {
     public class SqlServerDataStoreConfiguration
@@ -55,6 +57,6 @@ namespace Microsoft.Health.SqlServer.Configs
         /// <summary>
         /// Specifies the statement timeout to set on ServerConnection.
         /// </summary>
-        public int StatementTimeoutInSecs { get; set; } = 14400;
+        public TimeSpan StatementTimeout { get; set; } = TimeSpan.FromSeconds(14400);
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -55,12 +55,12 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 
                 var server = new Server(serverConnection);
                 var watch = Stopwatch.StartNew();
-                _logger.LogInformation($"Query execution started at {DateTime.UtcNow}");
+                _logger.LogInformation($"Script execution started at {DateTime.UtcNow}");
 
                 server.ConnectionContext.ExecuteNonQuery(script);
 
                 watch.Stop();
-                _logger.LogInformation($"Query execution time is {watch.Elapsed}");
+                _logger.LogInformation($"Script execution time is {watch.Elapsed}");
                 await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (e is SqlException || e is ExecutionFailureException)

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -5,10 +5,14 @@
 
 using System;
 using System.Data;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Extensions;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
@@ -18,12 +22,17 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
     public class SchemaManagerDataStore : ISchemaManagerDataStore
     {
         private readonly ISqlConnectionFactory _sqlConnectionFactory;
+        private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
+        private readonly ILogger<SchemaManagerDataStore> _logger;
 
-        public SchemaManagerDataStore(ISqlConnectionFactory sqlConnectionFactory)
+        public SchemaManagerDataStore(
+            ISqlConnectionFactory sqlConnectionFactory,
+            IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
+            ILogger<SchemaManagerDataStore> logger)
         {
-            EnsureArg.IsNotNull(sqlConnectionFactory);
-
-            _sqlConnectionFactory = sqlConnectionFactory;
+            _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
+            _sqlConnectionFactory = EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
         }
 
         /// <inheritdoc />
@@ -34,7 +43,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 
             using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-            var serverConnection = new ServerConnection(connection);
+            var serverConnection = GetServerConnectionWithTimeout(connection);
 
             try
             {
@@ -45,7 +54,13 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
                 }
 
                 var server = new Server(serverConnection);
+                var watch = Stopwatch.StartNew();
+                _logger.LogInformation($"Query execution started at {DateTime.UtcNow}");
+
                 server.ConnectionContext.ExecuteNonQuery(script);
+
+                watch.Stop();
+                _logger.LogInformation($"Query execution time is {watch.Elapsed}");
                 await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
@@ -145,6 +160,14 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 
             using var command = new SqlCommand(procedureQuery, connection);
             return (int)await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
+        }
+
+        private ServerConnection GetServerConnectionWithTimeout(SqlConnection sqlConnection)
+        {
+            var serverConnection = new ServerConnection(sqlConnection);
+            serverConnection.StatementTimeout = _sqlServerDataStoreConfiguration.StatementTimeoutInSecs;
+            _logger.LogInformation($"ServerConnection timeout sets to {serverConnection.StatementTimeout} seconds");
+            return serverConnection;
         }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -12,6 +12,7 @@ using EnsureThat;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Core;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Extensions;
 using Microsoft.SqlServer.Management.Common;
@@ -55,7 +56,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 
                 var server = new Server(serverConnection);
                 var watch = Stopwatch.StartNew();
-                _logger.LogInformation($"Script execution started at {DateTime.UtcNow}");
+                _logger.LogInformation($"Script execution started at {Clock.UtcNow}");
 
                 server.ConnectionContext.ExecuteNonQuery(script);
 
@@ -165,7 +166,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
         private ServerConnection GetServerConnectionWithTimeout(SqlConnection sqlConnection)
         {
             var serverConnection = new ServerConnection(sqlConnection);
-            serverConnection.StatementTimeout = _sqlServerDataStoreConfiguration.StatementTimeoutInSecs;
+            serverConnection.StatementTimeout = (int)_sqlServerDataStoreConfiguration.StatementTimeout.TotalSeconds;
             _logger.LogInformation($"ServerConnection timeout sets to {serverConnection.StatementTimeout} seconds");
             return serverConnection;
         }

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Health.SqlServer.Registration
                     var schemaManagerDataStore = p.GetService<IReadOnlySchemaManagerDataStore>() as SchemaManagerDataStore;
                     return schemaManagerDataStore != null
                         ? schemaManagerDataStore
-                        : new SchemaManagerDataStore(p.GetRequiredService<ISqlConnectionFactory>());
+                        : new SchemaManagerDataStore(p.GetRequiredService<ISqlConnectionFactory>(), p.GetRequiredService<IOptions<SqlServerDataStoreConfiguration>>(), p.GetRequiredService<ILogger<SchemaManagerDataStore>>());
                 });
 
             return services;

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/Manager/BaseSchemaRunnerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/Manager/BaseSchemaRunnerTests.cs
@@ -6,6 +6,8 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Exceptions;
 using Xunit;
@@ -22,7 +24,8 @@ namespace Microsoft.Health.SqlServer.Tests.Integration.Features.Schema.Manager
             : base(output)
         {
             var sqlConnectionFactory = new DefaultSqlConnectionFactory(ConnectionStringProvider);
-            _dataStore = new SchemaManagerDataStore(sqlConnectionFactory);
+            var config = Options.Create(new SqlServerDataStoreConfiguration());
+            _dataStore = new SchemaManagerDataStore(sqlConnectionFactory, config, NullLogger<SchemaManagerDataStore>.Instance);
 
             _runner = new BaseSchemaRunner(sqlConnectionFactory, _dataStore, ConnectionStringProvider, NullLogger<BaseSchemaRunner>.Instance);
         }

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using Microsoft.SqlServer.Management.Common;
@@ -32,7 +34,8 @@ namespace Microsoft.Health.SqlServer.Tests.Integration.Features.Schema
 
             var connectionFactory = Substitute.For<ISqlConnectionFactory>();
             connectionFactory.GetSqlConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs((x) => GetSqlConnection());
-            _schemaDataStore = new SchemaManagerDataStore(connectionFactory);
+            var config = Options.Create(new SqlServerDataStoreConfiguration());
+            _schemaDataStore = new SchemaManagerDataStore(connectionFactory, config, NullLogger<SchemaManagerDataStore>.Instance);
             _runner = new SchemaUpgradeRunner(new ScriptProvider<SchemaVersion>(), new BaseScriptProvider(), NullLogger<SchemaUpgradeRunner>.Instance, connectionFactory, _schemaDataStore);
         }
 

--- a/test/Microsoft.Health.SqlServer.Web/Properties/launchSettings.json
+++ b/test/Microsoft.Health.SqlServer.Web/Properties/launchSettings.json
@@ -8,7 +8,7 @@
             "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true",
             "SqlServer:AllowDatabaseCreation": "false",
             "SqlServer:ConnectionString": "server=(local);Initial Catalog=SHARED_HEALTHCARE;Integrated Security=true",
-            "SqlServer:StatementTimeoutInSecs": "14400" // 4hrs
+            "SqlServer:StatementTimeout": "04:00:00"
         },
       "applicationUrl": "https://localhost:63637/"
     }

--- a/test/Microsoft.Health.SqlServer.Web/Properties/launchSettings.json
+++ b/test/Microsoft.Health.SqlServer.Web/Properties/launchSettings.json
@@ -2,13 +2,14 @@
   "profiles": {
     "Microsoft.Health.SqlServer.Web": {
       "commandName": "Project",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "development",
-        "SqlServer:Initialize": "false",
-        "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true",
-        "SqlServer:AllowDatabaseCreation": "false",
-        "SqlServer:ConnectionString": "server=(local);Initial Catalog=SHARED_HEALTHCARE;Integrated Security=true"
-      },
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "development",
+            "SqlServer:Initialize": "false",
+            "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true",
+            "SqlServer:AllowDatabaseCreation": "false",
+            "SqlServer:ConnectionString": "server=(local);Initial Catalog=SHARED_HEALTHCARE;Integrated Security=true",
+            "SqlServer:StatementTimeoutInSecs": "14400" // 4hrs
+        },
       "applicationUrl": "https://localhost:63637/"
     }
   }


### PR DESCRIPTION
## Description
This PR sets the explicit statement timeout on ServerConnection. The default timeout is 10 mins which is not enough for few long running statements in the migration scripts.

## Related issues
Addresses [#86103](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=86103)

## Testing
This is tested manually by upgrading the schema for 1TB database from schema version 17 to 19.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
