### PR TITLE
Remove AppendInterpolatedStringHandler IndentedStringBuilder Methods

### DIFF
--- a/src/Microsoft.Health.SqlServer/IndentedStringBuilder.Generated.net6.0.cs
+++ b/src/Microsoft.Health.SqlServer/IndentedStringBuilder.Generated.net6.0.cs
@@ -133,14 +133,6 @@ namespace Microsoft.Health.SqlServer
         }
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        public IndentedStringBuilder Append(System.IFormatProvider provider, [System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("", "provider")] ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
-        {
-            AppendIndent();
-            _inner.Append(provider, ref handler);
-            return this;
-        }
-
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
         public IndentedStringBuilder Append(System.Int16 value)
         {
             AppendIndent();
@@ -225,14 +217,6 @@ namespace Microsoft.Health.SqlServer
         {
             AppendIndent();
             _inner.Append(value);
-            return this;
-        }
-
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        public IndentedStringBuilder Append([System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("")] ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
-        {
-            AppendIndent();
-            _inner.Append(ref handler);
             return this;
         }
 
@@ -390,28 +374,10 @@ namespace Microsoft.Health.SqlServer
         }
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        public IndentedStringBuilder AppendLine(System.IFormatProvider provider, [System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("", "provider")] ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
-        {
-            AppendIndent();
-            _inner.AppendLine(provider, ref handler);
-            _indentPending = true;
-            return this;
-        }
-
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
         public IndentedStringBuilder AppendLine(System.String value)
         {
             AppendIndent();
             _inner.AppendLine(value);
-            _indentPending = true;
-            return this;
-        }
-
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        public IndentedStringBuilder AppendLine([System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("")] ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
-        {
-            AppendIndent();
-            _inner.AppendLine(ref handler);
             _indentPending = true;
             return this;
         }

--- a/src/Microsoft.Health.SqlServer/IndentedStringBuilder.Generated.net6.0.cs
+++ b/src/Microsoft.Health.SqlServer/IndentedStringBuilder.Generated.net6.0.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Health.SqlServer
         }
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        public IndentedStringBuilder Append(System.IFormatProvider provider, ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
+        public IndentedStringBuilder Append(System.IFormatProvider provider, [System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("", "provider")] ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
         {
             AppendIndent();
             _inner.Append(provider, ref handler);
@@ -229,7 +229,7 @@ namespace Microsoft.Health.SqlServer
         }
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        public IndentedStringBuilder Append(ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
+        public IndentedStringBuilder Append([System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("")] ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
         {
             AppendIndent();
             _inner.Append(ref handler);
@@ -390,7 +390,7 @@ namespace Microsoft.Health.SqlServer
         }
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        public IndentedStringBuilder AppendLine(System.IFormatProvider provider, ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
+        public IndentedStringBuilder AppendLine(System.IFormatProvider provider, [System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("", "provider")] ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
         {
             AppendIndent();
             _inner.AppendLine(provider, ref handler);
@@ -408,7 +408,7 @@ namespace Microsoft.Health.SqlServer
         }
 
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-        public IndentedStringBuilder AppendLine(ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
+        public IndentedStringBuilder AppendLine([System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("")] ref System.Text.StringBuilder.AppendInterpolatedStringHandler handler)
         {
             AppendIndent();
             _inner.AppendLine(ref handler);

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/DelegatingInterfaceImplementationGenerator.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/DelegatingInterfaceImplementationGenerator.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator
     /// Generates a class that implements one or more interfaces, delegating implementation to an inner field.
     /// Implementations are explicit.
     /// </summary>
-    public class DelegatingInterfaceImplementationGenerator : ICodeGenerator
+    internal class DelegatingInterfaceImplementationGenerator : ICodeGenerator
     {
         internal const string DeclaringTypeKind = "DeclaringType";
         private readonly SyntaxTokenList _typeModifiers;

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/IndentedStringBuilderGenerator.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/IndentedStringBuilderGenerator.cs
@@ -69,6 +69,12 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator
                     return IncompleteMember();
                 }
 
+                if (node.ParameterList.Parameters.Any(p => p.Identifier.ValueText == "handler"))
+                {
+                    // skip methods that use the AppendInterpolatedStringHandler
+                    return IncompleteMember();
+                }
+
                 node = node
                     .WithExplicitInterfaceSpecifier(null)
                     .AddModifiers(Token(SyntaxKind.PublicKeyword));

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.csproj
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.0" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.5282.3" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.2.0-alpha.19174.3" />
   </ItemGroup>

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/ParameterExtensions.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/ParameterExtensions.cs
@@ -1,0 +1,123 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator
+{
+    internal static class ParameterExtensions
+    {
+        public static ParameterSyntax WithOptionalAttributeLists(this ParameterSyntax parameter, IEnumerable<CustomAttributeData> attributes)
+        {
+            // Skip internal attributes which are not meant to be used by developers
+            // but may be discovered using reflection.
+            // TODO: Enable nullability attributes once the repository uses a nullable-aware context
+            List<CustomAttributeData> eligibleAttributes = attributes
+                .Where(x =>
+
+                    // Used internally to record whether a reference type may be nullable
+                    // Developers should use "?" instead
+                    x.AttributeType.FullName != "System.Runtime.CompilerServices.NullableAttribute" &&
+
+                    // Used internally for "params" parameters
+                    x.AttributeType != typeof(ParamArrayAttribute) &&
+
+                    // Below are public attributes used by developer
+                    x.AttributeType != typeof(AllowNullAttribute) &&
+                    x.AttributeType != typeof(DisallowNullAttribute) &&
+                    x.AttributeType != typeof(MaybeNullAttribute) &&
+                    x.AttributeType != typeof(NotNullAttribute) &&
+                    x.AttributeType != typeof(MaybeNullWhenAttribute) &&
+                    x.AttributeType != typeof(NotNullWhenAttribute) &&
+                    x.AttributeType != typeof(NotNullIfNotNullAttribute) &&
+                    x.AttributeType != typeof(DoesNotReturnIfAttribute))
+                .ToList();
+
+            return eligibleAttributes.Count > 0 ? parameter.WithAttributeLists(GetAttributeList(eligibleAttributes)) : parameter;
+        }
+
+        private static SyntaxList<AttributeListSyntax> GetAttributeList(this IEnumerable<CustomAttributeData> attributes)
+        {
+            return SyntaxFactory.SingletonList(SyntaxFactory.AttributeList(
+                SyntaxFactory.SeparatedList(
+                    attributes.Select(x => SyntaxFactory.Attribute(
+                        SyntaxFactory.IdentifierName(x.AttributeType.FullName),
+                        SyntaxFactory.AttributeArgumentList(
+                            SyntaxFactory.SeparatedList(
+                                x.ConstructorArguments
+                                    .SelectMany(GetConstructorArguments)
+                                    .Concat(x.NamedArguments.Select(GetNamedAttributeArgument)))))))));
+        }
+
+        private static IEnumerable<AttributeArgumentSyntax> GetConstructorArguments(CustomAttributeTypedArgument arg)
+        {
+            // First check if this is a params ctor argument (cannot be nested)
+            if (arg.ArgumentType.IsArray && arg.Value != null)
+            {
+                foreach (CustomAttributeTypedArgument element in arg.Value as IEnumerable<CustomAttributeTypedArgument>)
+                {
+                    yield return SyntaxFactory.AttributeArgument(default, default, GetExpression(element.Value));
+                }
+            }
+            else
+            {
+                yield return SyntaxFactory.AttributeArgument(default, default, GetExpression(arg.Value));
+            }
+        }
+
+        private static AttributeArgumentSyntax GetNamedAttributeArgument(CustomAttributeNamedArgument arg)
+        {
+            if (arg.IsField)
+            {
+                return SyntaxFactory.AttributeArgument(
+                    SyntaxFactory.NameEquals(
+                        SyntaxFactory.IdentifierName(arg.MemberName),
+                        SyntaxFactory.Token(SyntaxKind.EqualsToken)),
+                    default,
+                    GetExpression(arg.TypedValue.Value));
+            }
+            else
+            {
+                return SyntaxFactory.AttributeArgument(
+                    default,
+                    SyntaxFactory.NameColon(
+                        SyntaxFactory.IdentifierName(arg.MemberName),
+                        SyntaxFactory.Token(SyntaxKind.ColonToken)),
+                    GetExpression(arg.TypedValue.Value));
+            }
+        }
+
+        private static ExpressionSyntax GetExpression(object value)
+        {
+            return value switch
+            {
+                string str => SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(str)),
+                char c => SyntaxFactory.LiteralExpression(SyntaxKind.CharacterLiteralExpression, SyntaxFactory.Literal(c)),
+                byte b => SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(b)),
+                sbyte sb => SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(sb)),
+                short s => SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(s)),
+                ushort us => SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(us)),
+                int i => SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(i)),
+                uint ui => SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(ui)),
+                long l => SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(l)),
+                ulong ul => SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(ul)),
+                float f => SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(f)),
+                double d => SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(d)),
+                decimal m => SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(m)),
+                bool b when b => SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression, SyntaxFactory.Token(SyntaxKind.TrueKeyword)),
+                bool b when !b => SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression, SyntaxFactory.Token(SyntaxKind.FalseKeyword)),
+                null => SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)),
+                _ => throw new ArgumentOutOfRangeException(nameof(value)),
+            };
+        }
+    }
+}

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/ParameterExtensions.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/ParameterExtensions.cs
@@ -47,15 +47,16 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator
 
         private static SyntaxList<AttributeListSyntax> GetAttributeList(this IEnumerable<CustomAttributeData> attributes)
         {
-            return SyntaxFactory.SingletonList(SyntaxFactory.AttributeList(
-                SyntaxFactory.SeparatedList(
-                    attributes.Select(x => SyntaxFactory.Attribute(
-                        SyntaxFactory.IdentifierName(x.AttributeType.FullName),
-                        SyntaxFactory.AttributeArgumentList(
-                            SyntaxFactory.SeparatedList(
-                                x.ConstructorArguments
-                                    .SelectMany(GetConstructorArguments)
-                                    .Concat(x.NamedArguments.Select(GetNamedAttributeArgument)))))))));
+            return SyntaxFactory.SingletonList(
+                SyntaxFactory.AttributeList(
+                    SyntaxFactory.SeparatedList(
+                        attributes.Select(x => SyntaxFactory.Attribute(
+                            SyntaxFactory.IdentifierName(x.AttributeType.FullName),
+                            SyntaxFactory.AttributeArgumentList(
+                                SyntaxFactory.SeparatedList(
+                                    x.ConstructorArguments
+                                        .SelectMany(GetConstructorArguments)
+                                        .Concat(x.NamedArguments.Select(GetNamedAttributeArgument)))))))));
         }
 
         private static IEnumerable<AttributeArgumentSyntax> GetConstructorArguments(CustomAttributeTypedArgument arg)

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/ParameterExtensions.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/ParameterExtensions.cs
@@ -23,23 +23,23 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator
             // TODO: Enable nullability attributes once the repository uses a nullable-aware context
             List<CustomAttributeData> eligibleAttributes = attributes
                 .Where(x =>
+                {
+                    // Used internally to record whether a reference type may be nullable. Developers should use '?' instead
+                    return x.AttributeType.FullName != "System.Runtime.CompilerServices.NullableAttribute" &&
 
-                    // Used internally to record whether a reference type may be nullable
-                    // Developers should use "?" instead
-                    x.AttributeType.FullName != "System.Runtime.CompilerServices.NullableAttribute" &&
+                        // Used internally for "params" parameters
+                        x.AttributeType != typeof(ParamArrayAttribute) &&
 
-                    // Used internally for "params" parameters
-                    x.AttributeType != typeof(ParamArrayAttribute) &&
-
-                    // Below are public attributes used by developer
-                    x.AttributeType != typeof(AllowNullAttribute) &&
-                    x.AttributeType != typeof(DisallowNullAttribute) &&
-                    x.AttributeType != typeof(MaybeNullAttribute) &&
-                    x.AttributeType != typeof(NotNullAttribute) &&
-                    x.AttributeType != typeof(MaybeNullWhenAttribute) &&
-                    x.AttributeType != typeof(NotNullWhenAttribute) &&
-                    x.AttributeType != typeof(NotNullIfNotNullAttribute) &&
-                    x.AttributeType != typeof(DoesNotReturnIfAttribute))
+                        // Public attributes used by developers for aiding in static code analysis
+                        x.AttributeType != typeof(AllowNullAttribute) &&
+                        x.AttributeType != typeof(DisallowNullAttribute) &&
+                        x.AttributeType != typeof(MaybeNullAttribute) &&
+                        x.AttributeType != typeof(NotNullAttribute) &&
+                        x.AttributeType != typeof(MaybeNullWhenAttribute) &&
+                        x.AttributeType != typeof(NotNullWhenAttribute) &&
+                        x.AttributeType != typeof(NotNullIfNotNullAttribute) &&
+                        x.AttributeType != typeof(DoesNotReturnIfAttribute);
+                })
                 .ToList();
 
             return eligibleAttributes.Count > 0 ? parameter.WithAttributeLists(GetAttributeList(eligibleAttributes)) : parameter;


### PR DESCRIPTION
## Description
- Add support for attributes in code gen!
- Remove any methods for `IndentedStringBuilder` that use `AppendInterpolatedStringHandler` as we should have a version of this type specific to the `IndentedStringBuilder`
  - Its overloads also cause binding ambiguity today when using certain interpolated strings as arguments
- Update SQL package

## Related issues
N/A

## Testing
N/A

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
I'll lump this in the 4.x version and unlist 4.x of sql
