### PR TITLE
Update SchemaInitializer.cs to open connection before lock acquisition.

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -75,7 +75,9 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
             if (_sqlServerDataStoreConfiguration.SchemaOptions.AutomaticUpdatesEnabled)
             {
-                IDistributedLock sqlLock = new SqlDistributedLock(SchemaUpgradeLockName, await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken));
+                using SqlConnection sqlConnection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken);
+                await sqlConnection.OpenAsync(cancellationToken);
+                IDistributedLock sqlLock = new SqlDistributedLock(SchemaUpgradeLockName, sqlConnection);
 
                 try
                 {


### PR DESCRIPTION
## Description
Update SchemaInitializer.cs to open connection before lock acquisition.

## Related issues
Addresses [AB#86546](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/86546).

## Testing
Manually pulled latest to local dicom-server.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch
