### PR TITLE
Add SQL Integration Tests to CI

### DIFF
--- a/CredScanSuppressions.json
+++ b/CredScanSuppressions.json
@@ -1,0 +1,9 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+        {
+            "placeholder": "T3stP@ssw0rd",
+            "_justification": "This password is used for accessing a local dockerized SQL Server while testing in build pipelines."
+        }
+    ]
+}

--- a/build/.vsts-template.yml
+++ b/build/.vsts-template.yml
@@ -30,9 +30,8 @@ jobs:
     nuGetVersion: $[dependencies.Semver.outputs['SharedComponentsVersioning.GitVersion.SemVer']]
   steps:
   - template: build.yml
-    parameters:
-      runIntegrationTests: 'true'
       pack: 'false'
+  - template: integration-tests.yml
 
 - job: WindowsBuild
   displayName: 'Build (Windows)'

--- a/build/.vsts-template.yml
+++ b/build/.vsts-template.yml
@@ -30,6 +30,7 @@ jobs:
     nuGetVersion: $[dependencies.Semver.outputs['SharedComponentsVersioning.GitVersion.SemVer']]
   steps:
   - template: build.yml
+    parameters:
       pack: 'false'
   - template: integration-tests.yml
 

--- a/build/.vsts-template.yml
+++ b/build/.vsts-template.yml
@@ -31,6 +31,7 @@ jobs:
   steps:
   - template: build.yml
     parameters:
+      runIntegrationTests: 'true'
       pack: 'false'
 
 - job: WindowsBuild

--- a/build/analyze.yml
+++ b/build/analyze.yml
@@ -23,6 +23,7 @@ steps:
   inputs:
     scanFolder: '$(Build.Repository.LocalPath)'
     outputFormat: 'sarif'
+    suppressionsFile: 'CredScanSuppressions.json'
     verboseOutput: true
 
 - task: SdtReport@2

--- a/build/build.yml
+++ b/build/build.yml
@@ -1,5 +1,4 @@
 parameters:
-  runIntegrationTests: 'false'
   pack: 'true'
 
 steps:
@@ -28,9 +27,6 @@ steps:
       **/*[t|T]est*/*.csproj
       !**/Microsoft.Health.SqlServer.Tests.Integration.csproj
     arguments: '--configuration $(buildConfiguration) --no-build'
-
-- ${{ if eq(parameters.runIntegrationTests, 'true') }}:
-  - template: integration-tests.yml
 
 - ${{ if eq(parameters.pack, 'true') }}:
   - task: DotNetCoreCLI@2

--- a/build/build.yml
+++ b/build/build.yml
@@ -22,19 +22,20 @@ steps:
 - script: docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=T3stP@ssw0rd" -p 1433:1433 -d --rm --name sql-server mcr.microsoft.com/mssql/server:2019-latest
   displayName: 'Start SQL Server'
 
-- bash: for i in {1..6}; do docker exec -it sql-server sh -c "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P T3stP@ssw0rd -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" && break || sleep 5; done
+- bash: for i in {1..6}; do docker exec sql-server sh -c "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P T3stP@ssw0rd -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" && exit 0 || sleep 5; done; exit 1
   displayName: 'Wait for SQL Server'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
   inputs:
     command: test
-    projects: '**/*test*/*.csproj'
+    projects: '**/*[t|T]est*/*.csproj'
     arguments: '--configuration $(buildConfiguration) --no-build'
   env:
     TestSqlConnectionString: 'Server=(local);Persist Security Info=False;User ID=sa;Password=T3stP@ssw0rd;MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true'
 
 - script: docker stop sql-server
+  condition: always()
   displayName: 'Stop SQL Server'
 
 - ${{ if eq(parameters.pack, 'true') }}:

--- a/build/build.yml
+++ b/build/build.yml
@@ -1,12 +1,6 @@
 parameters:
   pack: 'true'
 
-variables:
-  ${{ if eq(Agent.OS, 'Linux') }}:
-    testProjects: '**/*[t|T]est*/*.csproj'
-  ${{ else }}:
-    testProjects: '**/*UnitTests/*.csproj'
-
 steps:
 - task: UseDotNet@2
   displayName: 'Use .NET (global.json)'
@@ -37,7 +31,10 @@ steps:
   displayName: 'dotnet test'
   inputs:
     command: test
-    projects: '$(testProjects)'
+    ${{ if eq(Agent.OS, 'Linux') }}:
+      projects: '**/*[t|T]est*/*.csproj'
+    ${{ else }}:
+      projects: '**/*UnitTests/*.csproj'
     arguments: '--configuration $(buildConfiguration) --no-build'
   ${{ if eq(Agent.OS, 'Linux') }}:
     env:

--- a/build/build.yml
+++ b/build/build.yml
@@ -2,7 +2,7 @@ parameters:
   pack: 'true'
 
 variables:
-  ${{ if eq(variables.Agent.OS, 'Linux') }}:
+  ${{ if eq(Agent.OS, 'Linux') }}:
     testProjects: '**/*[t|T]est*/*.csproj'
   ${{ else }}:
     testProjects: '**/*UnitTests/*.csproj'
@@ -25,26 +25,26 @@ steps:
     command: build
     arguments: '--configuration $(buildConfiguration) -p:AssemblyVersion="$(assemblySemVer)" -p:FileVersion="$(assemblySemFileVer)" -p:InformationalVersion="$(informationalVersion)" -p:ContinuousIntegrationBuild=true'
 
-- ${{ if eq(variables.Agent.OS, 'Linux') }}:
+- ${{ if eq(Agent.OS, 'Linux') }}:
   - script: docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=T3stP@ssw0rd" -p 1433:1433 -d --rm --name sql-server mcr.microsoft.com/mssql/server:2019-latest
     displayName: 'Start SQL Server'
 
-- ${{ if eq(variables.Agent.OS, 'Linux') }}:
+- ${{ if eq(Agent.OS, 'Linux') }}:
   - bash: for i in {1..6}; do docker exec sql-server sh -c "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P T3stP@ssw0rd -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" && exit 0 || sleep 5; done; exit 1
     displayName: 'Wait for SQL Server'
 
-- ${{ if eq(variables.Agent.OS, 'Linux') }}:
+- ${{ if eq(Agent.OS, 'Linux') }}:
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
   inputs:
     command: test
     projects: '$(testProjects)'
     arguments: '--configuration $(buildConfiguration) --no-build'
-  ${{ if eq(variables.Agent.OS, 'Linux') }}:
+  ${{ if eq(Agent.OS, 'Linux') }}:
     env:
       TestSqlConnectionString: 'Server=(local);Persist Security Info=False;User ID=sa;Password=T3stP@ssw0rd;MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true'
 
-- ${{ if eq(variables.Agent.OS, 'Linux') }}:
+- ${{ if eq(Agent.OS, 'Linux') }}:
   - script: docker stop sql-server
     displayName: 'Stop SQL Server'
     condition: always()

--- a/build/build.yml
+++ b/build/build.yml
@@ -19,12 +19,23 @@ steps:
     command: build
     arguments: '--configuration $(buildConfiguration) -p:AssemblyVersion="$(assemblySemVer)" -p:FileVersion="$(assemblySemFileVer)" -p:InformationalVersion="$(informationalVersion)" -p:ContinuousIntegrationBuild=true'
 
+- script: docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=T3stP@ssw0rd" -p 1433:1433 -d --rm --name sql-server mcr.microsoft.com/mssql/server:2019-latest
+  displayName: 'Start SQL Server'
+
+- bash: for i in {1..6}; do docker exec -it sql-server sh -c "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P T3stP@ssw0rd -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" && break || sleep 5; done
+  displayName: 'Wait for SQL Server'
+
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
   inputs:
     command: test
-    projects: '**/*UnitTests/*.csproj'
+    projects: '**/*test*/*.csproj'
     arguments: '--configuration $(buildConfiguration) --no-build'
+  env:
+    TestSqlConnectionString: 'Server=(local);Persist Security Info=False;User ID=sa;Password=T3stP@ssw0rd;MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true'
+
+- script: docker stop sql-server
+  displayName: 'Stop SQL Server'
 
 - ${{ if eq(parameters.pack, 'true') }}:
   - task: DotNetCoreCLI@2

--- a/build/build.yml
+++ b/build/build.yml
@@ -33,7 +33,6 @@ steps:
   - bash: for i in {1..6}; do docker exec sql-server sh -c "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P T3stP@ssw0rd -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" && exit 0 || sleep 5; done; exit 1
     displayName: 'Wait for SQL Server'
 
-- ${{ if eq(Agent.OS, 'Linux') }}:
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
   inputs:

--- a/build/build.yml
+++ b/build/build.yml
@@ -1,6 +1,12 @@
 parameters:
   pack: 'true'
 
+variables:
+  ${{ if eq(variables.Agent.OS, 'Linux') }}:
+    testProjects: '**/*[t|T]est*/*.csproj'
+  ${{ else }}:
+    testProjects: '**/*UnitTests/*.csproj'
+
 steps:
 - task: UseDotNet@2
   displayName: 'Use .NET (global.json)'
@@ -19,24 +25,29 @@ steps:
     command: build
     arguments: '--configuration $(buildConfiguration) -p:AssemblyVersion="$(assemblySemVer)" -p:FileVersion="$(assemblySemFileVer)" -p:InformationalVersion="$(informationalVersion)" -p:ContinuousIntegrationBuild=true'
 
-- script: docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=T3stP@ssw0rd" -p 1433:1433 -d --rm --name sql-server mcr.microsoft.com/mssql/server:2019-latest
-  displayName: 'Start SQL Server'
+- ${{ if eq(variables.Agent.OS, 'Linux') }}:
+  - script: docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=T3stP@ssw0rd" -p 1433:1433 -d --rm --name sql-server mcr.microsoft.com/mssql/server:2019-latest
+    displayName: 'Start SQL Server'
 
-- bash: for i in {1..6}; do docker exec sql-server sh -c "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P T3stP@ssw0rd -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" && exit 0 || sleep 5; done; exit 1
-  displayName: 'Wait for SQL Server'
+- ${{ if eq(variables.Agent.OS, 'Linux') }}:
+  - bash: for i in {1..6}; do docker exec sql-server sh -c "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P T3stP@ssw0rd -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" && exit 0 || sleep 5; done; exit 1
+    displayName: 'Wait for SQL Server'
 
+- ${{ if eq(variables.Agent.OS, 'Linux') }}:
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
   inputs:
     command: test
-    projects: '**/*[t|T]est*/*.csproj'
+    projects: '$(testProjects)'
     arguments: '--configuration $(buildConfiguration) --no-build'
-  env:
-    TestSqlConnectionString: 'Server=(local);Persist Security Info=False;User ID=sa;Password=T3stP@ssw0rd;MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true'
+  ${{ if eq(variables.Agent.OS, 'Linux') }}:
+    env:
+      TestSqlConnectionString: 'Server=(local);Persist Security Info=False;User ID=sa;Password=T3stP@ssw0rd;MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true'
 
-- script: docker stop sql-server
-  condition: always()
-  displayName: 'Stop SQL Server'
+- ${{ if eq(variables.Agent.OS, 'Linux') }}:
+  - script: docker stop sql-server
+    displayName: 'Stop SQL Server'
+    condition: always()
 
 - ${{ if eq(parameters.pack, 'true') }}:
   - task: DotNetCoreCLI@2

--- a/build/build.yml
+++ b/build/build.yml
@@ -1,4 +1,5 @@
 parameters:
+  runIntegrationTests: 'true'
   pack: 'true'
 
 steps:
@@ -19,31 +20,17 @@ steps:
     command: build
     arguments: '--configuration $(buildConfiguration) -p:AssemblyVersion="$(assemblySemVer)" -p:FileVersion="$(assemblySemFileVer)" -p:InformationalVersion="$(informationalVersion)" -p:ContinuousIntegrationBuild=true'
 
-- ${{ if eq(Agent.OS, 'Linux') }}:
-  - script: docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=T3stP@ssw0rd" -p 1433:1433 -d --rm --name sql-server mcr.microsoft.com/mssql/server:2019-latest
-    displayName: 'Start SQL Server'
-
-- ${{ if eq(Agent.OS, 'Linux') }}:
-  - bash: for i in {1..6}; do docker exec sql-server sh -c "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P T3stP@ssw0rd -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" && exit 0 || sleep 5; done; exit 1
-    displayName: 'Wait for SQL Server'
-
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
   inputs:
     command: test
-    ${{ if eq(Agent.OS, 'Linux') }}:
-      projects: '**/*[t|T]est*/*.csproj'
-    ${{ else }}:
-      projects: '**/*UnitTests/*.csproj'
+    projects: |
+      **/*[t|T]est*/*.csproj
+      !**/Microsoft.Health.SqlServer.Tests.Integration.csproj
     arguments: '--configuration $(buildConfiguration) --no-build'
-  ${{ if eq(Agent.OS, 'Linux') }}:
-    env:
-      TestSqlConnectionString: 'Server=(local);Persist Security Info=False;User ID=sa;Password=T3stP@ssw0rd;MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true'
 
-- ${{ if eq(Agent.OS, 'Linux') }}:
-  - script: docker stop sql-server
-    displayName: 'Stop SQL Server'
-    condition: always()
+- ${{ if eq(parameters.runIntegrationTests, 'true') }}:
+  - template: integration-tests.yml
 
 - ${{ if eq(parameters.pack, 'true') }}:
   - task: DotNetCoreCLI@2

--- a/build/build.yml
+++ b/build/build.yml
@@ -1,5 +1,5 @@
 parameters:
-  runIntegrationTests: 'true'
+  runIntegrationTests: 'false'
   pack: 'true'
 
 steps:

--- a/build/integration-tests.yml
+++ b/build/integration-tests.yml
@@ -1,0 +1,21 @@
+# We create a separate template for these tests because the hosted Windows agents do not support Linux docker containers,
+# and the MS SQL Server team does not provide a docker image whose base image is Windows. Therefore these steps can only run on Linux agents.
+steps:
+- script: docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=T3stP@ssw0rd" -p 1433:1433 -d --rm --name sql-server mcr.microsoft.com/mssql/server:2019-latest
+  displayName: 'Start SQL Server'
+
+- bash: for i in {1..6}; do docker exec sql-server sh -c "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P T3stP@ssw0rd -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" && exit 0 || sleep 5; done; exit 1
+  displayName: 'Wait for SQL Server'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test Microsoft.Health.SqlServer.Tests.Integration.csproj'
+  inputs:
+    command: test
+    projects: '**/Microsoft.Health.SqlServer.Tests.Integration.csproj'
+    arguments: '--configuration $(buildConfiguration) --no-build'
+    env:
+      TestSqlConnectionString: 'Server=(local);Persist Security Info=False;User ID=sa;Password=T3stP@ssw0rd;MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true'
+
+- script: docker stop sql-server
+  displayName: 'Stop SQL Server'
+  condition: always()

--- a/build/integration-tests.yml
+++ b/build/integration-tests.yml
@@ -13,8 +13,8 @@ steps:
     command: test
     projects: '**/Microsoft.Health.SqlServer.Tests.Integration.csproj'
     arguments: '--configuration $(buildConfiguration) --no-build'
-    env:
-      TestSqlConnectionString: 'Server=(local);Persist Security Info=False;User ID=sa;Password=T3stP@ssw0rd;MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true'
+  env:
+    TestSqlConnectionString: 'Server=(local);Persist Security Info=False;User ID=sa;Password=T3stP@ssw0rd;MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true'
 
 - script: docker stop sql-server
   displayName: 'Stop SQL Server'

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/SqlIntegrationTestBase.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/SqlIntegrationTestBase.cs
@@ -21,9 +21,14 @@ public abstract class SqlIntegrationTestBase : IAsyncLifetime
     {
         Output = outputHelper;
         DatabaseName = $"IntegrationTests_BaseSchemaRunner_{Guid.NewGuid().ToString().Replace("-", string.Empty)}";
+        var builder = new SqlConnectionStringBuilder(Environment.GetEnvironmentVariable("TestSqlConnectionString") ?? $"server=(local);Integrated Security=true")
+        {
+            InitialCatalog = DatabaseName
+        };
+
         Config = new SqlServerDataStoreConfiguration
         {
-            ConnectionString = Environment.GetEnvironmentVariable("TestSqlConnectionString") ?? $"server=(local);Initial Catalog={DatabaseName};Integrated Security=true",
+            ConnectionString = builder.ToString(),
             AllowDatabaseCreation = true,
         };
 


### PR DESCRIPTION
## Description
- Run all tests in PR and CI pipelines
- Use dockerized SQL Server for integration tests

## Related issues
N/A

## Testing
Pipeline

## Semver Change ([docs](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md))
+semver: patch
