### PR TITLE
Revise the command timeout to 180 seconds

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlCommandWrapper.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlCommandWrapper.cs
@@ -26,6 +26,7 @@ public class SqlCommandWrapper : IDisposable
         EnsureArg.IsNotNull(sqlCommand, nameof(sqlCommand));
 
         _sqlCommand = sqlCommand;
+        CommandTimeout = 180;
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
We're creating a temporary build for a customer that need to have the default CommandTimeout increased to 180 seconds.

## Related issues
n/a

## Testing
Successfully ran the following tests.
Microsoft.Health.SqlServer.Tests.E2E (net5.0)
﻿Microsoft.Health.SqlServer.Tests.E2E (net6.0)
﻿Microsoft.Health.SqlServer.UnitTests (net5.0)
﻿Microsoft.Health.SqlServer.UnitTests (net6.0)

Refs [AB#89901](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/89901)
+semver: patch
