### PR TITLE
Reconciles substitution call with package upgrade

### DIFF
--- a/test/Microsoft.Health.Test.Common/Mock.cs
+++ b/test/Microsoft.Health.Test.Common/Mock.cs
@@ -115,10 +115,7 @@ namespace Microsoft.Health.Test.Utilities
                     }
                     else
                     {
-                        object item = parameter.ParameterType.IsInterface ?
-                            Substitute.For(new[] { parameter.ParameterType }, null) :
-                            SubstitutionContext.Current.SubstituteFactory.CreatePartial(new[] { parameter.ParameterType }, null);
-                        arguments.Add(item);
+                        arguments.Add(Substitute.For(new[] { parameter.ParameterType }, Array.Empty<object>()));
                     }
                 }
             }


### PR DESCRIPTION
## Description
Similar to PR [#1299](https://github.com/microsoft/dicom-server/pull/1299) in the dicom-server, this PR passes in an empty array to the substitution call in `Mock.cs`. It also removes a check that is handled in the NSubstitute repo.

## Testing
Copied .pdb and .dll files. and ran fhir-server tests locally.

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/master/docs/Versioning.md))
None (bug fix)
