### PR TITLE
Fix Code Gen Targets File Path for NET 6.0

### DIFF
--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.targets
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.targets
@@ -2,22 +2,24 @@
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <PropertyGroup>
-        <GeneratorPath>$(MSBuildThisFileDirectory)../../tools/$(TargetFramework)/Microsoft.Health.Extensions.BuildTimeCodeGenerator.dll</GeneratorPath>
-    </PropertyGroup>
+  <PropertyGroup>
+    <ToolTargetFramework>net5.0</ToolTargetFramework>
+    <ToolTargetFramework Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">$(TargetFramework)</ToolTargetFramework>
+    <GeneratorPath>$(MSBuildThisFileDirectory)../../tools/$(ToolTargetFramework)/Microsoft.Health.Extensions.BuildTimeCodeGenerator.dll</GeneratorPath>
+  </PropertyGroup>
 
-    <Target Name="CollectGenerateFilesInputs" BeforeTargets="GenerateFiles">
-        <ItemGroup>
-            <GenerateFilesInputs Include="$(GeneratorPath)" />
-            <GenerateFilesInputs Include="$(MSBuildProjectFile)" />
-            <GenerateFilesInputs Include="$(MSBuildThisFileFullPath)" />
-        </ItemGroup>
-    </Target>
+  <Target Name="CollectGenerateFilesInputs" BeforeTargets="GenerateFiles">
+    <ItemGroup>
+      <GenerateFilesInputs Include="$(GeneratorPath)" />
+      <GenerateFilesInputs Include="$(MSBuildProjectFile)" />
+      <GenerateFilesInputs Include="$(MSBuildThisFileFullPath)" />
+    </ItemGroup>
+  </Target>
 
-    <Target Name="GenerateFiles" BeforeTargets="CoreCompile" Inputs="@(GenerateFilesInputs)" Outputs="@(Generated)">
-        <ItemGroup>
-            <Compile Include="@(Generated)" Condition="!Exists('@(Generated)')" />
-        </ItemGroup>
-        <Exec Command='dotnet "$(GeneratorPath)" --generator-name "%(Generated.Generator)" --output-file "%(Generated.FullPath)" --namespace "%(Generated.Namespace)" %(Generated.Args)' />
-    </Target>
+  <Target Name="GenerateFiles" BeforeTargets="CoreCompile" Inputs="@(GenerateFilesInputs)" Outputs="@(Generated)">
+    <ItemGroup>
+      <Compile Include="@(Generated)" Condition="!Exists('@(Generated)')" />
+    </ItemGroup>
+    <Exec Command='dotnet "$(GeneratorPath)" --generator-name "%(Generated.Generator)" --output-file "%(Generated.FullPath)" --namespace "%(Generated.Namespace)" %(Generated.Args)' />
+  </Target>
 </Project>


### PR DESCRIPTION
## Description
- Change tool path to be less dependent on consuming project `$(TargetFramework)`
- Normalize tabs to 2 spaces

## Related issues
[AB#86627](https://microsofthealth.visualstudio.com/Health/_workitems/edit/86627)

## Testing
Tested locally

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch
