### PR TITLE
Reduce Minimum Durable Task Extension Version to 2.6.1

### DIFF
--- a/src/Microsoft.Health.Operations.Functions.UnitTests/Microsoft.Health.Operations.Functions.UnitTests.csproj
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/Microsoft.Health.Operations.Functions.UnitTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(SdkPackageVersion)" />

--- a/src/Microsoft.Health.Operations.Functions/Microsoft.Health.Operations.Functions.csproj
+++ b/src/Microsoft.Health.Operations.Functions/Microsoft.Health.Operations.Functions.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Core" Version="3.0.32" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />

--- a/test/Microsoft.Health.Functions.Examples/Microsoft.Health.Functions.Examples.csproj
+++ b/test/Microsoft.Health.Functions.Examples/Microsoft.Health.Functions.Examples.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Core" Version="3.0.32" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.0" />
   </ItemGroup>
 

--- a/test/Microsoft.Health.Functions.Tests.Integration/Microsoft.Health.Functions.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Functions.Tests.Integration/Microsoft.Health.Functions.Tests.Integration.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.11.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
## Description
- Revert to version 2.6.1

## Related issues
N/A

## Testing
Pipelines

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
