### PR TITLE
Ensure to publish the Schema notifications even when schema is up-to date and Schema Initializer is called again

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
         public async Task InitializeAsync(bool forceIncrementalSchemaUpgrade = false, CancellationToken cancellationToken = default)
         {
-            bool schemaNotificationSent = false;
+            bool schemaUpgradedNotificationSent = false;
 
             if (!await CanInitializeAsync(cancellationToken).ConfigureAwait(false))
             {
@@ -119,7 +119,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
                             await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, true);
 
-                            schemaNotificationSent = true;
+                            schemaUpgradedNotificationSent = true;
                         }
 
                         // If the current schema version needs to be upgraded
@@ -137,7 +137,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                                 await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, false);
                             }
 
-                            schemaNotificationSent = true;
+                            schemaUpgradedNotificationSent = true;
                         }
                     }
                 }
@@ -154,7 +154,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema
 
                 // Ensure to publish the Schema notifications even when schema is up-to date and Schema Initializer is called again (like restarting FHIR server will call this again)
                 // There is a dependency on this notification in FHIR server to enable some background jobs
-                if (!schemaNotificationSent && _schemaInformation.Current >= _schemaInformation.MinimumSupportedVersion)
+                if (!schemaUpgradedNotificationSent && _schemaInformation.Current >= _schemaInformation.MinimumSupportedVersion)
                 {
                     await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, false);
                 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -145,6 +145,13 @@ namespace Microsoft.Health.SqlServer.Features.Schema
                 {
                     _logger.LogWarning($"Error occurred during multiplexed release lock");
                 }
+
+                // Ensure to publish the Schema notifications even when schema is up-to date and Schema Initializer is called again (like restarting FHIR server will call this again)
+                // There is a dependency on this notification in FHIR server to enable some background jobs
+                if (_schemaInformation.Current >= _schemaInformation.MinimumSupportedVersion)
+                {
+                    await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, false);
+                }
             }
         }
 


### PR DESCRIPTION
## Description
We want to ensure that the Schema notifications event is published when the schema is up-to-date and Initializer is called again. SchemaUpgrade notification is responsible for enabling some background tasks in the FHIR server like ReindexJob Worker. In case when DB's are upgraded with the latest version and the FHIR server is restarted, no notification is sent and that disables a couple of job workers in the FHIR. We want to make sure Schema ready event Is triggered to enable the FHIR server jobs.

## Related issues
Addresses [[86809](https://microsofthealth.visualstudio.com/Health/_workitems/edit/86809)].

## Testing
Local Testing. Pull in this package to the FHIR server and ensure that the notification is published and handled.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
