### PR TITLE
Personal/apurvabhale/use sql wrapper

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
@@ -50,7 +50,7 @@ public class SqlServerBaseRegistrationExtensionsTests
         Assert.True(services.ContainsSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>());
         Assert.True(services.ContainsSingleton<SchemaInitializer>());
         Assert.True(services.ContainsSingleton<SchemaJobWorker>());
-        Assert.True(services.ContainsSingleton<SchemaUpgradeRunner>());
+        Assert.True(services.ContainsScoped<SchemaUpgradeRunner>());
         Assert.True(services.ContainsScoped<SchemaManagerDataStore>());
         Assert.True(services.ContainsSingleton<ScriptProvider<ExampleVersion>>());
         Assert.True(services.ContainsSingleton<SqlServerDataStoreConfiguration>());
@@ -86,6 +86,6 @@ public class SqlServerBaseRegistrationExtensionsTests
         Assert.True(services.ContainsScoped<ISchemaManagerDataStore>());
         Assert.True(services.ContainsSingleton<IScriptProvider, ScriptProvider<ExampleVersion>>());
         Assert.True(services.ContainsSingleton<SchemaJobWorker>());
-        Assert.True(services.ContainsSingleton<SchemaUpgradeRunner>());
+        Assert.True(services.ContainsScoped<SchemaUpgradeRunner>());
     }
 }

--- a/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
@@ -44,14 +44,14 @@ public class SqlServerBaseRegistrationExtensionsTests
         Assert.True(services.ContainsSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>());
         Assert.True(services.ContainsSingleton<IBaseScriptProvider, BaseScriptProvider>());
         Assert.True(services.ContainsSingleton<IHostedService, SchemaInitializer>());
-        Assert.True(services.ContainsSingleton<ISchemaManagerDataStore>());
+        Assert.True(services.ContainsScoped<ISchemaManagerDataStore>());
         Assert.True(services.ContainsSingleton<IScriptProvider, ScriptProvider<ExampleVersion>>());
         Assert.True(services.ContainsSingleton<ISqlConnectionBuilder>());
         Assert.True(services.ContainsSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>());
         Assert.True(services.ContainsSingleton<SchemaInitializer>());
         Assert.True(services.ContainsSingleton<SchemaJobWorker>());
         Assert.True(services.ContainsSingleton<SchemaUpgradeRunner>());
-        Assert.True(services.ContainsSingleton<SchemaManagerDataStore>());
+        Assert.True(services.ContainsScoped<SchemaManagerDataStore>());
         Assert.True(services.ContainsSingleton<ScriptProvider<ExampleVersion>>());
         Assert.True(services.ContainsSingleton<SqlServerDataStoreConfiguration>());
     }
@@ -70,7 +70,7 @@ public class SqlServerBaseRegistrationExtensionsTests
         Assert.True(services.ContainsSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>());
         Assert.True(services.ContainsSingleton<ISqlConnectionBuilder>());
         Assert.True(services.ContainsSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>());
-        Assert.True(services.ContainsSingleton<IReadOnlySchemaManagerDataStore, SchemaManagerDataStore>());
+        Assert.True(services.ContainsScoped<IReadOnlySchemaManagerDataStore, SchemaManagerDataStore>());
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class SqlServerBaseRegistrationExtensionsTests
 
         Assert.True(services.ContainsSingleton<IBaseScriptProvider, BaseScriptProvider>());
         Assert.True(services.ContainsSingleton<IHostedService, SchemaInitializer>());
-        Assert.True(services.ContainsSingleton<ISchemaManagerDataStore>());
+        Assert.True(services.ContainsScoped<ISchemaManagerDataStore>());
         Assert.True(services.ContainsSingleton<IScriptProvider, ScriptProvider<ExampleVersion>>());
         Assert.True(services.ContainsSingleton<SchemaJobWorker>());
         Assert.True(services.ContainsSingleton<SchemaUpgradeRunner>());

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -150,8 +150,7 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
             sqlCommandWrapper.Parameters.AddWithValue("@name", objectName);
             sqlCommandWrapper.Parameters.AddWithValue("@type", objectType);
 
-            var test = await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken);
-            return (int)test != 0;
+            return (int)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
         }
     }
 

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -43,34 +43,33 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         EnsureArg.IsNotNull(script, nameof(script));
         EnsureArg.IsGte(version, 1);
 
-        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
-        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
+        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
+
+        var serverConnection = GetServerConnectionWithTimeout(sqlCommandWrapper.Connection);
+
+        try
         {
-            var serverConnection = GetServerConnectionWithTimeout(sqlCommandWrapper.Connection);
-
-            try
+            // FullSchemaSnapshot script(x.sql) inserts 'started' status into the SchemaVersion table itself.
+            if (!applyFullSchemaSnapshot)
             {
-                // FullSchemaSnapshot script(x.sql) inserts 'started' status into the SchemaVersion table itself.
-                if (!applyFullSchemaSnapshot)
-                {
-                    await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.started.ToString(), cancellationToken).ConfigureAwait(false);
-                }
-
-                var server = new Server(serverConnection);
-                var watch = Stopwatch.StartNew();
-                _logger.LogInformation("Script execution started at {UtcTime}", Clock.UtcNow);
-
-                server.ConnectionContext.ExecuteNonQuery(script);
-
-                watch.Stop();
-                _logger.LogInformation("Script execution time is {ElapsedTime}", watch.Elapsed);
-                await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
+                await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.started.ToString(), cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
-            {
-                await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.failed.ToString(), cancellationToken).ConfigureAwait(false);
-                throw;
-            }
+
+            var server = new Server(serverConnection);
+            var watch = Stopwatch.StartNew();
+            _logger.LogInformation("Script execution started at {UtcTime}", Clock.UtcNow);
+
+            server.ConnectionContext.ExecuteNonQuery(script);
+
+            watch.Stop();
+            _logger.LogInformation("Script execution time is {ElapsedTime}", watch.Elapsed);
+            await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
+        {
+            await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.failed.ToString(), cancellationToken).ConfigureAwait(false);
+            throw;
         }
     }
 
@@ -80,29 +79,27 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         EnsureArg.IsNotNull(status, nameof(status));
         EnsureArg.IsGte(version, 1);
 
-        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
-        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
-        {
-            sqlCommandWrapper.CommandText = "DELETE FROM dbo.SchemaVersion WHERE Version = @version AND Status = @status";
-            sqlCommandWrapper.Parameters.AddWithValue("@version", version);
-            sqlCommandWrapper.Parameters.AddWithValue("@status", status);
+        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
+        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
 
-            await sqlCommandWrapper.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
+        sqlCommandWrapper.CommandText = "DELETE FROM dbo.SchemaVersion WHERE Version = @version AND Status = @status";
+        sqlCommandWrapper.Parameters.AddWithValue("@version", version);
+        sqlCommandWrapper.Parameters.AddWithValue("@status", status);
+
+        await sqlCommandWrapper.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task<int> GetCurrentSchemaVersionAsync(CancellationToken cancellationToken)
     {
-        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
-        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
-        {
-            sqlCommandWrapper.CommandType = CommandType.StoredProcedure;
-            sqlCommandWrapper.CommandText = "dbo.SelectCurrentSchemaVersion";
+        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
+        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
 
-            object current = await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-            return (current == null || Convert.IsDBNull(current)) ? 0 : (int)current;
-        }
+        sqlCommandWrapper.CommandType = CommandType.StoredProcedure;
+        sqlCommandWrapper.CommandText = "dbo.SelectCurrentSchemaVersion";
+
+        object current = await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return (current == null || Convert.IsDBNull(current)) ? 0 : (int)current;
     }
 
     private static async Task UpsertSchemaVersionAsync(SqlConnection connection, int version, string status, CancellationToken cancellationToken)
@@ -126,12 +123,11 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
     {
         EnsureArg.IsNotNull(script, nameof(script));
 
-        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
-        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
-        {
-            var server = new Server(GetServerConnectionWithTimeout(sqlCommandWrapper.Connection));
-            server.ConnectionContext.ExecuteNonQuery(script);
-        }
+        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
+        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
+
+        var server = new Server(GetServerConnectionWithTimeout(sqlCommandWrapper.Connection));
+        server.ConnectionContext.ExecuteNonQuery(script);
     }
 
     /// <inheritdoc />
@@ -143,27 +139,25 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
     /// <inheritdoc />
     public async Task<bool> ObjectExistsAsync(string objectName, string objectType, CancellationToken cancellationToken)
     {
-        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
-        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
-        {
-            sqlCommandWrapper.CommandText = "SELECT COUNT(*) FROM sys.objects WHERE name = @name and type = @type";
-            sqlCommandWrapper.Parameters.AddWithValue("@name", objectName);
-            sqlCommandWrapper.Parameters.AddWithValue("@type", objectType);
+        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
+        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
 
-            return (int)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
-        }
+        sqlCommandWrapper.CommandText = "SELECT COUNT(*) FROM sys.objects WHERE name = @name and type = @type";
+        sqlCommandWrapper.Parameters.AddWithValue("@name", objectName);
+        sqlCommandWrapper.Parameters.AddWithValue("@type", objectType);
+
+        return (int)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
     }
 
     /// <inheritdoc />
     public async Task<bool> InstanceSchemaRecordExistsAsync(CancellationToken cancellationToken)
     {
-        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
-        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
-        {
-            sqlCommandWrapper.CommandText = "SELECT COUNT(*) FROM dbo.InstanceSchema";
+        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
+        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
+        
+        sqlCommandWrapper.CommandText = "SELECT COUNT(*) FROM dbo.InstanceSchema";
 
-            return (int)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
-        }
+        return (int)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
     }
 
     private ServerConnection GetServerConnectionWithTimeout(SqlConnection sqlConnection)

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Core;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Extensions;
+using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
 
@@ -22,17 +23,17 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager;
 
 public class SchemaManagerDataStore : ISchemaManagerDataStore
 {
-    private readonly ISqlConnectionBuilder _sqlConnectionBuilder;
+    private readonly SqlConnectionWrapperFactory _sqlConnectionWrapperFactory;
     private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
     private readonly ILogger<SchemaManagerDataStore> _logger;
 
     public SchemaManagerDataStore(
-        ISqlConnectionBuilder sqlConnectionBuilder,
+        SqlConnectionWrapperFactory sqlConnectionWrapperFactory,
         IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
         ILogger<SchemaManagerDataStore> logger)
     {
         _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
-        _sqlConnectionBuilder = EnsureArg.IsNotNull(sqlConnectionBuilder, nameof(sqlConnectionBuilder));
+        _sqlConnectionWrapperFactory = EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));
     }
 
@@ -42,32 +43,34 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         EnsureArg.IsNotNull(script, nameof(script));
         EnsureArg.IsGte(version, 1);
 
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-        var serverConnection = GetServerConnectionWithTimeout(connection);
-
-        try
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
         {
-            // FullSchemaSnapshot script(x.sql) inserts 'started' status into the SchemaVersion table itself.
-            if (!applyFullSchemaSnapshot)
+            var serverConnection = GetServerConnectionWithTimeout(sqlCommandWrapper.Connection);
+
+            try
             {
-                await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.started.ToString(), cancellationToken).ConfigureAwait(false);
+                // FullSchemaSnapshot script(x.sql) inserts 'started' status into the SchemaVersion table itself.
+                if (!applyFullSchemaSnapshot)
+                {
+                    await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.started.ToString(), cancellationToken).ConfigureAwait(false);
+                }
+
+                var server = new Server(serverConnection);
+                var watch = Stopwatch.StartNew();
+                _logger.LogInformation("Script execution started at {UtcTime}", Clock.UtcNow);
+
+                server.ConnectionContext.ExecuteNonQuery(script);
+
+                watch.Stop();
+                _logger.LogInformation("Script execution time is {ElapsedTime}", watch.Elapsed);
+                await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
             }
-
-            var server = new Server(serverConnection);
-            var watch = Stopwatch.StartNew();
-            _logger.LogInformation("Script execution started at {UtcTime}", Clock.UtcNow);
-
-            server.ConnectionContext.ExecuteNonQuery(script);
-
-            watch.Stop();
-            _logger.LogInformation("Script execution time is {ElapsedTime}", watch.Elapsed);
-            await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
-        {
-            await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.failed.ToString(), cancellationToken).ConfigureAwait(false);
-            throw;
+            catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
+            {
+                await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.failed.ToString(), cancellationToken).ConfigureAwait(false);
+                throw;
+            }
         }
     }
 
@@ -77,29 +80,29 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         EnsureArg.IsNotNull(status, nameof(status));
         EnsureArg.IsGte(version, 1);
 
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+        {
+            sqlCommandWrapper.CommandText = "DELETE FROM dbo.SchemaVersion WHERE Version = @version AND Status = @status";
+            sqlCommandWrapper.Parameters.AddWithValue("@version", version);
+            sqlCommandWrapper.Parameters.AddWithValue("@status", status);
 
-        using var deleteCommand = new SqlCommand("DELETE FROM dbo.SchemaVersion WHERE Version = @version AND Status = @status", connection);
-        deleteCommand.Parameters.AddWithValue("@version", version);
-        deleteCommand.Parameters.AddWithValue("@status", status);
-
-        await deleteCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            await sqlCommandWrapper.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />
     public async Task<int> GetCurrentSchemaVersionAsync(CancellationToken cancellationToken)
     {
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-
-        using var selectCommand = new SqlCommand("dbo.SelectCurrentSchemaVersion", connection)
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
         {
-            CommandType = CommandType.StoredProcedure,
-        };
+            sqlCommandWrapper.CommandType = CommandType.StoredProcedure;
+            sqlCommandWrapper.CommandText = "dbo.SelectCurrentSchemaVersion";
 
-        object current = await selectCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-        return (current == null || Convert.IsDBNull(current)) ? 0 : (int)current;
+            object current = await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            return (current == null || Convert.IsDBNull(current)) ? 0 : (int)current;
+        }
     }
 
     private static async Task UpsertSchemaVersionAsync(SqlConnection connection, int version, string status, CancellationToken cancellationToken)
@@ -123,11 +126,12 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
     {
         EnsureArg.IsNotNull(script, nameof(script));
 
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-        var server = new Server(GetServerConnectionWithTimeout(connection));
-
-        server.ConnectionContext.ExecuteNonQuery(script);
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+        {
+            var server = new Server(GetServerConnectionWithTimeout(sqlCommandWrapper.Connection));
+            server.ConnectionContext.ExecuteNonQuery(script);
+        }
     }
 
     /// <inheritdoc />
@@ -139,28 +143,28 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
     /// <inheritdoc />
     public async Task<bool> ObjectExistsAsync(string objectName, string objectType, CancellationToken cancellationToken)
     {
-        var procedureQuery = "SELECT COUNT(*) FROM sys.objects WHERE name = @name and type = @type";
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+        {
+            sqlCommandWrapper.CommandText = "SELECT COUNT(*) FROM sys.objects WHERE name = @name and type = @type";
+            sqlCommandWrapper.Parameters.AddWithValue("@name", objectName);
+            sqlCommandWrapper.Parameters.AddWithValue("@type", objectType);
 
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-
-        using var command = new SqlCommand(procedureQuery, connection);
-        command.Parameters.AddWithValue("@name", objectName);
-        command.Parameters.AddWithValue("@type", objectType);
-
-        return (int)await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
+            var test = await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken);
+            return (int)test != 0;
+        }
     }
 
     /// <inheritdoc />
     public async Task<bool> InstanceSchemaRecordExistsAsync(CancellationToken cancellationToken)
     {
-        var procedureQuery = "SELECT COUNT(*) FROM dbo.InstanceSchema";
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+        {
+            sqlCommandWrapper.CommandText = "SELECT COUNT(*) FROM dbo.InstanceSchema";
 
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-
-        using var command = new SqlCommand(procedureQuery, connection);
-        return (int)await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
+            return (int)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
+        }
     }
 
     private ServerConnection GetServerConnectionWithTimeout(SqlConnection sqlConnection)

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Core;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Extensions;
+using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
 
@@ -22,17 +23,17 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager;
 
 public class SchemaManagerDataStore : ISchemaManagerDataStore
 {
-    private readonly ISqlConnectionBuilder _sqlConnectionBuilder;
+    private readonly SqlConnectionWrapperFactory _sqlConnectionWrapperFactory;
     private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
     private readonly ILogger<SchemaManagerDataStore> _logger;
 
     public SchemaManagerDataStore(
-        ISqlConnectionBuilder sqlConnectionBuilder,
+        SqlConnectionWrapperFactory sqlConnectionWrapperFactory,
         IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
         ILogger<SchemaManagerDataStore> logger)
     {
         _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
-        _sqlConnectionBuilder = EnsureArg.IsNotNull(sqlConnectionBuilder, nameof(sqlConnectionBuilder));
+        _sqlConnectionWrapperFactory = EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));
     }
 
@@ -42,32 +43,34 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         EnsureArg.IsNotNull(script, nameof(script));
         EnsureArg.IsGte(version, 1);
 
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-        var serverConnection = GetServerConnectionWithTimeout(connection);
-
-        try
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
         {
-            // FullSchemaSnapshot script(x.sql) inserts 'started' status into the SchemaVersion table itself.
-            if (!applyFullSchemaSnapshot)
+            var serverConnection = GetServerConnectionWithTimeout(sqlCommandWrapper.Connection);
+
+            try
             {
-                await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.started.ToString(), cancellationToken).ConfigureAwait(false);
+                // FullSchemaSnapshot script(x.sql) inserts 'started' status into the SchemaVersion table itself.
+                if (!applyFullSchemaSnapshot)
+                {
+                    await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.started.ToString(), cancellationToken).ConfigureAwait(false);
+                }
+
+                var server = new Server(serverConnection);
+                var watch = Stopwatch.StartNew();
+                _logger.LogInformation("Script execution started at {UtcTime}", Clock.UtcNow);
+
+                server.ConnectionContext.ExecuteNonQuery(script);
+
+                watch.Stop();
+                _logger.LogInformation("Script execution time is {ElapsedTime}", watch.Elapsed);
+                await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
             }
-
-            var server = new Server(serverConnection);
-            var watch = Stopwatch.StartNew();
-            _logger.LogInformation("Script execution started at {UtcTime}", Clock.UtcNow);
-
-            server.ConnectionContext.ExecuteNonQuery(script);
-
-            watch.Stop();
-            _logger.LogInformation("Script execution time is {ElapsedTime}", watch.Elapsed);
-            await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
-        {
-            await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.failed.ToString(), cancellationToken).ConfigureAwait(false);
-            throw;
+            catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
+            {
+                await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.failed.ToString(), cancellationToken).ConfigureAwait(false);
+                throw;
+            }
         }
     }
 
@@ -77,29 +80,29 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         EnsureArg.IsNotNull(status, nameof(status));
         EnsureArg.IsGte(version, 1);
 
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+        {
+            sqlCommandWrapper.CommandText = "DELETE FROM dbo.SchemaVersion WHERE Version = @version AND Status = @status";
+            sqlCommandWrapper.Parameters.AddWithValue("@version", version);
+            sqlCommandWrapper.Parameters.AddWithValue("@status", status);
 
-        using var deleteCommand = new SqlCommand("DELETE FROM dbo.SchemaVersion WHERE Version = @version AND Status = @status", connection);
-        deleteCommand.Parameters.AddWithValue("@version", version);
-        deleteCommand.Parameters.AddWithValue("@status", status);
-
-        await deleteCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            await sqlCommandWrapper.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />
     public async Task<int> GetCurrentSchemaVersionAsync(CancellationToken cancellationToken)
     {
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-
-        using var selectCommand = new SqlCommand("dbo.SelectCurrentSchemaVersion", connection)
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
         {
-            CommandType = CommandType.StoredProcedure,
-        };
+            sqlCommandWrapper.CommandType = CommandType.StoredProcedure;
+            sqlCommandWrapper.CommandText = "dbo.SelectCurrentSchemaVersion";
 
-        object current = await selectCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-        return (current == null || Convert.IsDBNull(current)) ? 0 : (int)current;
+            object current = await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            return (current == null || Convert.IsDBNull(current)) ? 0 : (int)current;
+        }
     }
 
     private static async Task UpsertSchemaVersionAsync(SqlConnection connection, int version, string status, CancellationToken cancellationToken)
@@ -123,11 +126,12 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
     {
         EnsureArg.IsNotNull(script, nameof(script));
 
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-        var server = new Server(GetServerConnectionWithTimeout(connection));
-
-        server.ConnectionContext.ExecuteNonQuery(script);
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+        {
+            var server = new Server(GetServerConnectionWithTimeout(sqlCommandWrapper.Connection));
+            server.ConnectionContext.ExecuteNonQuery(script);
+        }
     }
 
     /// <inheritdoc />
@@ -139,28 +143,27 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
     /// <inheritdoc />
     public async Task<bool> ObjectExistsAsync(string objectName, string objectType, CancellationToken cancellationToken)
     {
-        var procedureQuery = "SELECT COUNT(*) FROM sys.objects WHERE name = @name and type = @type";
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+        {
+            sqlCommandWrapper.CommandText = "SELECT COUNT(*) FROM sys.objects WHERE name = @name and type = @type";
+            sqlCommandWrapper.Parameters.AddWithValue("@name", objectName);
+            sqlCommandWrapper.Parameters.AddWithValue("@type", objectType);
 
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-
-        using var command = new SqlCommand(procedureQuery, connection);
-        command.Parameters.AddWithValue("@name", objectName);
-        command.Parameters.AddWithValue("@type", objectType);
-
-        return (int)await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
+            return (int)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
+        }
     }
 
     /// <inheritdoc />
     public async Task<bool> InstanceSchemaRecordExistsAsync(CancellationToken cancellationToken)
     {
-        var procedureQuery = "SELECT COUNT(*) FROM dbo.InstanceSchema";
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+        {
+            sqlCommandWrapper.CommandText = "SELECT COUNT(*) FROM dbo.InstanceSchema";
 
-        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
-
-        using var command = new SqlCommand(procedureQuery, connection);
-        return (int)await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
+            return (int)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
+        }
     }
 
     private ServerConnection GetServerConnectionWithTimeout(SqlConnection sqlConnection)

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Core;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Extensions;
-using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
 
@@ -23,17 +22,17 @@ namespace Microsoft.Health.SqlServer.Features.Schema.Manager;
 
 public class SchemaManagerDataStore : ISchemaManagerDataStore
 {
-    private readonly SqlConnectionWrapperFactory _sqlConnectionWrapperFactory;
+    private readonly ISqlConnectionBuilder _sqlConnectionBuilder;
     private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
     private readonly ILogger<SchemaManagerDataStore> _logger;
 
     public SchemaManagerDataStore(
-        SqlConnectionWrapperFactory sqlConnectionWrapperFactory,
+        ISqlConnectionBuilder sqlConnectionBuilder,
         IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
         ILogger<SchemaManagerDataStore> logger)
     {
         _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
-        _sqlConnectionWrapperFactory = EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
+        _sqlConnectionBuilder = EnsureArg.IsNotNull(sqlConnectionBuilder, nameof(sqlConnectionBuilder));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));
     }
 
@@ -43,17 +42,16 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         EnsureArg.IsNotNull(script, nameof(script));
         EnsureArg.IsGte(version, 1);
 
-        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
-        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
-
-        var serverConnection = GetServerConnectionWithTimeout(sqlCommandWrapper.Connection);
+        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
+        var serverConnection = GetServerConnectionWithTimeout(connection);
 
         try
         {
             // FullSchemaSnapshot script(x.sql) inserts 'started' status into the SchemaVersion table itself.
             if (!applyFullSchemaSnapshot)
             {
-                await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.started.ToString(), cancellationToken).ConfigureAwait(false);
+                await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.started.ToString(), cancellationToken).ConfigureAwait(false);
             }
 
             var server = new Server(serverConnection);
@@ -64,11 +62,11 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
 
             watch.Stop();
             _logger.LogInformation("Script execution time is {ElapsedTime}", watch.Elapsed);
-            await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
+            await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
         {
-            await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.failed.ToString(), cancellationToken).ConfigureAwait(false);
+            await UpsertSchemaVersionAsync(connection, version, SchemaVersionStatus.failed.ToString(), cancellationToken).ConfigureAwait(false);
             throw;
         }
     }
@@ -79,26 +77,28 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         EnsureArg.IsNotNull(status, nameof(status));
         EnsureArg.IsGte(version, 1);
 
-        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
-        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
+        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
 
-        sqlCommandWrapper.CommandText = "DELETE FROM dbo.SchemaVersion WHERE Version = @version AND Status = @status";
-        sqlCommandWrapper.Parameters.AddWithValue("@version", version);
-        sqlCommandWrapper.Parameters.AddWithValue("@status", status);
+        using var deleteCommand = new SqlCommand("DELETE FROM dbo.SchemaVersion WHERE Version = @version AND Status = @status", connection);
+        deleteCommand.Parameters.AddWithValue("@version", version);
+        deleteCommand.Parameters.AddWithValue("@status", status);
 
-        await sqlCommandWrapper.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        await deleteCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task<int> GetCurrentSchemaVersionAsync(CancellationToken cancellationToken)
     {
-        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
-        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
+        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
 
-        sqlCommandWrapper.CommandType = CommandType.StoredProcedure;
-        sqlCommandWrapper.CommandText = "dbo.SelectCurrentSchemaVersion";
+        using var selectCommand = new SqlCommand("dbo.SelectCurrentSchemaVersion", connection)
+        {
+            CommandType = CommandType.StoredProcedure,
+        };
 
-        object current = await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        object current = await selectCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
         return (current == null || Convert.IsDBNull(current)) ? 0 : (int)current;
     }
 
@@ -123,10 +123,10 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
     {
         EnsureArg.IsNotNull(script, nameof(script));
 
-        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
-        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
+        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
+        var server = new Server(GetServerConnectionWithTimeout(connection));
 
-        var server = new Server(GetServerConnectionWithTimeout(sqlCommandWrapper.Connection));
         server.ConnectionContext.ExecuteNonQuery(script);
     }
 
@@ -139,25 +139,28 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
     /// <inheritdoc />
     public async Task<bool> ObjectExistsAsync(string objectName, string objectType, CancellationToken cancellationToken)
     {
-        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
-        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
+        var procedureQuery = "SELECT COUNT(*) FROM sys.objects WHERE name = @name and type = @type";
 
-        sqlCommandWrapper.CommandText = "SELECT COUNT(*) FROM sys.objects WHERE name = @name and type = @type";
-        sqlCommandWrapper.Parameters.AddWithValue("@name", objectName);
-        sqlCommandWrapper.Parameters.AddWithValue("@type", objectType);
+        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
 
-        return (int)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
+        using var command = new SqlCommand(procedureQuery, connection);
+        command.Parameters.AddWithValue("@name", objectName);
+        command.Parameters.AddWithValue("@type", objectType);
+
+        return (int)await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
     }
 
     /// <inheritdoc />
     public async Task<bool> InstanceSchemaRecordExistsAsync(CancellationToken cancellationToken)
     {
-        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
-        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
-        
-        sqlCommandWrapper.CommandText = "SELECT COUNT(*) FROM dbo.InstanceSchema";
+        var procedureQuery = "SELECT COUNT(*) FROM dbo.InstanceSchema";
 
-        return (int)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
+        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        await connection.TryOpenAsync(cancellationToken).ConfigureAwait(false);
+
+        using var command = new SqlCommand(procedureQuery, connection);
+        return (int)await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
     }
 
     private ServerConnection GetServerConnectionWithTimeout(SqlConnection sqlConnection)

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
@@ -98,15 +98,14 @@ public class SchemaUpgradeRunner
 
     private async Task UpsertSchemaVersionAsync(int schemaVersion, string status, CancellationToken cancellationToken)
     {
-        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
-        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
-        {
-            sqlCommandWrapper.CommandText = "dbo.UpsertSchemaVersion";
-            sqlCommandWrapper.CommandType = CommandType.StoredProcedure;
-            sqlCommandWrapper.Parameters.AddWithValue("@version", schemaVersion);
-            sqlCommandWrapper.Parameters.AddWithValue("@status", status);
+        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken);
+        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
 
-            await sqlCommandWrapper.ExecuteNonQueryAsync(cancellationToken);
-        }
+        sqlCommandWrapper.CommandText = "dbo.UpsertSchemaVersion";
+        sqlCommandWrapper.CommandType = CommandType.StoredProcedure;
+        sqlCommandWrapper.Parameters.AddWithValue("@version", schemaVersion);
+        sqlCommandWrapper.Parameters.AddWithValue("@status", status);
+
+        await sqlCommandWrapper.ExecuteNonQueryAsync(cancellationToken);
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
@@ -11,6 +11,7 @@ using EnsureThat;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.SqlServer.Extensions;
+using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using Microsoft.SqlServer.Management.Common;
 
@@ -21,26 +22,26 @@ public class SchemaUpgradeRunner
     private readonly IScriptProvider _scriptProvider;
     private readonly IBaseScriptProvider _baseScriptProvider;
     private readonly ILogger<SchemaUpgradeRunner> _logger;
-    private readonly ISqlConnectionBuilder _sqlConnectionBuilder;
+    private readonly SqlConnectionWrapperFactory _sqlConnectionWrapperFactory;
     private ISchemaManagerDataStore _schemaManagerDataStore;
 
     public SchemaUpgradeRunner(
         IScriptProvider scriptProvider,
         IBaseScriptProvider baseScriptProvider,
         ILogger<SchemaUpgradeRunner> logger,
-        ISqlConnectionBuilder sqlConnectionBuilder,
+        SqlConnectionWrapperFactory sqlConnectionWrapperFactory,
         ISchemaManagerDataStore schemaManagerDataStore)
     {
         EnsureArg.IsNotNull(scriptProvider, nameof(scriptProvider));
         EnsureArg.IsNotNull(baseScriptProvider, nameof(baseScriptProvider));
         EnsureArg.IsNotNull(logger, nameof(logger));
-        EnsureArg.IsNotNull(sqlConnectionBuilder, nameof(sqlConnectionBuilder));
+        EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
         EnsureArg.IsNotNull(schemaManagerDataStore, nameof(schemaManagerDataStore));
 
         _scriptProvider = scriptProvider;
         _baseScriptProvider = baseScriptProvider;
         _logger = logger;
-        _sqlConnectionBuilder = sqlConnectionBuilder;
+        _sqlConnectionWrapperFactory = sqlConnectionWrapperFactory;
         _schemaManagerDataStore = schemaManagerDataStore;
     }
 
@@ -97,15 +98,15 @@ public class SchemaUpgradeRunner
 
     private async Task UpsertSchemaVersionAsync(int schemaVersion, string status, CancellationToken cancellationToken)
     {
-        using (var connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken))
-        using (var upsertCommand = new SqlCommand("dbo.UpsertSchemaVersion", connection))
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
         {
-            upsertCommand.CommandType = CommandType.StoredProcedure;
-            upsertCommand.Parameters.AddWithValue("@version", schemaVersion);
-            upsertCommand.Parameters.AddWithValue("@status", status);
+            sqlCommandWrapper.CommandText = "dbo.UpsertSchemaVersion";
+            sqlCommandWrapper.CommandType = CommandType.StoredProcedure;
+            sqlCommandWrapper.Parameters.AddWithValue("@version", schemaVersion);
+            sqlCommandWrapper.Parameters.AddWithValue("@status", status);
 
-            await connection.TryOpenAsync(cancellationToken);
-            await upsertCommand.ExecuteNonQueryAsync(cancellationToken);
+            await sqlCommandWrapper.ExecuteNonQueryAsync(cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -168,7 +168,7 @@ public static class SqlServerBaseRegistrationExtensions
                 var schemaManagerDataStore = p.GetService<IReadOnlySchemaManagerDataStore>() as SchemaManagerDataStore;
                 return schemaManagerDataStore != null
                     ? schemaManagerDataStore
-                    : new SchemaManagerDataStore(p.GetRequiredService<SqlConnectionWrapperFactory>(), p.GetRequiredService<IOptions<SqlServerDataStoreConfiguration>>(), p.GetRequiredService<ILogger<SchemaManagerDataStore>>());
+                    : new SchemaManagerDataStore(p.GetRequiredService<ISqlConnectionBuilder>(), p.GetRequiredService<IOptions<SqlServerDataStoreConfiguration>>(), p.GetRequiredService<ILogger<SchemaManagerDataStore>>());
             });
 
         return services;

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -48,7 +48,7 @@ public static class SqlServerBaseRegistrationExtensions
         services.TryAddSingleton(p => p.GetServices<IHostedService>().First(x => x is SchemaInitializer) as SchemaInitializer);
         services.TryAddSingleton(p => p.GetRequiredService<IScriptProvider>() as ScriptProvider<TSchemaVersionEnum>);
         services.TryAddSingleton(p => p.GetRequiredService<IBaseScriptProvider>() as BaseScriptProvider);
-        services.TryAddSingleton(p => p.GetRequiredService<ISchemaManagerDataStore>() as SchemaManagerDataStore);
+        services.TryAddScoped(p => p.GetRequiredService<ISchemaManagerDataStore>() as SchemaManagerDataStore);
         services.AddSqlRetryLogicProvider();
 
         return services;
@@ -104,7 +104,7 @@ public static class SqlServerBaseRegistrationExtensions
         services.TryAddScoped<SqlConnectionWrapperFactory>();
         services.TryAddScoped<SqlTransactionHandler>();
         services.TryAddScoped<ITransactionHandler>(handlerFactory);
-        services.TryAddSingleton<IReadOnlySchemaManagerDataStore, SchemaManagerDataStore>();
+        services.TryAddScoped<IReadOnlySchemaManagerDataStore, SchemaManagerDataStore>();
 
         return services;
     }
@@ -162,7 +162,7 @@ public static class SqlServerBaseRegistrationExtensions
             });
 
         // Re-use the existing SchemaManagerDataStore
-        services.TryAddSingleton<ISchemaManagerDataStore>(
+        services.TryAddScoped<ISchemaManagerDataStore>(
             p =>
             {
                 var schemaManagerDataStore = p.GetService<IReadOnlySchemaManagerDataStore>() as SchemaManagerDataStore;

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -168,7 +168,7 @@ public static class SqlServerBaseRegistrationExtensions
                 var schemaManagerDataStore = p.GetService<IReadOnlySchemaManagerDataStore>() as SchemaManagerDataStore;
                 return schemaManagerDataStore != null
                     ? schemaManagerDataStore
-                    : new SchemaManagerDataStore(p.GetRequiredService<ISqlConnectionBuilder>(), p.GetRequiredService<IOptions<SqlServerDataStoreConfiguration>>(), p.GetRequiredService<ILogger<SchemaManagerDataStore>>());
+                    : new SchemaManagerDataStore(p.GetRequiredService<SqlConnectionWrapperFactory>(), p.GetRequiredService<IOptions<SqlServerDataStoreConfiguration>>(), p.GetRequiredService<ILogger<SchemaManagerDataStore>>());
             });
 
         return services;

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -148,7 +148,7 @@ public static class SqlServerBaseRegistrationExtensions
         services.TryAddSingleton<SchemaJobWorker>();
         services.TryAddSingleton<IScriptProvider, ScriptProvider<TVersion>>();
         services.TryAddSingleton<IBaseScriptProvider, BaseScriptProvider>();
-        services.TryAddSingleton<SchemaUpgradeRunner>();
+        services.TryAddScoped<SchemaUpgradeRunner>();
         services.AddHostedService<SchemaInitializer>();
 
         // Resolve IProcessTerminator based on the configuration

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/Manager/BaseSchemaRunnerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/Manager/BaseSchemaRunnerTests.cs
@@ -3,39 +3,30 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
-using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Exceptions;
-using Microsoft.Health.SqlServer.Features.Storage;
-using NSubstitute;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.Health.SqlServer.Tests.Integration.Features.Schema.Manager;
 
-public sealed class BaseSchemaRunnerTests : SqlIntegrationTestBase, IDisposable
+public class BaseSchemaRunnerTests : SqlIntegrationTestBase
 {
     private readonly BaseSchemaRunner _runner;
     private readonly ISchemaManagerDataStore _dataStore;
-    private SqlTransactionHandler _sqlTransactionHandler = new SqlTransactionHandler();
 
     public BaseSchemaRunnerTests(ITestOutputHelper output)
         : base(output)
     {
         var config = Options.Create(new SqlServerDataStoreConfiguration());
         var sqlConnection = new DefaultSqlConnectionBuilder(ConnectionStringProvider, SqlConfigurableRetryFactory.CreateNoneRetryProvider());
-        
-        SqlRetryLogicBaseProvider sqlRetryLogicBaseProvider = SqlConfigurableRetryFactory.CreateFixedRetryProvider(new SqlClientRetryOptions().Settings);
-
-        var sqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(_sqlTransactionHandler, sqlConnection, sqlRetryLogicBaseProvider, config);
-        _dataStore = new SchemaManagerDataStore(sqlConnectionWrapperFactory, config, NullLogger<SchemaManagerDataStore>.Instance);
+        _dataStore = new SchemaManagerDataStore(sqlConnection, config, NullLogger<SchemaManagerDataStore>.Instance);
 
         _runner = new BaseSchemaRunner(sqlConnection, _dataStore, ConnectionStringProvider, NullLogger<BaseSchemaRunner>.Instance);
     }
@@ -62,11 +53,5 @@ public sealed class BaseSchemaRunnerTests : SqlIntegrationTestBase, IDisposable
     public async Task EnsureInstanceSchemaRecordExists_WhenNotExists_Throws()
     {
         await Assert.ThrowsAsync<SchemaManagerException>(() => _runner.EnsureInstanceSchemaRecordExistsAsync(CancellationToken.None));
-    }
-
-    public void Dispose()
-    {
-        _sqlTransactionHandler.Dispose();
-        GC.SuppressFinalize(this);
     }
 }

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
@@ -10,10 +10,8 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
-using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
-using Microsoft.Health.SqlServer.Features.Storage;
 using Microsoft.SqlServer.Management.Common;
 using NSubstitute;
 using Xunit;
@@ -21,11 +19,10 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Health.SqlServer.Tests.Integration.Features.Schema;
 
-public sealed class SchemaUpgradeRunnerTests : SqlIntegrationTestBase, IDisposable
+public class SchemaUpgradeRunnerTests : SqlIntegrationTestBase
 {
     private SchemaUpgradeRunner _runner;
     private SchemaManagerDataStore _schemaDataStore;
-    private SqlTransactionHandler _sqlTransactionHandler = new SqlTransactionHandler();
 
     public SchemaUpgradeRunnerTests(ITestOutputHelper outputHelper)
         : base(outputHelper)
@@ -39,12 +36,8 @@ public sealed class SchemaUpgradeRunnerTests : SqlIntegrationTestBase, IDisposab
         var sqlConnection = Substitute.For<ISqlConnectionBuilder>();
         sqlConnection.GetSqlConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs((x) => GetSqlConnection());
         var config = Options.Create(new SqlServerDataStoreConfiguration());
-
-        SqlRetryLogicBaseProvider sqlRetryLogicBaseProvider = SqlConfigurableRetryFactory.CreateFixedRetryProvider(new SqlClientRetryOptions().Settings);
-        var sqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(_sqlTransactionHandler, sqlConnection, sqlRetryLogicBaseProvider, config);
-
-        _schemaDataStore = new SchemaManagerDataStore(sqlConnectionWrapperFactory, config, NullLogger<SchemaManagerDataStore>.Instance);
-        _runner = new SchemaUpgradeRunner(new ScriptProvider<SchemaVersion>(), new BaseScriptProvider(), NullLogger<SchemaUpgradeRunner>.Instance, sqlConnectionWrapperFactory, _schemaDataStore);
+        _schemaDataStore = new SchemaManagerDataStore(sqlConnection, config, NullLogger<SchemaManagerDataStore>.Instance);
+        _runner = new SchemaUpgradeRunner(new ScriptProvider<SchemaVersion>(), new BaseScriptProvider(), NullLogger<SchemaUpgradeRunner>.Instance, sqlConnection, _schemaDataStore);
     }
 
     [Fact]
@@ -105,11 +98,5 @@ public sealed class SchemaUpgradeRunnerTests : SqlIntegrationTestBase, IDisposab
         await _runner.ApplySchemaAsync(3, applyFullSchemaSnapshot: false, CancellationToken.None);
         version = await _schemaDataStore.GetCurrentSchemaVersionAsync(CancellationToken.None);
         Assert.Equal(3, version);
-    }
-
-    public void Dispose()
-    {
-        _sqlTransactionHandler.Dispose();
-        GC.SuppressFinalize(this);
     }
 }

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/SqlIntegrationTestBase.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/SqlIntegrationTestBase.cs
@@ -22,7 +22,7 @@ public abstract class SqlIntegrationTestBase : IAsyncLifetime
     {
         Output = outputHelper;
         DatabaseName = $"IntegrationTests_BaseSchemaRunner_{Guid.NewGuid().ToString().Replace("-", string.Empty, StringComparison.Ordinal)}";
-        var builder = new SqlConnectionStringBuilder(Environment.GetEnvironmentVariable("TestSqlConnectionString") ?? $"server=(local);Integrated Security=true")
+        var builder = new SqlConnectionStringBuilder(Environment.GetEnvironmentVariable("TestSqlConnectionString") ?? $"server=(local);Integrated Security=true;TrustServerCertificate=true;")
         {
             InitialCatalog = DatabaseName
         };

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/SqlIntegrationTestBase.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/SqlIntegrationTestBase.cs
@@ -22,7 +22,7 @@ public abstract class SqlIntegrationTestBase : IAsyncLifetime
     {
         Output = outputHelper;
         DatabaseName = $"IntegrationTests_BaseSchemaRunner_{Guid.NewGuid().ToString().Replace("-", string.Empty, StringComparison.Ordinal)}";
-        var builder = new SqlConnectionStringBuilder(Environment.GetEnvironmentVariable("TestSqlConnectionString") ?? $"server=(local);Integrated Security=true;TrustServerCertificate=true;")
+        var builder = new SqlConnectionStringBuilder(Environment.GetEnvironmentVariable("TestSqlConnectionString") ?? $"server=(local);Integrated Security=true")
         {
             InitialCatalog = DatabaseName
         };

--- a/tools/SchemaManager/Program.cs
+++ b/tools/SchemaManager/Program.cs
@@ -51,7 +51,7 @@ internal class Program
         services.AddSingleton<ISqlConnectionBuilder, DefaultSqlConnectionBuilder>();
         services.AddSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>();
         services.AddSingleton<IBaseSchemaRunner, BaseSchemaRunner>();
-        services.AddSingleton<ISchemaManagerDataStore, SchemaManagerDataStore>();
+        services.AddScoped<ISchemaManagerDataStore, SchemaManagerDataStore>();
         services.AddSingleton<ISchemaClient, SchemaClient>();
         services.AddSingleton<ISchemaManager, SqlSchemaManager>();
         services.AddLogging(configure => configure.AddConsole());

--- a/tools/SchemaManager/Program.cs
+++ b/tools/SchemaManager/Program.cs
@@ -15,7 +15,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer;
 using Microsoft.Health.SqlServer.Configs;
+using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
+using Microsoft.Health.SqlServer.Features.Storage;
 using SchemaManager.Core;
 
 namespace SchemaManager;
@@ -69,6 +71,8 @@ internal class Program
         });
         services.AddSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>();
         services.AddSingleton<IBaseSchemaRunner, BaseSchemaRunner>();
+        services.AddScoped<SqlConnectionWrapperFactory>();
+        services.AddScoped<SqlTransactionHandler>();
         services.AddScoped<ISchemaManagerDataStore, SchemaManagerDataStore>();
         services.AddSingleton<ISchemaClient, SchemaClient>();
         services.AddSingleton<ISchemaManager, SqlSchemaManager>();


### PR DESCRIPTION
## Description
This PR updates following - 
- SchemaUpgradeRunner and SchemaManagerDataStore to use SqlConnectionWrapperFactory.
- IReadOnlySchemaManagerDataStore to be a scoped service
- SchemaUpgradeRunner to be a scoped service
- SchemaInitializer to accomodate scoped services IReadOnlySchemaManagerDataStore  & SchemaUpgradeRunner 

Singleton => SchemaInitializer -> IReadOnlySchemaManagerDataStore -> SqlConnectionBuilder
Singleton => SchemaInitializer -> SchemaUpgradeRunner -> SqlConnectionBuilder

Instead of using SqlConnectionBuilder we want to use SqlConnectionWrapperFactory which is a scoped service. To avoid Cannot consume scoped service X  from singleton Y exception, changing SchemaManagerDataStore & SchemaUpgradeRunner to be scoped services. SchemaInitializer is a IHosted Singleton service which is updatd to accomodate scoped services IReadOnlySchemaManagerDataStore  & SchemaUpgradeRunner 
## Related issues
Addresses [AB88191](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=88191)

## Testing
1. Unit test pass
2. New changes work with FHIR - using dll's
3. New changes work with DICOM - using dll'a
4. Schema Upgrade tool works

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
