### PR TITLE
Adds SQL error code

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorCodes.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorCodes.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Health.SqlServer.Features.Storage
         private const int CustomErrorCodeBase = 50000;
 
         /// <summary>
+        /// Client error
+        /// </summary>
+        public const int BadRequest = CustomErrorCodeBase + 400;
+
+        /// <summary>
         /// A resource was not found
         /// </summary>
         public const int NotFound = CustomErrorCodeBase + 404;


### PR DESCRIPTION
## Description
[PR #2457](https://github.com/microsoft/fhir-server/pull/2457) in the [fhir-server repo](https://github.com/microsoft/fhir-server) modifies the `UpsertResource` stored procedure to return 400 Bad Request when no `if-match` header is provided for an update request and the versioning policy is set to "versioned-update".

This PR adds the error code as a constant, so it can be used in `SqlServerFhirDataStore.cs`.

## Related issues
Addresses [AB#88286](https://microsofthealth.visualstudio.com/Health/_workitems/edit/88286).

## Testing
Ran the FHIR server locally with the changes following [these steps](https://microsoft.sharepoint.com/teams/msh/_layouts/OneNote.aspx?id=%2Fteams%2Fmsh%2FShared%20Documents%2FNotebooks%2FResolute%20Engineering&wd=target%28Operations%2FHow%20to.one%7CD4D99CD6-8FB8-492B-ADE2-F4FCCDCDD552%2FTest%20the%20OSS%20FHIR%20server%20locally%20with%20local%20healthcare%20shared%7C6F4A6358-9CF0-4A6C-8B12-4B6B00A104E0%2F%29)

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
None (small backwards compatible change)
