### PR TITLE
Add More Function Utilities

### DIFF
--- a/src/Microsoft.Health.Operations.Functions.UnitTests/DurableTask/IDurableContextExtensionsTests.cs
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/DurableTask/IDurableContextExtensionsTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Microsoft.Health.Operations.Functions.UnitTests.DurableTask;
 
-public class IDurableOrchestrationContextExtensionsTests
+public class IDurableContextExtensionsTests
 {
     [Theory]
     [InlineData("foo")]
@@ -37,8 +37,29 @@ public class IDurableOrchestrationContextExtensionsTests
 
     [Theory]
     [InlineData("bar")]
+    [InlineData("5e81a27e-3bc0-435e-8ff5-a748203e5306")]
+    public void GivenInvalidIdInActivity_WhenGettingOperationId_ThenThrowFormatException(string instanceId)
+    {
+        IDurableActivityContext context = Substitute.For<IDurableActivityContext>();
+        context.InstanceId.Returns(instanceId);
+
+        Assert.Throws<FormatException>(() => context.GetOperationId());
+    }
+
+    [Fact]
+    public void GivenValidIdInActivity_WhenGettingOperationId_ThenReturnedParsedValue()
+    {
+        Guid expected = Guid.NewGuid();
+        IDurableActivityContext context = Substitute.For<IDurableActivityContext>();
+        context.InstanceId.Returns(expected.ToString(OperationId.FormatSpecifier));
+
+        Assert.Equal(expected, context.GetOperationId());
+    }
+
+    [Theory]
+    [InlineData("baz")]
     [InlineData("ba9a0977-cc48-4bfc-b4c9-f160f82b888a")]
-    public void GivenInvalidId_WhenGettingOperationId_ThenThrowFormatException(string instanceId)
+    public void GivenInvalidIdInOrchestration_WhenGettingOperationId_ThenThrowFormatException(string instanceId)
     {
         IDurableOrchestrationContext context = Substitute.For<IDurableOrchestrationContext>();
         context.InstanceId.Returns(instanceId);
@@ -47,7 +68,7 @@ public class IDurableOrchestrationContextExtensionsTests
     }
 
     [Fact]
-    public void GivenValidId_WhenGettingOperationId_ThenReturnedParsedValue()
+    public void GivenValidIdInOrchestration_WhenGettingOperationId_ThenReturnedParsedValue()
     {
         Guid expected = Guid.NewGuid();
         IDurableOrchestrationContext context = Substitute.For<IDurableOrchestrationContext>();

--- a/src/Microsoft.Health.Operations.Functions.UnitTests/DurableTask/OrchestrationRuntimeStatusExtensionsTests.cs
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/DurableTask/OrchestrationRuntimeStatusExtensionsTests.cs
@@ -1,0 +1,50 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Health.Operations.Functions.DurableTask;
+using Xunit;
+
+namespace Microsoft.Health.Operations.Functions.UnitTests.DurableTask;
+
+public class OrchestrationRuntimeStatusExtensionsTests
+{
+    [Theory]
+    [InlineData(OrchestrationRuntimeStatus.Unknown, false)]
+    [InlineData(OrchestrationRuntimeStatus.Running, true)]
+    [InlineData(OrchestrationRuntimeStatus.Completed, false)]
+    [InlineData(OrchestrationRuntimeStatus.ContinuedAsNew, true)]
+    [InlineData(OrchestrationRuntimeStatus.Failed, false)]
+    [InlineData(OrchestrationRuntimeStatus.Canceled, false)]
+    [InlineData(OrchestrationRuntimeStatus.Terminated, false)]
+    [InlineData(OrchestrationRuntimeStatus.Pending, true)]
+    public void GivenStatus_WhenCheckingIfInProgress_ThenReturnProperValue(OrchestrationRuntimeStatus status, bool expected)
+        => Assert.Equal(expected, status.IsInProgress());
+
+    [Theory]
+    [InlineData(OrchestrationRuntimeStatus.Unknown, false)]
+    [InlineData(OrchestrationRuntimeStatus.Running, false)]
+    [InlineData(OrchestrationRuntimeStatus.Completed, true)]
+    [InlineData(OrchestrationRuntimeStatus.ContinuedAsNew, false)]
+    [InlineData(OrchestrationRuntimeStatus.Failed, true)]
+    [InlineData(OrchestrationRuntimeStatus.Canceled, true)]
+    [InlineData(OrchestrationRuntimeStatus.Terminated, true)]
+    [InlineData(OrchestrationRuntimeStatus.Pending, false)]
+    public void GivenStatus_WhenCheckingIfStopped_ThenReturnProperValue(OrchestrationRuntimeStatus status, bool expected)
+        => Assert.Equal(expected, status.IsStopped());
+
+    [Theory]
+    [InlineData((OrchestrationRuntimeStatus)47, OperationStatus.Unknown)]
+    [InlineData(OrchestrationRuntimeStatus.Unknown, OperationStatus.Unknown)]
+    [InlineData(OrchestrationRuntimeStatus.Running, OperationStatus.Running)]
+    [InlineData(OrchestrationRuntimeStatus.Completed, OperationStatus.Completed)]
+    [InlineData(OrchestrationRuntimeStatus.ContinuedAsNew, OperationStatus.Running)]
+    [InlineData(OrchestrationRuntimeStatus.Failed, OperationStatus.Failed)]
+    [InlineData(OrchestrationRuntimeStatus.Canceled, OperationStatus.Canceled)]
+    [InlineData(OrchestrationRuntimeStatus.Terminated, OperationStatus.Canceled)]
+    [InlineData(OrchestrationRuntimeStatus.Pending, OperationStatus.NotStarted)]
+    public void GivenStatus_WhenConvertingToOperationStatus_ThenReturnCorrespondingValue(OrchestrationRuntimeStatus status, OperationStatus expected)
+        => Assert.Equal(expected, status.ToOperationStatus());
+}

--- a/src/Microsoft.Health.Operations.Functions/DurableTask/IDurableContextExtensions.cs
+++ b/src/Microsoft.Health.Operations.Functions/DurableTask/IDurableContextExtensions.cs
@@ -13,10 +13,22 @@ using Microsoft.Health.Operations.Functions.Management;
 namespace Microsoft.Health.Operations.Functions.DurableTask;
 
 /// <summary>
-/// Provides a set of <see langword="static"/> utility methods for <see cref="IDurableOrchestrationContext"/> objects.
+/// Provides a set of <see langword="static"/> utility methods for <see cref="IDurableOrchestrationContext"/>
+/// and <see cref="IDurableActivityContext"/> objects.
 /// </summary>
-public static class IDurableOrchestrationContextExtensions
+public static class IDurableContextExtensions
 {
+    /// <summary>
+    /// Gets the operation ID encoded as the value of the <see cref="IDurableActivityContext.InstanceId"/> property.
+    /// </summary>
+    /// <param name="context">An orchestration context.</param>
+    /// <returns>The parsed operation ID.</returns>
+    /// <exception cref="FormatException">
+    /// The <see cref="IDurableActivityContext.InstanceId"/> cannot be parsed as an operation ID.
+    /// </exception>
+    public static Guid GetOperationId(this IDurableActivityContext context)
+        => GetOperationId(EnsureArg.IsNotNull(context, nameof(context)).InstanceId);
+
     /// <summary>
     /// Gets the operation ID encoded as the value of the <see cref="IDurableOrchestrationContext.InstanceId"/> property.
     /// </summary>
@@ -26,15 +38,7 @@ public static class IDurableOrchestrationContextExtensions
     /// The <see cref="IDurableOrchestrationContext.InstanceId"/> cannot be parsed as an operation ID.
     /// </exception>
     public static Guid GetOperationId(this IDurableOrchestrationContext context)
-    {
-        EnsureArg.IsNotNull(context, nameof(context));
-        if (!Guid.TryParseExact(context.InstanceId, OperationId.FormatSpecifier, out Guid operationId))
-        {
-            throw new FormatException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidInstanceId, context.InstanceId));
-        }
-
-        return operationId;
-    }
+        => GetOperationId(EnsureArg.IsNotNull(context, nameof(context)).InstanceId);
 
     /// <summary>
     /// Throws a <see cref="FormatException"/> if the value of the <see cref="IDurableOrchestrationContext.InstanceId"/>
@@ -70,4 +74,9 @@ public static class IDurableOrchestrationContextExtensions
 
         return status.CreatedTime;
     }
+
+    private static Guid GetOperationId(string instanceId)
+        => Guid.TryParseExact(instanceId, OperationId.FormatSpecifier, out Guid operationId)
+            ? operationId
+            : throw new FormatException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidInstanceId, instanceId));
 }

--- a/src/Microsoft.Health.Operations.Functions/DurableTask/OrchestrationRuntimeStatusExtensions.cs
+++ b/src/Microsoft.Health.Operations.Functions/DurableTask/OrchestrationRuntimeStatusExtensions.cs
@@ -1,0 +1,61 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+namespace Microsoft.Health.Operations.Functions.DurableTask;
+
+/// <summary>
+/// Provides a set of <see langword="static"/> utility methods for <see cref="OrchestrationRuntimeStatus"/> values.
+/// </summary>
+public static class OrchestrationRuntimeStatusExtensions
+{
+    /// <summary>
+    /// Determines whether the <see cref="OrchestrationRuntimeStatus"/> indicates that the orchestration has not yet finished.
+    /// </summary>
+    /// <remarks><see cref="OrchestrationRuntimeStatus.Unknown"/> is not considered in-progress.</remarks>
+    /// <param name="status">The orchestration's reported status.</param>
+    /// <returns>
+    /// <see langword="true"/> if the orchestration has not yet reached a terminal status; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool IsInProgress(this OrchestrationRuntimeStatus status)
+        => status is OrchestrationRuntimeStatus.Pending or OrchestrationRuntimeStatus.Running or OrchestrationRuntimeStatus.ContinuedAsNew;
+
+    /// <summary>
+    /// Determines whether the <see cref="OrchestrationRuntimeStatus"/> indicates that the orchestration has stopped execution.
+    /// </summary>
+    /// <remarks><see cref="OrchestrationRuntimeStatus.Unknown"/> is not considered stopped.</remarks>
+    /// <param name="status">The orchestration's reported status.</param>
+    /// <returns>
+    /// <see langword="true"/> if the orchestration has reached a terminal status; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool IsStopped(this OrchestrationRuntimeStatus status)
+        => status is OrchestrationRuntimeStatus.Completed
+            or OrchestrationRuntimeStatus.Canceled
+            or OrchestrationRuntimeStatus.Terminated
+            or OrchestrationRuntimeStatus.Failed;
+
+    /// <summary>
+    /// Gets the corresponding <see cref="OperationStatus"/> value for the given
+    /// <see cref="OrchestrationRuntimeStatus"/> value.
+    /// </summary>
+    /// <param name="status">The orchestration's reported status.</param>
+    /// <returns>
+    /// The corresponding <see cref="OperationStatus"/> value or <see cref="OperationStatus.Unknown"/> if the
+    /// given <paramref name="status"/> is not recognized.
+    /// </returns>
+    public static OperationStatus ToOperationStatus(this OrchestrationRuntimeStatus status)
+        => status switch
+        {
+            OrchestrationRuntimeStatus.Running => OperationStatus.Running,
+            OrchestrationRuntimeStatus.Completed => OperationStatus.Completed,
+            OrchestrationRuntimeStatus.ContinuedAsNew => OperationStatus.Running,
+            OrchestrationRuntimeStatus.Failed => OperationStatus.Failed,
+            OrchestrationRuntimeStatus.Canceled => OperationStatus.Canceled,
+            OrchestrationRuntimeStatus.Terminated => OperationStatus.Canceled,
+            OrchestrationRuntimeStatus.Pending => OperationStatus.NotStarted,
+            _ => OperationStatus.Unknown
+        };
+}

--- a/src/Microsoft.Health.Operations.UnitTests/OperationStatusExtensionsTests.cs
+++ b/src/Microsoft.Health.Operations.UnitTests/OperationStatusExtensionsTests.cs
@@ -1,0 +1,31 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Microsoft.Health.Operations.UnitTests;
+
+public class OperationStatusExtensionsTests
+{
+    [Theory]
+    [InlineData(OperationStatus.Unknown, false)]
+    [InlineData(OperationStatus.NotStarted, true)]
+    [InlineData(OperationStatus.Running, true)]
+    [InlineData(OperationStatus.Completed, false)]
+    [InlineData(OperationStatus.Failed, false)]
+    [InlineData(OperationStatus.Canceled, false)]
+    public void GivenStatus_WhenCheckingIfInProgress_ThenReturnProperValue(OperationStatus status, bool expected)
+        => Assert.Equal(expected, status.IsInProgress());
+
+    [Theory]
+    [InlineData(OperationStatus.Unknown, false)]
+    [InlineData(OperationStatus.NotStarted, false)]
+    [InlineData(OperationStatus.Running, false)]
+    [InlineData(OperationStatus.Completed, true)]
+    [InlineData(OperationStatus.Failed, true)]
+    [InlineData(OperationStatus.Canceled, true)]
+    public void GivenStatus_WhenCheckingIfStopped_ThenReturnProperValue(OperationStatus status, bool expected)
+        => Assert.Equal(expected, status.IsStopped());
+}

--- a/src/Microsoft.Health.Operations/OperationStatusExtensions.cs
+++ b/src/Microsoft.Health.Operations/OperationStatusExtensions.cs
@@ -1,0 +1,34 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Operations;
+
+/// <summary>
+/// Provides a set of <see langword="static"/> utility methods for <see cref="OperationStatus"/> values.
+/// </summary>
+public static class OperationStatusExtensions
+{
+    /// <summary>
+    /// Determines whether the <see cref="OperationStatus"/> indicates that the operation has not yet finished.
+    /// </summary>
+    /// <remarks><see cref="OperationStatus.Unknown"/> is not considered in-progress.</remarks>
+    /// <param name="status">The operation's reported status.</param>
+    /// <returns>
+    /// <see langword="true"/> if the operation has not yet reached a terminal status; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool IsInProgress(this OperationStatus status)
+        => status is OperationStatus.NotStarted or OperationStatus.Running;
+
+    /// <summary>
+    /// Determines whether the <see cref="OperationStatus"/> indicates that the operation has stopped execution.
+    /// </summary>
+    /// <remarks><see cref="OperationStatus.Unknown"/> is not considered stopped.</remarks>
+    /// <param name="status">The operation's reported status.</param>
+    /// <returns>
+    /// <see langword="true"/> if the operation has reached a terminal status; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool IsStopped(this OperationStatus status)
+        => status is OperationStatus.Completed or OperationStatus.Canceled or OperationStatus.Failed;
+}

--- a/test/Microsoft.Health.Functions.Tests.Integration/DurableFunctionsTest.cs
+++ b/test/Microsoft.Health.Functions.Tests.Integration/DurableFunctionsTest.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
 using Microsoft.Health.Functions.Examples;
 using Microsoft.Health.Functions.Examples.Sorting;
+using Microsoft.Health.Operations.Functions.DurableTask;
 using Xunit;
 
 namespace Microsoft.Health.Functions.Tests.Integration;
@@ -29,7 +30,7 @@ public class DurableFunctionsTest : IClassFixture<WebJobsTestFixture<Startup>>
             new SortingInput(new int[] { 3, 4, 1, 5, 4, 2 }));
 
         DurableOrchestrationStatus status = await _durableClient.GetStatusAsync(instanceId);
-        while (IsRunning(status.RuntimeStatus))
+        while (status.RuntimeStatus.IsInProgress())
         {
             await Task.Delay(1000);
             status = await _durableClient.GetStatusAsync(instanceId);
@@ -43,10 +44,4 @@ public class DurableFunctionsTest : IClassFixture<WebJobsTestFixture<Startup>>
         Assert.NotNull(actual);
         Assert.True(expected.SequenceEqual(actual!));
     }
-
-    private static bool IsRunning(OrchestrationRuntimeStatus runtimeStatus)
-        => runtimeStatus == OrchestrationRuntimeStatus.Pending
-        || runtimeStatus == OrchestrationRuntimeStatus.Running
-        || runtimeStatus == OrchestrationRuntimeStatus.ContinuedAsNew;
-
 }


### PR DESCRIPTION
## Description
Add more utility methods:
- Get operation IDs within activities more succinctly
- Convert between orchestration and operation statues
- Determine whether a given status is terminal

## Related issues
[AB#87713](https://microsofthealth.visualstudio.com/Health/_workitems/edit/87713)

## Testing
Via unit tests

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
