### PR TITLE
Update SchemaInitializer.cs to use ConnectionFactory

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
             if (_sqlServerDataStoreConfiguration.SchemaOptions.AutomaticUpdatesEnabled)
             {
-                IDistributedLock sqlLock = new SqlDistributedLock(SchemaUpgradeLockName, await _sqlConnectionStringProvider.GetSqlConnectionString(cancellationToken));
+                IDistributedLock sqlLock = new SqlDistributedLock(SchemaUpgradeLockName, await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken));
 
                 try
                 {
@@ -136,14 +136,12 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                 catch (SqlException e) when (e.Number == SqlErrorCodes.KilledSessionState)
                 {
                     _logger.LogWarning("Schema upgrade lock was not acquired because the session is in the kill state, skipping");
-                    return;
                 }
 
                 // This exception sometimes occurs at Medallion.Threading.Internal.Data.MultiplexedConnectionLock.ReleaseAsync
                 catch (SqlException e) when (e.Message.Contains("The connection is broken and recovery is not possible.", StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogWarning($"Error occurred during multiplexed release lock");
-                    return;
                 }
             }
         }


### PR DESCRIPTION
## Description
This PR updates the `SchemaInitializer.cs` to use a `SqlConnection` instead of a `ConnectionString` to get a distributed lock. This will enable the `SqlDistributedLock` to use managed identity.

## Related issues
Addresses [AB#86546](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/86546).

## Testing
Describe how this change was tested.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch