### PR TITLE
Fix Orchestration Instance History Purge Range

### DIFF
--- a/src/Microsoft.Health.Operations.Functions.UnitTests/DurableTask/IDurableContextExtensionsTests.cs
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/DurableTask/IDurableContextExtensionsTests.cs
@@ -91,7 +91,7 @@ public class IDurableContextExtensionsTests
         context
             .CallActivityAsync<DurableOrchestrationStatus>(
                 nameof(DurableOrchestrationClientActivity.GetInstanceStatusAsync),
-                Arg.Is<GetInstanceStatusInput>(x => x.InstanceId == operationId))
+                Arg.Any<GetInstanceStatusOptions>())
             .Returns(new DurableOrchestrationStatus { CreatedTime = expected });
 
         // Invoke
@@ -104,7 +104,7 @@ public class IDurableContextExtensionsTests
             .Received(1)
             .CallActivityAsync<DurableOrchestrationStatus>(
                 nameof(DurableOrchestrationClientActivity.GetInstanceStatusAsync),
-                Arg.Is<GetInstanceStatusInput>(x => x.InstanceId == operationId));
+                Arg.Any<GetInstanceStatusOptions>());
     }
 
     [Fact]
@@ -124,7 +124,7 @@ public class IDurableContextExtensionsTests
             .CallActivityWithRetryAsync<DurableOrchestrationStatus>(
                 nameof(DurableOrchestrationClientActivity.GetInstanceStatusAsync),
                 options,
-                Arg.Is<GetInstanceStatusInput>(x => x.InstanceId == operationId))
+                Arg.Any<GetInstanceStatusOptions>())
             .Returns(new DurableOrchestrationStatus { CreatedTime = expected });
 
         // Invoke
@@ -138,6 +138,6 @@ public class IDurableContextExtensionsTests
             .CallActivityWithRetryAsync<DurableOrchestrationStatus>(
                 nameof(DurableOrchestrationClientActivity.GetInstanceStatusAsync),
                 options,
-                Arg.Is<GetInstanceStatusInput>(x => x.InstanceId == operationId));
+                Arg.Any<GetInstanceStatusOptions>());
     }
 }

--- a/src/Microsoft.Health.Operations.Functions.UnitTests/Management/DurableOrchestrationClientActivityTests.cs
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/Management/DurableOrchestrationClientActivityTests.cs
@@ -22,7 +22,7 @@ public class DurableOrchestrationClientActivityTests
 
         IDurableActivityContext context = Substitute.For<IDurableActivityContext>();
         context.InstanceId.Returns(instanceId);
-        context.GetInput<GetInstanceStatusOptions>().Returns(new GetInstanceStatusOptions(false, false, false));
+        context.GetInput<GetInstanceStatusOptions>().Returns(new GetInstanceStatusOptions());
 
         // Note: this scenario should not happen, as an orchestration should be the one invoking this activity!
         IDurableOrchestrationClient client = Substitute.For<IDurableOrchestrationClient>();
@@ -46,7 +46,7 @@ public class DurableOrchestrationClientActivityTests
 
         IDurableActivityContext context = Substitute.For<IDurableActivityContext>();
         context.InstanceId.Returns(instanceId);
-        context.GetInput<GetInstanceStatusOptions>().Returns(new GetInstanceStatusOptions(true, true, false));
+        context.GetInput<GetInstanceStatusOptions>().Returns(new GetInstanceStatusOptions { ShowHistory = true, ShowHistoryOutput = true });
 
         IDurableOrchestrationClient client = Substitute.For<IDurableOrchestrationClient>();
         client.GetStatusAsync(instanceId, true, true, false).Returns(Task.FromResult(expected));

--- a/src/Microsoft.Health.Operations.Functions.UnitTests/Management/DurableOrchestrationClientActivityTests.cs
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/Management/DurableOrchestrationClientActivityTests.cs
@@ -21,7 +21,8 @@ public class DurableOrchestrationClientActivityTests
         string instanceId = OperationId.Generate();
 
         IDurableActivityContext context = Substitute.For<IDurableActivityContext>();
-        context.GetInput<GetInstanceStatusInput>().Returns(new GetInstanceStatusInput(instanceId, false, false, false));
+        context.InstanceId.Returns(instanceId);
+        context.GetInput<GetInstanceStatusOptions>().Returns(new GetInstanceStatusOptions(false, false, false));
 
         // Note: this scenario should not happen, as an orchestration should be the one invoking this activity!
         IDurableOrchestrationClient client = Substitute.For<IDurableOrchestrationClient>();
@@ -32,7 +33,7 @@ public class DurableOrchestrationClientActivityTests
 
         // Assert behavior
         Assert.Null(actual);
-        context.Received(1).GetInput<GetInstanceStatusInput>();
+        context.Received(1).GetInput<GetInstanceStatusOptions>();
         await client.Received(1).GetStatusAsync(instanceId, false, false, false);
     }
 
@@ -44,7 +45,8 @@ public class DurableOrchestrationClientActivityTests
         var expected = new DurableOrchestrationStatus { InstanceId = instanceId };
 
         IDurableActivityContext context = Substitute.For<IDurableActivityContext>();
-        context.GetInput<GetInstanceStatusInput>().Returns(new GetInstanceStatusInput(instanceId, true, true, false));
+        context.InstanceId.Returns(instanceId);
+        context.GetInput<GetInstanceStatusOptions>().Returns(new GetInstanceStatusOptions(true, true, false));
 
         IDurableOrchestrationClient client = Substitute.For<IDurableOrchestrationClient>();
         client.GetStatusAsync(instanceId, true, true, false).Returns(Task.FromResult(expected));
@@ -54,7 +56,7 @@ public class DurableOrchestrationClientActivityTests
 
         // Assert behavior
         Assert.Same(expected, actual);
-        context.Received(1).GetInput<GetInstanceStatusInput>();
+        context.Received(1).GetInput<GetInstanceStatusOptions>();
         await client.Received(1).GetStatusAsync(instanceId, true, true, false);
     }
 }

--- a/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
@@ -47,8 +47,8 @@ public class PurgeOrchestrationInstanceHistoryTests
     {
         _durableClient
             .PurgeInstanceHistoryAsync(
+                DateTime.MinValue,
                 _utcNow.AddDays(-_purgeConfig.MinimumAgeDays),
-                _utcNow,
                 _purgeConfig.Statuses)
             .Returns(new PurgeHistoryResult(deleted));
 
@@ -60,8 +60,8 @@ public class PurgeOrchestrationInstanceHistoryTests
         await _durableClient
             .Received(1)
             .PurgeInstanceHistoryAsync(
+                DateTime.MinValue,
                 _utcNow.AddDays(-_purgeConfig.MinimumAgeDays),
-                _utcNow,
                 _purgeConfig.Statuses);
     }
 }

--- a/src/Microsoft.Health.Operations.Functions/DurableTask/IDurableContextExtensions.cs
+++ b/src/Microsoft.Health.Operations.Functions/DurableTask/IDurableContextExtensions.cs
@@ -67,7 +67,7 @@ public static class IDurableContextExtensions
         // so this value can be preserved in the input or custom status
         EnsureArg.IsNotNull(context, nameof(context));
 
-        var input = new GetInstanceStatusOptions(showHistory: false, showHistoryOutput: false, showInput: false);
+        var input = new GetInstanceStatusOptions { ShowHistory = false, ShowHistoryOutput = false, ShowInput = false };
         DurableOrchestrationStatus status = retryOptions is not null
             ? await context.CallActivityWithRetryAsync<DurableOrchestrationStatus>(nameof(DurableOrchestrationClientActivity.GetInstanceStatusAsync), retryOptions, input)
             : await context.CallActivityAsync<DurableOrchestrationStatus>(nameof(DurableOrchestrationClientActivity.GetInstanceStatusAsync), input);

--- a/src/Microsoft.Health.Operations.Functions/DurableTask/IDurableContextExtensions.cs
+++ b/src/Microsoft.Health.Operations.Functions/DurableTask/IDurableContextExtensions.cs
@@ -67,7 +67,7 @@ public static class IDurableContextExtensions
         // so this value can be preserved in the input or custom status
         EnsureArg.IsNotNull(context, nameof(context));
 
-        var input = new GetInstanceStatusInput(context.InstanceId, showHistory: false, showHistoryOutput: false, showInput: false);
+        var input = new GetInstanceStatusOptions(showHistory: false, showHistoryOutput: false, showInput: false);
         DurableOrchestrationStatus status = retryOptions is not null
             ? await context.CallActivityWithRetryAsync<DurableOrchestrationStatus>(nameof(DurableOrchestrationClientActivity.GetInstanceStatusAsync), retryOptions, input)
             : await context.CallActivityAsync<DurableOrchestrationStatus>(nameof(DurableOrchestrationClientActivity.GetInstanceStatusAsync), input);

--- a/src/Microsoft.Health.Operations.Functions/Management/DurableOrchestrationClientActivity.cs
+++ b/src/Microsoft.Health.Operations.Functions/Management/DurableOrchestrationClientActivity.cs
@@ -39,7 +39,7 @@ public static class DurableOrchestrationClientActivity
 
         logger.LogInformation("Fetching status for orchestration instance ID '{InstanceId}'.", context.InstanceId);
 
-        GetInstanceStatusInput input = context.GetInput<GetInstanceStatusInput>();
-        return client.GetStatusAsync(input.InstanceId, input.ShowHistory, input.ShowHistoryOutput, input.ShowInput);
+        GetInstanceStatusOptions options = context.GetInput<GetInstanceStatusOptions>();
+        return client.GetStatusAsync(context.InstanceId, options.ShowHistory, options.ShowHistoryOutput, options.ShowInput);
     }
 }

--- a/src/Microsoft.Health.Operations.Functions/Management/GetInstanceStatusOptions.cs
+++ b/src/Microsoft.Health.Operations.Functions/Management/GetInstanceStatusOptions.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using EnsureThat;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 
 namespace Microsoft.Health.Operations.Functions.Management;
@@ -12,13 +10,8 @@ namespace Microsoft.Health.Operations.Functions.Management;
 /// <summary>
 /// Represents the input to <see cref="IDurableOrchestrationClient.GetStatusAsync(string, bool, bool, bool)"/>.
 /// </summary>
-public class GetInstanceStatusInput
+public class GetInstanceStatusOptions
 {
-    /// <summary>
-    /// Gets or sets the ID of the orchestration instance to query.
-    /// </summary>
-    public string InstanceId { get; }
-
     /// <summary>
     /// Gets or sets a flag for including execution history in the response.
     /// </summary>
@@ -35,16 +28,13 @@ public class GetInstanceStatusInput
     public bool ShowInput { get; }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="GetInstanceStatusInput"/> class based on the provided arguments.
+    /// Initializes a new instance of the <see cref="GetInstanceStatusOptions"/> class based on the provided arguments.
     /// </summary>
-    /// <param name="instanceId">The ID of the orchestration instance to query.</param>
     /// <param name="showHistory">Indicates whether execution history should be included in the response.</param>
     /// <param name="showHistoryOutput">Indicates whether the input and output should be included in the execution history response.</param>
     /// <param name="showInput">Indicates whether the orchestration input should be included.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="instanceId"/> is <see langword="null"/>.</exception>
-    public GetInstanceStatusInput(string instanceId, bool showHistory = false, bool showHistoryOutput = false, bool showInput = true)
+    public GetInstanceStatusOptions(bool showHistory = false, bool showHistoryOutput = false, bool showInput = true)
     {
-        InstanceId = EnsureArg.IsNotNull(instanceId, nameof(instanceId));
         ShowHistory = showHistory;
         ShowHistoryOutput = showHistoryOutput;
         ShowInput = showInput;

--- a/src/Microsoft.Health.Operations.Functions/Management/GetInstanceStatusOptions.cs
+++ b/src/Microsoft.Health.Operations.Functions/Management/GetInstanceStatusOptions.cs
@@ -15,28 +15,15 @@ public class GetInstanceStatusOptions
     /// <summary>
     /// Gets or sets a flag for including execution history in the response.
     /// </summary>
-    public bool ShowHistory { get; }
+    public bool ShowHistory { get; set; }
 
     /// <summary>
     /// Gets or sets a flag for including input and output in the execution history response.
     /// </summary>
-    public bool ShowHistoryOutput { get; }
+    public bool ShowHistoryOutput { get; set; }
 
     /// <summary>
     /// Gets or sets a flag for including the orchestration input.
     /// </summary>
-    public bool ShowInput { get; }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GetInstanceStatusOptions"/> class based on the provided arguments.
-    /// </summary>
-    /// <param name="showHistory">Indicates whether execution history should be included in the response.</param>
-    /// <param name="showHistoryOutput">Indicates whether the input and output should be included in the execution history response.</param>
-    /// <param name="showInput">Indicates whether the orchestration input should be included.</param>
-    public GetInstanceStatusOptions(bool showHistory = false, bool showHistoryOutput = false, bool showInput = true)
-    {
-        ShowHistory = showHistory;
-        ShowHistoryOutput = showHistoryOutput;
-        ShowInput = showInput;
-    }
+    public bool ShowInput { get; set; }
 }

--- a/src/Microsoft.Health.Operations.Functions/Management/PurgeOrchestrationInstanceHistory.cs
+++ b/src/Microsoft.Health.Operations.Functions/Management/PurgeOrchestrationInstanceHistory.cs
@@ -64,14 +64,12 @@ public sealed class PurgeOrchestrationInstanceHistory
             log.LogWarning("Current function invocation is running late.");
         }
 
-        DateTimeOffset end = Clock.UtcNow;
-        DateTimeOffset start = end - _minimumAge;
-        log.LogInformation("Purging all orchestration instances with status in {{{Statuses}}} that started between '{Start}' and '{End}'",
+        DateTimeOffset end = Clock.UtcNow - _minimumAge;
+        log.LogInformation("Purging all orchestration instances with status in {{{Statuses}}} that started before '{End}'.",
             string.Join(", ", _statuses),
-            start,
             end);
 
-        PurgeHistoryResult result = await client.PurgeInstanceHistoryAsync(start.UtcDateTime, end.UtcDateTime, _statuses);
+        PurgeHistoryResult result = await client.PurgeInstanceHistoryAsync(DateTime.MinValue, end.UtcDateTime, _statuses);
 
         if (result.InstancesDeleted > 0)
         {


### PR DESCRIPTION
## Description
- Fix bug where the history was purged if the job completed within the age, instead of being older than the age (eg. within 20 days vs after 20 days)
- Refactored `GetInstanceStatusAsync` to rely on instance ID from context

## Related issues
N/A

## Testing
Pipeline

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
