### PR TITLE
Increased SQL server timeout for schema auto-upgrade mechanism

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager
 
             using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-            var server = new Server(new ServerConnection(connection));
+            var server = new Server(GetServerConnectionWithTimeout(connection));
 
             server.ConnectionContext.ExecuteNonQuery(script);
         }


### PR DESCRIPTION
## Description
Increased SQL server timeout for schema auto-upgrade mechanism

## Related issues
Addresses [[86868](https://microsofthealth.visualstudio.com/Health/_workitems/edit/86868)].

## Testing
Manual Testing

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
