### PR TITLE
Schema Manager Propogate errors and check current version

### DIFF
--- a/tools/SchemaManager.Core/ISchemaManager.cs
+++ b/tools/SchemaManager.Core/ISchemaManager.cs
@@ -40,5 +40,12 @@ namespace SchemaManager.Core
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A list of the current schema versions from the service.</returns>
         public Task<IList<CurrentVersion>> GetCurrentSchema(string connectionString, Uri server, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets the latest schema version of the service.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The latest version on the server</returns>
+        public Task<int> GetLatestSchema(CancellationToken cancellationToken = default);
     }
 }

--- a/tools/SchemaManager.Core/ISchemaManager.cs
+++ b/tools/SchemaManager.Core/ISchemaManager.cs
@@ -42,7 +42,7 @@ namespace SchemaManager.Core
         public Task<IList<CurrentVersion>> GetCurrentSchema(string connectionString, Uri server, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Gets the latest schema version of the service.
+        /// Gets the latest schema version of the db.
         /// </summary>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The latest version on the server</returns>

--- a/tools/SchemaManager.Core/SqlSchemaManager.cs
+++ b/tools/SchemaManager.Core/SqlSchemaManager.cs
@@ -179,7 +179,6 @@ namespace SchemaManager.Core
                 if (ex is SqlException || ex is ExecutionFailureException)
                 {
                     _logger.LogError(ex, "Script execution has failed.");
-                    return;
                 }
 
                 throw;
@@ -303,6 +302,13 @@ namespace SchemaManager.Core
             {
                 throw new SchemaManagerException(string.Format(CultureInfo.InvariantCulture, Resources.InvalidVersionMessage, version));
             }
+        }
+
+        public async Task<int> GetLatestSchema(CancellationToken cancellationToken = default)
+        {
+            int latestVersion = await _schemaManagerDataStore.GetCurrentSchemaVersionAsync(cancellationToken);
+            _logger.LogInformation("Latest schema version in db is : {Version}", latestVersion);
+            return latestVersion;
         }
     }
 }


### PR DESCRIPTION
## Description
Fix bug where error was not being propagated and also add a method to return the current schema in the database.

## Related issues
[AB#87894](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/87894)

## Testing
Describe how this change was tested.
Published changes to local nuget feed, built schema-manager image in health paas and tested on personal aks cluster.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
Patch
