### PR TITLE
Add config support for SqlCommand CommandTimeout

### DIFF
--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -20,12 +20,12 @@ public class SqlServerDataStoreConfiguration
     public string ConnectionString { get; set; }
 
     /// <summary>
-    /// Allows the experimental schema initializer to attempt to bring the schema to the minimum supported version.
+    /// Allows the schema initializer to attempt to bring the schema to the minimum supported version.
     /// </summary>
     public bool Initialize { get; set; }
 
     /// <summary>
-    /// Allows the experimental schema initializer to attempt to create the database if not present.
+    /// Allows the schema initializer to attempt to create the database if not present.
     /// </summary>
     public bool AllowDatabaseCreation { get; set; }
 
@@ -58,4 +58,9 @@ public class SqlServerDataStoreConfiguration
     /// Specifies the statement timeout to set on ServerConnection.
     /// </summary>
     public TimeSpan StatementTimeout { get; set; } = TimeSpan.FromSeconds(14400);
+
+    /// <summary>
+    /// Specifies the SqlCommand.CommandTimeout
+    /// </summary>
+    public TimeSpan CommandTimeout { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapperFactory.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapperFactory.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.SqlServer.Features.Client;
@@ -16,16 +18,19 @@ public class SqlConnectionWrapperFactory
     private readonly SqlTransactionHandler _sqlTransactionHandler;
     private readonly ISqlConnectionBuilder _sqlConnectionBuilder;
     private readonly SqlRetryLogicBaseProvider _sqlRetryLogicBaseProvider;
+    private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
 
     public SqlConnectionWrapperFactory(
         SqlTransactionHandler sqlTransactionHandler,
         ISqlConnectionBuilder sqlConnectionBuilder,
-        SqlRetryLogicBaseProvider sqlRetryLogicBaseProvider)
+        SqlRetryLogicBaseProvider sqlRetryLogicBaseProvider,
+        IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration)
     {
         EnsureArg.IsNotNull(sqlTransactionHandler, nameof(sqlTransactionHandler));
         EnsureArg.IsNotNull(sqlConnectionBuilder, nameof(sqlConnectionBuilder));
         EnsureArg.IsNotNull(sqlRetryLogicBaseProvider, nameof(sqlRetryLogicBaseProvider));
 
+        _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
         _sqlTransactionHandler = sqlTransactionHandler;
         _sqlConnectionBuilder = sqlConnectionBuilder;
         _sqlRetryLogicBaseProvider = sqlRetryLogicBaseProvider;
@@ -33,7 +38,7 @@ public class SqlConnectionWrapperFactory
 
     public async Task<SqlConnectionWrapper> ObtainSqlConnectionWrapperAsync(CancellationToken cancellationToken, bool enlistInTransaction = false)
     {
-        SqlConnectionWrapper sqlConnectionWrapper = new SqlConnectionWrapper(_sqlTransactionHandler, _sqlConnectionBuilder, _sqlRetryLogicBaseProvider, enlistInTransaction);
+        SqlConnectionWrapper sqlConnectionWrapper = new SqlConnectionWrapper(_sqlTransactionHandler, _sqlConnectionBuilder, _sqlRetryLogicBaseProvider, enlistInTransaction, _sqlServerDataStoreConfiguration);
         await sqlConnectionWrapper.InitializeAsync(cancellationToken);
 
         return sqlConnectionWrapper;


### PR DESCRIPTION
## Description
This revision is to support the ability to handle an incoming configuration for overriding the default SqlCommand.CommandTimeout value which is 30 seconds. We've had customers that have a need to be able to change this to a longer timeout setting than is defaulted.

## Related issues
Addresses [89901](https://microsofthealth.visualstudio.com/Health/_workitems/edit/89901).

## Testing
Locally I ran all tests successfully in the sln except for the following:
Microsoft.Health.Functions.Tests.Integration.DurableFunctionsTest.GivenOrchestration_WhenStarting_ThenCompleteSuccessfully 
Microsoft.Health.SqlServer.Tests.Integration (net5.0) - all 11 failed with same error
Microsoft.Health.SqlServer.Tests.Integration (net6.0) - all 11 failed with same error

The error for the 22 failed tests above is the same and shown below which doesn't appear to be caused by my change.
Microsoft.Data.SqlClient.SqlException : A connection was successfully established with the server, but then an error occurred during the login process. (provider: SSL Provider, error: 0 - The certificate chain was issued by an authority that is not trusted.)
    ---- System.ComponentModel.Win32Exception : The certificate chain was issued by an authority that is not trusted.

Refs [AB#89901](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/89901)
+semver: patch
