### PR TITLE
Add Logger for XUnit

### DIFF
--- a/test/Microsoft.Health.Test.Common.Tests/Logging/XUnitLoggerTests.cs
+++ b/test/Microsoft.Health.Test.Common.Tests/Logging/XUnitLoggerTests.cs
@@ -1,0 +1,43 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Health.Test.Utilities.UnitTests.Logging;
+
+public class XUnitLoggerTests : IClassFixture<LoggingFixture>
+{
+    private readonly ILogger<LoggingFixture> _logger;
+
+    public XUnitLoggerTests(ITestOutputHelper outputHelper)
+    {
+        _logger = new ServiceCollection()
+            .AddLogging(x => x.AddXUnit(outputHelper))
+            .BuildServiceProvider()
+            .GetRequiredService<ILogger<LoggingFixture>>();
+    }
+
+    [Fact]
+    public void GivenXUnitTest_WhenLogging_ThenWriteWithoutIssue()
+    {
+        _logger.LogInformation("Running test");
+    }
+}
+
+public class LoggingFixture
+{
+    public LoggingFixture(IMessageSink sink)
+    {
+        ILogger<LoggingFixture> logger = new ServiceCollection()
+            .AddLogging(x => x.AddXUnit(sink))
+            .BuildServiceProvider()
+            .GetRequiredService<ILogger<LoggingFixture>>();
+
+        logger.LogInformation("Starting class fixture");
+    }
+}

--- a/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
+++ b/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
@@ -15,4 +15,10 @@
     <ProjectReference Include="..\Microsoft.Health.Test.Common\Microsoft.Health.Test.Utilities.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None >
+  </ItemGroup>
+
 </Project>

--- a/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
+++ b/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
@@ -6,19 +6,20 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Test.Common\Microsoft.Health.Test.Utilities.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None >
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Health.Test.Common.Tests/xunit.runner.json
+++ b/test/Microsoft.Health.Test.Common.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "diagnosticMessages": true
+}

--- a/test/Microsoft.Health.Test.Common.Tests/xunit.runner.json
+++ b/test/Microsoft.Health.Test.Common.Tests/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-    "diagnosticMessages": true
-}

--- a/test/Microsoft.Health.Test.Common/Logging/LoggingRegistrationExtensions.cs
+++ b/test/Microsoft.Health.Test.Common/Logging/LoggingRegistrationExtensions.cs
@@ -1,0 +1,54 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Test.Utilities.Logging;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering new providers on an <see cref="ILoggingBuilder"/> instance.
+/// </summary>
+public static class LoggingRegistrationExtensions
+{
+    /// <summary>
+    /// Adds an <see cref="XUnitLoggerProvider"/> to the <paramref name="builder"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+    /// <param name="sink">A diagnostic message sink.</param>
+    /// <returns>The <see cref="ILoggingBuilder"/> so that additional calls can be chained.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/> or <paramref name="sink"/> is <see langword="null"/>.
+    /// </exception>
+    public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, IMessageSink sink)
+    {
+        EnsureArg.IsNotNull(builder, nameof(builder));
+        EnsureArg.IsNotNull(sink, nameof(sink));
+
+        builder.Services.AddSingleton<ILoggerProvider>(_ => new XUnitLoggerProvider(sink));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an <see cref="XUnitLoggerProvider"/> to the <paramref name="builder"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+    /// <param name="outputHelper">A console-like outputter.</param>
+    /// <returns>The <see cref="ILoggingBuilder"/> so that additional calls can be chained.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/> or <paramref name="outputHelper"/> is <see langword="null"/>.
+    /// </exception>
+    public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, ITestOutputHelper outputHelper)
+    {
+        EnsureArg.IsNotNull(builder, nameof(builder));
+        EnsureArg.IsNotNull(outputHelper, nameof(outputHelper));
+
+        builder.Services.AddSingleton<ILoggerProvider>(_ => new XUnitLoggerProvider(outputHelper));
+        return builder;
+    }
+}

--- a/test/Microsoft.Health.Test.Common/Logging/XUnitLogger.cs
+++ b/test/Microsoft.Health.Test.Common/Logging/XUnitLogger.cs
@@ -1,0 +1,65 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Microsoft.Health.Test.Utilities.Logging;
+
+internal sealed class XUnitLogger : ILogger
+{
+    private readonly string _name;
+    private readonly ITestOutputHelper _outputHelper;
+
+    public XUnitLogger(string name, ITestOutputHelper outputHelper)
+    {
+        _name = name;
+        _outputHelper = EnsureArg.IsNotNull(outputHelper, nameof(outputHelper));
+    }
+
+    // TODO: Support scopes
+    public IDisposable BeginScope<TState>(TState state)
+        => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel)
+        => logLevel != LogLevel.None;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+    {
+        EnsureArg.IsNotNull(formatter, nameof(formatter));
+
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        string message = formatter(state, exception);
+        if (string.IsNullOrEmpty(message))
+        {
+            return;
+        }
+
+        message = $"{ logLevel }: {_name} [{eventId.Id}] {message}";
+        if (exception != null)
+        {
+            message += Environment.NewLine + Environment.NewLine + exception;
+        }
+
+        _outputHelper.WriteLine(message);
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new NullScope();
+
+        private NullScope()
+        { }
+
+        public void Dispose()
+        { }
+    }
+}

--- a/test/Microsoft.Health.Test.Common/Logging/XUnitLoggerProvider.cs
+++ b/test/Microsoft.Health.Test.Common/Logging/XUnitLoggerProvider.cs
@@ -1,0 +1,61 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Health.Test.Utilities.Logging;
+
+/// <summary>
+/// Represents an <see cref="ILoggerProvider"/> for the XUnit test framework.
+/// </summary>
+public sealed class XUnitLoggerProvider : ILoggerProvider
+{
+    private readonly ITestOutputHelper _outputHelper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XUnitLoggerProvider"/>
+    /// with the specified <see cref="IMessageSink"/>.
+    /// </summary>
+    /// <param name="sink">A sink for diagnostic messages.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="sink"/> is <see langword="null"/>.</exception>
+    public XUnitLoggerProvider(IMessageSink sink)
+        : this(new TestOutputHelperSink(sink))
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XUnitLoggerProvider"/>
+    /// with the specified <see cref="ITestOutputHelper"/>.
+    /// </summary>
+    /// <param name="outputHelper">A console-like outputter.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="outputHelper"/> is <see langword="null"/>.</exception>
+    public XUnitLoggerProvider(ITestOutputHelper outputHelper)
+        => _outputHelper = EnsureArg.IsNotNull(outputHelper, nameof(outputHelper));
+
+    /// <inheritdoc cref="ILoggerProvider.CreateLogger(string)" />
+    public ILogger CreateLogger(string categoryName)
+        => new XUnitLogger(categoryName, _outputHelper);
+
+    /// <inheritdoc cref="IDisposable.Dispose" />
+    public void Dispose()
+    { }
+
+    private sealed class TestOutputHelperSink : ITestOutputHelper
+    {
+        private readonly IMessageSink _sink;
+
+        public TestOutputHelperSink(IMessageSink sink)
+            => _sink = EnsureArg.IsNotNull(sink, nameof(sink));
+
+        public void WriteLine(string message)
+            => _sink.OnMessage(new DiagnosticMessage(message));
+
+        public void WriteLine(string format, params object[] args)
+            => _sink.OnMessage(new DiagnosticMessage(format, args));
+    }
+}

--- a/test/Microsoft.Health.Test.Common/Microsoft.Health.Test.Utilities.csproj
+++ b/test/Microsoft.Health.Test.Common/Microsoft.Health.Test.Utilities.csproj
@@ -3,14 +3,16 @@
   <PropertyGroup>
     <TargetFrameworks>$(SupportedFrameworks)</TargetFrameworks>
     <IsPackable>true</IsPackable>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description
By default, XUnit does not support piping `Console` output to the test framework.
- Add new logger for XUnit diagnostics

## Related issues
N/A

## Testing
Pass pipeline

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
