### PR TITLE
NVarchar max column has length -1 - SqlTruncateException

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/ColumnsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/ColumnsTests.cs
@@ -52,6 +52,17 @@ public class ColumnsTests
     }
 
     [Fact]
+    public void GivenANVarCharColumnColumnWithMaxLength_WhenSettingAValue_ThenSqlDBNullIsSet()
+    {
+        var nVarCharColumn = new NVarCharColumn("textOverflowColumn", -1);
+        var record = new SqlDataRecord(nVarCharColumn.Metadata);
+
+        nVarCharColumn.Set(record, 0, "text");
+
+        Assert.True(record.GetSqlString(0).Value.Equals("text", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void GivenDecimalValueGreaterThanDefinedColumnPrecisionAndScaleMax_WhenSettingDecimalValue_ThenSqlTruncateExceptionThrown()
     {
         var decimalColumn = new DecimalColumn("decimalColumn", 18, 6);

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -762,7 +762,7 @@ public abstract class StringColumn : Column<string>
 
         if (value != null)
         {
-            // NVarChar(max) columns has -1 length
+            // NVarChar(max) column has -1 length
             if (Metadata.MaxLength > 0 && Metadata.MaxLength < value.Length)
             {
                 throw new SqlTruncateException(string.Format(CultureInfo.CurrentCulture, Resources.StringTooLong, value.Length, Metadata.Name, Metadata.MaxLength));

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -762,7 +762,8 @@ public abstract class StringColumn : Column<string>
 
         if (value != null)
         {
-            if (Metadata.MaxLength < value.Length)
+            // NVarChar(max) columns has -1 length
+            if (Metadata.MaxLength > 0 && Metadata.MaxLength < value.Length)
             {
                 throw new SqlTruncateException(string.Format(CultureInfo.CurrentCulture, Resources.StringTooLong, value.Length, Metadata.Name, Metadata.MaxLength));
             }


### PR DESCRIPTION
## Description
FHIR tests are failing with below error while trying to save data in TextOverflow column.
Exception -  Microsoft.Health.Fhir.Client.FhirException : BadRequest: Value of length 550 is too long for column TextOverflow with length -1

TextOverflow is nvarchar(max) in SQL, It is generated as NullableNVarCharColumn("TextOverflow", -1, "Latin1_General_100_CI_AI_SC") with length as -1. We need to cover this scenario in column.cs

## Related issues
Addresses [AB91568](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=91568)

## Testing
Unit test added

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
