### PR TITLE
Make DefaultAzureCredentialOptions configurable

### DIFF
--- a/src/Microsoft.Health.Blob/Configs/BlobDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobDataStoreConfiguration.cs
@@ -20,12 +20,16 @@ namespace Microsoft.Health.Blob.Configs
         /// <summary>
         /// If set, the client id of the managed identity to use when connecting to azure storage, if AuthenticationType == ManagedIdentity.
         /// </summary>
-        public string ManagedIdentityClientId { get; set; }
+        public string ManagedIdentityClientId
+        {
+            get => Credentials.ManagedIdentityClientId;
+            set => Credentials.ManagedIdentityClientId = value;
+        }
 
         /// <summary>
         /// Gets or sets the options for configuring DefaultAzureCredential
         /// </summary>
         /// <value>The settings for configuring the default azure credential</value>
-        public DefaultAzureCredentialOptions DefaultAzureCredentialOptions { get; set; } = new DefaultAzureCredentialOptions();
+        public DefaultAzureCredentialOptions Credentials { get; set; } = new DefaultAzureCredentialOptions();
     }
 }

--- a/src/Microsoft.Health.Blob/Configs/BlobDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobDataStoreConfiguration.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Azure.Identity;
+
 namespace Microsoft.Health.Blob.Configs
 {
     public class BlobDataStoreConfiguration
@@ -19,5 +21,11 @@ namespace Microsoft.Health.Blob.Configs
         /// If set, the client id of the managed identity to use when connecting to azure storage, if AuthenticationType == ManagedIdentity.
         /// </summary>
         public string ManagedIdentityClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the options for configuring DefaultAzureCredential
+        /// </summary>
+        /// <value>The settings for configuring the default azure credential</value>
+        public DefaultAzureCredentialOptions DefaultAzureCredentialOptions { get; set; } = new DefaultAzureCredentialOptions();
     }
 }

--- a/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
@@ -56,7 +56,11 @@ namespace Microsoft.Health.Blob.Configs
         /// This setting should only be set if <see cref="Credential"/> contains the value <c>"managedidentity"</c>.
         /// </remarks>
         /// <value>The client id if using managed identity to authenticate; otherwise, <see langword="null"/>.</value>
-        public string ClientId { get; set; }
+        public string ClientId
+        {
+            get => Credentials.ManagedIdentityClientId;
+            set => Credentials.ManagedIdentityClientId = value;
+        }
 
         /// <summary>
         /// Gets or sets the options for <see cref="BlobServiceClient"/> operations.
@@ -75,6 +79,6 @@ namespace Microsoft.Health.Blob.Configs
         /// Gets or sets the options for configuring DefaultAzureCredential
         /// </summary>
         /// <value>The settings for configuring the default azure credential</value>
-        public DefaultAzureCredentialOptions DefaultAzureCredentialOptions { get; set; } = new DefaultAzureCredentialOptions();
+        public DefaultAzureCredentialOptions Credentials { get; set; } = new DefaultAzureCredentialOptions();
     }
 }

--- a/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Azure.Identity;
 using Azure.Storage.Blobs;
 
 namespace Microsoft.Health.Blob.Configs
@@ -69,5 +70,11 @@ namespace Microsoft.Health.Blob.Configs
         /// </summary>
         /// <value>The settings for configuring the underlying HTTP transport.</value>
         public TransportOverrideOptions TransportOverride { get; set; }
+
+        /// <summary>
+        /// Gets or sets the options for configuring DefaultAzureCredential
+        /// </summary>
+        /// <value>The settings for configuring the default azure credential</value>
+        public DefaultAzureCredentialOptions DefaultAzureCredentialOptions { get; set; } = new DefaultAzureCredentialOptions();
     }
 }

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Health.Blob.Features.Storage
 
             if (configuration.AuthenticationType == BlobDataStoreAuthenticationType.ManagedIdentity)
             {
-                ManagedIdentityCredential credential = new ManagedIdentityCredential(configuration.ManagedIdentityClientId);
+                configuration.DefaultAzureCredentialOptions.ManagedIdentityClientId = configuration.ManagedIdentityClientId;
+                DefaultAzureCredential credential = new DefaultAzureCredential(configuration.DefaultAzureCredentialOptions);
 
                 return new BlobServiceClient(new Uri(configuration.ConnectionString), credential, blobClientOptions);
             }

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
@@ -26,8 +26,7 @@ namespace Microsoft.Health.Blob.Features.Storage
 
             if (configuration.AuthenticationType == BlobDataStoreAuthenticationType.ManagedIdentity)
             {
-                configuration.DefaultAzureCredentialOptions.ManagedIdentityClientId = configuration.ManagedIdentityClientId;
-                DefaultAzureCredential credential = new DefaultAzureCredential(configuration.DefaultAzureCredentialOptions);
+                DefaultAzureCredential credential = new DefaultAzureCredential(configuration.Credentials);
 
                 return new BlobServiceClient(new Uri(configuration.ConnectionString), credential, blobClientOptions);
             }

--- a/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
+++ b/src/Microsoft.Health.Blob/Features/Storage/BlobClientFactory.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Blob.Features.Storage
 
             if (configuration.AuthenticationType == BlobDataStoreAuthenticationType.ManagedIdentity)
             {
-                DefaultAzureCredential credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = configuration.ManagedIdentityClientId });
+                ManagedIdentityCredential credential = new ManagedIdentityCredential(configuration.ManagedIdentityClientId);
 
                 return new BlobServiceClient(new Uri(configuration.ConnectionString), credential, blobClientOptions);
             }

--- a/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
@@ -132,15 +132,14 @@ namespace Microsoft.Extensions.DependencyInjection
                     if (string.Equals(options.Credential, "managedidentity", StringComparison.OrdinalIgnoreCase))
                     {
                         clientBuilder = builder
-                            .AddBlobServiceClient(new Uri(options.ConnectionString));
+                            .AddBlobServiceClient(new Uri(options.ConnectionString))
+                            .WithCredential(new DefaultAzureCredential(options.Credentials));
                     }
                     else
                     {
                         clientBuilder = builder
                             .AddBlobServiceClient(options.ConnectionString);
                     }
-
-                    clientBuilder = clientBuilder.WithCredential(new DefaultAzureCredential(options.Credentials));
 
                     clientBuilder = clientBuilder.ConfigureOptions(x => configuration.Bind(x));
                     if (configure != null)

--- a/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
@@ -131,11 +131,9 @@ namespace Microsoft.Extensions.DependencyInjection
                     IAzureClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder;
                     if (string.Equals(options.Credential, "managedidentity", StringComparison.OrdinalIgnoreCase))
                     {
-                        options.DefaultAzureCredentialOptions.ManagedIdentityClientId = options.ClientId;
-
                         clientBuilder = builder
                             .AddBlobServiceClient(new Uri(options.ConnectionString))
-                            .WithCredential(new DefaultAzureCredential(options.DefaultAzureCredentialOptions));
+                            .WithCredential(new DefaultAzureCredential(options.Credentials));
                     }
                     else
                     {

--- a/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
@@ -131,9 +131,11 @@ namespace Microsoft.Extensions.DependencyInjection
                     IAzureClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder;
                     if (string.Equals(options.Credential, "managedidentity", StringComparison.OrdinalIgnoreCase))
                     {
+                        options.DefaultAzureCredentialOptions.ManagedIdentityClientId = options.ClientId;
+
                         clientBuilder = builder
                             .AddBlobServiceClient(new Uri(options.ConnectionString))
-                            .WithCredential(new ManagedIdentityCredential(options.ClientId);
+                            .WithCredential(new DefaultAzureCredential(options.DefaultAzureCredentialOptions));
                     }
                     else
                     {

--- a/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     {
                         clientBuilder = builder
                             .AddBlobServiceClient(new Uri(options.ConnectionString))
-                            .WithCredential(new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = options.ClientId }));
+                            .WithCredential(new ManagedIdentityCredential(options.ClientId);
                     }
                     else
                     {

--- a/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Blob/Registration/BlobClientRegistrationExtensions.cs
@@ -132,14 +132,15 @@ namespace Microsoft.Extensions.DependencyInjection
                     if (string.Equals(options.Credential, "managedidentity", StringComparison.OrdinalIgnoreCase))
                     {
                         clientBuilder = builder
-                            .AddBlobServiceClient(new Uri(options.ConnectionString))
-                            .WithCredential(new DefaultAzureCredential(options.Credentials));
+                            .AddBlobServiceClient(new Uri(options.ConnectionString));
                     }
                     else
                     {
                         clientBuilder = builder
                             .AddBlobServiceClient(options.ConnectionString);
                     }
+
+                    clientBuilder = clientBuilder.WithCredential(new DefaultAzureCredential(options.Credentials));
 
                     clientBuilder = clientBuilder.ConfigureOptions(x => configuration.Bind(x));
                     if (configure != null)


### PR DESCRIPTION
## Description
DefaultAzureCredentialOptions added to the configurations - now for deploy we can specify which authentication flows should be used. So for testing, any auth can be used, but prod can specify to use a single authentication flow.

## Related issues
Addresses #87826.

## Testing
Tested that config would pick up changes made in dicom app settings

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking
