### PR TITLE
Personal/v mserdar/85267 handling sqltruncate exception

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -8,6 +8,7 @@ using System.Buffers;
 using System.Data;
 using System.Data.SqlTypes;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
@@ -240,6 +241,7 @@ public class DecimalColumn : Column<decimal>
     public override void Set(SqlDataRecord record, int ordinal, decimal value)
     {
         EnsureArg.IsNotNull(record, nameof(record));
+        ColumnUtilities.ValidateLength(Metadata, value);
         record.SetDecimal(ordinal, value);
     }
 }
@@ -479,6 +481,7 @@ public class NullableDecimalColumn : Column<decimal?>
 
         if (value.HasValue)
         {
+            ColumnUtilities.ValidateLength(Metadata, value.Value);
             record.SetDecimal(ordinal, value.Value);
         }
         else

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -8,7 +8,6 @@ using System.Buffers;
 using System.Data;
 using System.Data.SqlTypes;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
 using EnsureThat;
 using Microsoft.Data.SqlClient;

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/ColumnUtilities.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/ColumnUtilities.cs
@@ -4,7 +4,9 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Data.SqlTypes;
 using System.Globalization;
+using Microsoft.Data.SqlClient.Server;
 
 namespace Microsoft.Health.SqlServer.Features.Schema.Model;
 
@@ -23,6 +25,13 @@ internal static class ColumnUtilities
         else
         {
             throw new ArgumentOutOfRangeException(string.Format(CultureInfo.CurrentCulture, "Precision {0} must be between 1 & 53", precision));
+        }
+    }
+    internal static void ValidateLength(SqlMetaData sqlMetaData, decimal value)
+    {
+        if (((SqlDecimal)value).Precision > sqlMetaData.Precision || ((SqlDecimal)value).Scale > sqlMetaData.Scale)
+        {
+            throw new SqlTruncateException(string.Format(CultureInfo.CurrentCulture, Resources.DecimalValueOutOfRange, value, sqlMetaData.Precision, sqlMetaData.Scale));
         }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.SqlServer/Resources.Designer.cs
@@ -115,6 +115,15 @@ namespace Microsoft.Health.SqlServer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Value {0} is out of range of expected precision of {1} and scale of {2}.
+        /// </summary>
+        internal static string DecimalValueOutOfRange {
+            get {
+                return ResourceManager.GetString("DecimalValueOutOfRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The current version information could not be fetched from the service. Please try again..
         /// </summary>
         internal static string InstanceSchemaRecordErrorMessage {

--- a/src/Microsoft.Health.SqlServer/Resources.resx
+++ b/src/Microsoft.Health.SqlServer/Resources.resx
@@ -136,6 +136,10 @@
   <data name="CurrentSchemaVersionStoredProcedureNotFound" xml:space="preserve">
     <value>Could not find stored procedure 'dbo.SelectCurrentSchemaVersion'.</value>
   </data>
+  <data name="DecimalValueOutOfRange" xml:space="preserve">
+    <value>Value {0} is out of range of expected precision of {1} and scale of {2}.</value>
+    <comment>{0} is the decimal value, {1} is the precision expected and {2} is the scale expected</comment>
+  </data>
   <data name="InstanceSchemaRecordErrorMessage" xml:space="preserve">
     <value>The current version information could not be fetched from the service. Please try again.</value>
   </data>

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Program.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Program.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator;
 
 internal class Program
 {
-    private static HashSet<Assembly> cache = new HashSet<Assembly>();
-
     public static void Main(string generatorName, FileInfo outputFile, string @namespace, string[] args = null)
     {
         string className = Path.GetFileName(outputFile.Name).Split('.')[0];


### PR DESCRIPTION
## Description
This change adds validation to the decimal type. The validation will check that the precision and scale are both valid otherwise throw a SqlTruncateException.

## Related issues
Addresses [85267](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85267).

## Testing
This was tested by creating a local nupkg and using that in the Fhir-Server sln. From there I revised the json for an Observation that included a decimal value that is beyond the precision and scale for the data type.

The below json used was for my http call PUT https://{{hostname}}/Observation/observation-id and correctly returned a BadRequest


**http Response:**
HTTP/1.1 400 Bad Request
Connection: close
Date: Mon, 11 Apr 2022 15:43:38 GMT
Content-Type: application/fhir+json; charset=utf-8
Server: Kestrel
Transfer-Encoding: chunked
X-Request-Id: b57a7705-3793-46b9-8860-e9ca2fce7f58
X-Content-Type-Options: nosniff

{
  "resourceType": "OperationOutcome",
  "id": "b57a7705-3793-46b9-8860-e9ca2fce7f58",
  "meta": {
    "lastUpdated": "2022-04-11T15:43:38.1897302+00:00"
  },
  "issue": [
    {
      "severity": "error",
      "code": "value",
      "diagnostics": "Value 123456789012.0123456 is out of range of expected precision of 18 and scale of 6."
    }
  ]
}

**json used for testing:**
{
  "resourceType": "Observation",
  "id": "observation-id",
    "text": {
        "status": "generated",
        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">"
    },
  "identifier": [
    {
      "use": "official",
      "system": "http://www.bmc.nl/zorgportal/identifiers/observations",
      "value": "6323"
    }
  ],
  "status": "final",
  "code": {
    "coding": [
      {
        "system": "http://loinc.org",
        "code": "15074-8",
        "display": "Glucose [Moles/volume] in Blood"
      }
    ]
  },
  "subject": {
    "reference": "Patient/patient-id",
    "display": "P. van de Heuvel"
  },
  "valueQuantity": {
    "value": 123456789012.0123456,
    "unit": "mmol/l",
    "system": "http://unitsofmeasure.org",
    "code": "mmol/L"
  }
}

Refs [AB#85267](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/85267)
+semver: patch
