### PR TITLE
Include data dictionary health check response

### DIFF
--- a/src/Microsoft.Health.Api/Registration/ApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Health.Api/Registration/ApplicationBuilderExtensions.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Health.Api.Registration
                                 name = entry.Key,
                                 status = Enum.GetName(typeof(HealthStatus), entry.Value.Status),
                                 description = entry.Value.Description,
+                                data = entry.Value.Data,
+                                exception = entry.Value.Exception,
                             }),
                         });
 

--- a/src/Microsoft.Health.Api/Registration/ApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Health.Api/Registration/ApplicationBuilderExtensions.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Health.Api.Registration
                                 status = Enum.GetName(typeof(HealthStatus), entry.Value.Status),
                                 description = entry.Value.Description,
                                 data = entry.Value.Data,
-                                exception = entry.Value.Exception,
                             }),
                         });
 


### PR DESCRIPTION
## Description
Currently, only some properties of the HealthCheckResult are returned in the HTTP health check response.  Is it OK to include the data dictionary and/or the exception details?  For my usage, the data dictionary suffices so I'm happy to limit this change to that property, if that is more desirable.  

Motiviation:  if the data dictionary property, which is initialized in https://github.com/microsoft/fhir-server/blob/a2eb81ddf251555d5cc72ddf568945163875daf9/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs in the case of a customer CMK error, is propagated to the caller of the health check, then the caller can take appropriate action knowing the cause of the failure.  Note:  It's possible to key off of the description, but that seems less reliable than key'ing off of the data dictionary.

Today, in the above CMK scenario, only the description of the issue is returned in the response.

## Related issues
Azure DevOps 86699

## Testing
To be tested

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
