### PR TITLE
Throw truncate error if string value too long

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/ColumnsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/ColumnsTests.cs
@@ -29,4 +29,13 @@ public class ColumnsTests
         varBinaryColumn.Set(record, 0, input2);
         Assert.Equal(data2, ((SqlBinary)record.GetSqlValue(0)).Value);
     }
+
+    [Fact]
+    public void GivenStringValueGreaterThanColumnMax_WhenSettingStringValue_ThenSqlTruncateExceptionThrown()
+    {
+        var varCharColumn = new VarCharColumn("text", 10);
+        var record = new SqlDataRecord(varCharColumn.Metadata);
+
+        Assert.Throws<SqlTruncateException>(() => varCharColumn.Set(record, 0, "Astringwhichislongerthan10characters"));
+    }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -8,6 +8,7 @@ using System.Buffers;
 using System.Data;
 using System.Data.SqlTypes;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
@@ -702,6 +703,12 @@ public abstract class StringColumn : Column<string>
     public override void Set(SqlDataRecord record, int ordinal, string value)
     {
         EnsureArg.IsNotNull(record, nameof(record));
+        EnsureArg.IsNotNull(value, nameof(value));
+
+        if (Metadata.MaxLength < value.Length)
+        {
+            throw new SqlTruncateException(string.Format(CultureInfo.CurrentCulture, Resources.StringTooLong, value.Length, Metadata.Name, Metadata.MaxLength));
+        }
 
         if (value != null)
         {

--- a/src/Microsoft.Health.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.SqlServer/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Health.SqlServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Value {0} is out of range of expected precision of {1} and scale of {2}.
+        ///   Looks up a localized string similar to Value {0} is out of range of expected precision of {1} and scale of {2}..
         /// </summary>
         internal static string DecimalValueOutOfRange {
             get {
@@ -192,6 +192,15 @@ namespace Microsoft.Health.SqlServer {
         internal static string ScriptNotFound {
             get {
                 return ResourceManager.GetString("ScriptNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value of length {0} is too long for column {1} with length {2}.
+        /// </summary>
+        internal static string StringTooLong {
+            get {
+                return ResourceManager.GetString("StringTooLong", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.Health.SqlServer/Resources.resx
+++ b/src/Microsoft.Health.SqlServer/Resources.resx
@@ -166,4 +166,8 @@
   <data name="ScriptNotFound" xml:space="preserve">
     <value>The provided version is unknown.</value>
   </data>
+  <data name="StringTooLong" xml:space="preserve">
+    <value>Value of length {0} is too long for column {1} with length {2}</value>
+    <comment>{0} is length of string data, {1} is the name of the column, {2} is the max allowable size of the column</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Description
Compare string length to the max length of the column when setting the value.  Throw truncate error if the value is too long.

## Related issues
Addresses [issue [AB#91346](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/91346)].

## Testing
Unit test was added.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
