### PR TITLE
Use SqlConnectionWrapperFactory for Command Retries in Schema Upgrade

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapper.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapper.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
-using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Storage;
 
@@ -58,7 +57,7 @@ public class SqlConnectionWrapper : IDisposable
         }
     }
 
-    internal async Task InitializeAsync(CancellationToken cancellationToken)
+    internal async Task InitializeAsync(string initialCatalog = null, CancellationToken cancellationToken = default)
     {
         if (_enlistInTransactionIfPresent && _sqlTransactionHandler.SqlTransactionScope?.SqlConnection != null)
         {
@@ -66,7 +65,7 @@ public class SqlConnectionWrapper : IDisposable
         }
         else
         {
-            _sqlConnection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken);
+            _sqlConnection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog, cancellationToken: cancellationToken);
         }
 
         if (_enlistInTransactionIfPresent && _sqlTransactionHandler.SqlTransactionScope != null && _sqlTransactionHandler.SqlTransactionScope.SqlConnection == null)

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapperFactory.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapperFactory.cs
@@ -38,8 +38,16 @@ public class SqlConnectionWrapperFactory
 
     public async Task<SqlConnectionWrapper> ObtainSqlConnectionWrapperAsync(CancellationToken cancellationToken, bool enlistInTransaction = false)
     {
-        SqlConnectionWrapper sqlConnectionWrapper = new SqlConnectionWrapper(_sqlTransactionHandler, _sqlConnectionBuilder, _sqlRetryLogicBaseProvider, enlistInTransaction, _sqlServerDataStoreConfiguration);
-        await sqlConnectionWrapper.InitializeAsync(cancellationToken);
+        var sqlConnectionWrapper = new SqlConnectionWrapper(_sqlTransactionHandler, _sqlConnectionBuilder, _sqlRetryLogicBaseProvider, enlistInTransaction, _sqlServerDataStoreConfiguration);
+        await sqlConnectionWrapper.InitializeAsync(cancellationToken: cancellationToken);
+
+        return sqlConnectionWrapper;
+    }
+
+    public async Task<SqlConnectionWrapper> ObtainSqlConnectionWrapperAsync(string initialCatalog, CancellationToken cancellationToken, bool enlistInTransaction = false)
+    {
+        var sqlConnectionWrapper = new SqlConnectionWrapper(_sqlTransactionHandler, _sqlConnectionBuilder, _sqlRetryLogicBaseProvider, enlistInTransaction, _sqlServerDataStoreConfiguration);
+        await sqlConnectionWrapper.InitializeAsync(initialCatalog, cancellationToken: cancellationToken);
 
         return sqlConnectionWrapper;
     }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -92,7 +92,7 @@ public class SchemaInitializer : IHostedService
         {
             SchemaUpgradeRunner _schemaUpgradeRunner = scope.ServiceProvider.GetRequiredService<SchemaUpgradeRunner>();
 
-            using SqlConnectionWrapper sqlConnection = await scope.ServiceProvider.GetRequiredService<SqlConnectionWrapperFactory>().ObtainSqlConnectionWrapperAsync(cancellationToken);
+            using SqlConnectionWrapper sqlConnection = await connectionFactory.ObtainSqlConnectionWrapperAsync(cancellationToken);
             IDistributedLock sqlLock = new SqlDistributedLock(SchemaUpgradeLockName, sqlConnection.SqlConnection);
 
             try

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -97,62 +97,61 @@ public class SchemaInitializer : IHostedService
 
             try
             {
-                await using (IDistributedSynchronizationHandle lockHandle = await sqlLock.TryAcquireAsync(TimeSpan.FromSeconds(30), cancellationToken))
+                await using IDistributedSynchronizationHandle lockHandle = await sqlLock.TryAcquireAsync(TimeSpan.FromSeconds(30), cancellationToken);
+
+                if (lockHandle == null)
                 {
-                    if (lockHandle == null)
+                    _logger.LogInformation("Schema upgrade lock was not acquired, skipping");
+                    return;
+                }
+
+                _logger.LogInformation("Schema upgrade lock acquired");
+
+                // Recheck the version with lock
+                await GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation("Schema version is {Version}", _schemaInformation.Current?.ToString(CultureInfo.InvariantCulture) ?? "NULL");
+
+                // If the stored procedure to get the current schema version doesn't exist
+                if (_schemaInformation.Current == null)
+                {
+                    // Apply base schema
+                    await _schemaUpgradeRunner.ApplyBaseSchemaAsync(cancellationToken).ConfigureAwait(false);
+
+                    // This is for tests purpose only
+                    if (forceIncrementalSchemaUpgrade)
                     {
-                        _logger.LogInformation("Schema upgrade lock was not acquired, skipping");
-                        return;
+                        // Run version 1 and and apply .diff.sql files to upgrade the schema version.
+                        await _schemaUpgradeRunner.ApplySchemaAsync(_schemaInformation.MinimumSupportedVersion, applyFullSchemaSnapshot: true, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        // Apply the maximum supported version. This won't consider the .diff.sql files.
+                        await _schemaUpgradeRunner.ApplySchemaAsync(_schemaInformation.MaximumSupportedVersion, applyFullSchemaSnapshot: true, cancellationToken).ConfigureAwait(false);
                     }
 
-                    _logger.LogInformation("Schema upgrade lock acquired");
-
-                    // Recheck the version with lock
                     await GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
-                    _logger.LogInformation("Schema version is {Version}", _schemaInformation.Current?.ToString(CultureInfo.InvariantCulture) ?? "NULL");
 
-                    // If the stored procedure to get the current schema version doesn't exist
-                    if (_schemaInformation.Current == null)
+                    await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, true);
+
+                    schemaUpgradedNotificationSent = true;
+                }
+
+                // If the current schema version needs to be upgraded
+                if (_schemaInformation.Current < _schemaInformation.MaximumSupportedVersion)
+                {
+                    // Apply each .diff.sql file one by one.
+                    int current = _schemaInformation.Current ?? 0;
+                    for (int i = current + 1; i <= _schemaInformation.MaximumSupportedVersion; i++)
                     {
-                        // Apply base schema
-                        await _schemaUpgradeRunner.ApplyBaseSchemaAsync(cancellationToken).ConfigureAwait(false);
+                        await _schemaUpgradeRunner.ApplySchemaAsync(version: i, applyFullSchemaSnapshot: false, cancellationToken).ConfigureAwait(false);
 
-                        // This is for tests purpose only
-                        if (forceIncrementalSchemaUpgrade)
-                        {
-                            // Run version 1 and and apply .diff.sql files to upgrade the schema version.
-                            await _schemaUpgradeRunner.ApplySchemaAsync(_schemaInformation.MinimumSupportedVersion, applyFullSchemaSnapshot: true, cancellationToken).ConfigureAwait(false);
-                        }
-                        else
-                        {
-                            // Apply the maximum supported version. This won't consider the .diff.sql files.
-                            await _schemaUpgradeRunner.ApplySchemaAsync(_schemaInformation.MaximumSupportedVersion, applyFullSchemaSnapshot: true, cancellationToken).ConfigureAwait(false);
-                        }
-
+                        // we need to ensure that the schema upgrade notification is sent after updating the _schemaInformation.Current for each upgraded version
                         await GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
 
-                        await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, true);
-
-                        schemaUpgradedNotificationSent = true;
+                        await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, false);
                     }
 
-                    // If the current schema version needs to be upgraded
-                    if (_schemaInformation.Current < _schemaInformation.MaximumSupportedVersion)
-                    {
-                        // Apply each .diff.sql file one by one.
-                        int current = _schemaInformation.Current ?? 0;
-                        for (int i = current + 1; i <= _schemaInformation.MaximumSupportedVersion; i++)
-                        {
-                            await _schemaUpgradeRunner.ApplySchemaAsync(version: i, applyFullSchemaSnapshot: false, cancellationToken).ConfigureAwait(false);
-
-                            // we need to ensure that the schema upgrade notification is sent after updating the _schemaInformation.Current for each upgraded version
-                            await GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
-
-                            await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, false);
-                        }
-
-                        schemaUpgradedNotificationSent = true;
-                    }
+                    schemaUpgradedNotificationSent = true;
                 }
             }
             catch (SqlException e) when (e.Number == SqlErrorCodes.KilledSessionState)
@@ -278,14 +277,13 @@ public class SchemaInitializer : IHostedService
     {
         EnsureArg.IsNotNull(sqlConnection, nameof(sqlConnection));
 
-        using (SqlCommandWrapper checkDatabaseExistsCommand = sqlConnection.CreateRetrySqlCommand())
+        using SqlCommandWrapper checkDatabaseExistsCommand = sqlConnection.CreateRetrySqlCommand();
+
+        checkDatabaseExistsCommand.CommandText = "SELECT 1 FROM sys.databases where name = @databaseName";
+        checkDatabaseExistsCommand.Parameters.AddWithValue("@databaseName", databaseName);
+        if ((int?)await checkDatabaseExistsCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) == 1)
         {
-            checkDatabaseExistsCommand.CommandText = "SELECT 1 FROM sys.databases where name = @databaseName";
-            checkDatabaseExistsCommand.Parameters.AddWithValue("@databaseName", databaseName);
-            if ((int?)await checkDatabaseExistsCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) == 1)
-            {
-                return true;
-            }
+            return true;
         }
 
         return false;

--- a/src/Microsoft.Health.SqlServer/ManagedIdentitySqlConnectionBuilder.cs
+++ b/src/Microsoft.Health.SqlServer/ManagedIdentitySqlConnectionBuilder.cs
@@ -35,14 +35,13 @@ public class ManagedIdentitySqlConnectionBuilder : ISqlConnectionBuilder
     public async Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, CancellationToken cancellationToken = default)
     {
         SqlConnection sqlConnection = await SqlConnectionHelper.GetBaseSqlConnectionAsync(
-                                                                    _sqlConnectionStringProvider,
-                                                                    _sqlRetryLogicBaseProvider,
-                                                                    initialCatalog,
-                                                                    cancellationToken);
+            _sqlConnectionStringProvider,
+            _sqlRetryLogicBaseProvider,
+            initialCatalog,
+            cancellationToken);
 
         // set managed identity access token
-        var result = await _accessTokenHandler.GetAccessTokenAsync(_azureResource, cancellationToken);
-        sqlConnection.AccessToken = result;
+        sqlConnection.AccessToken = await _accessTokenHandler.GetAccessTokenAsync(_azureResource, cancellationToken);
         return sqlConnection;
     }
 }

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/Manager/BaseSchemaRunnerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/Manager/BaseSchemaRunnerTests.cs
@@ -29,15 +29,14 @@ public sealed class BaseSchemaRunnerTests : SqlIntegrationTestBase, IDisposable
     public BaseSchemaRunnerTests(ITestOutputHelper output)
         : base(output)
     {
-        var config = Options.Create(new SqlServerDataStoreConfiguration());
+        IOptions<SqlServerDataStoreConfiguration> options = Options.Create(new SqlServerDataStoreConfiguration());
         var sqlConnection = new DefaultSqlConnectionBuilder(ConnectionStringProvider, SqlConfigurableRetryFactory.CreateNoneRetryProvider());
-        
         SqlRetryLogicBaseProvider sqlRetryLogicBaseProvider = SqlConfigurableRetryFactory.CreateFixedRetryProvider(new SqlClientRetryOptions().Settings);
 
-        var sqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(_sqlTransactionHandler, sqlConnection, sqlRetryLogicBaseProvider, config);
-        _dataStore = new SchemaManagerDataStore(sqlConnectionWrapperFactory, config, NullLogger<SchemaManagerDataStore>.Instance);
+        var sqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(_sqlTransactionHandler, sqlConnection, sqlRetryLogicBaseProvider, options);
+        _dataStore = new SchemaManagerDataStore(sqlConnectionWrapperFactory, options, NullLogger<SchemaManagerDataStore>.Instance);
 
-        _runner = new BaseSchemaRunner(sqlConnection, _dataStore, ConnectionStringProvider, NullLogger<BaseSchemaRunner>.Instance);
+        _runner = new BaseSchemaRunner(sqlConnectionWrapperFactory, _dataStore, ConnectionStringProvider, NullLogger<BaseSchemaRunner>.Instance);
     }
 
     [Fact]

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaInitializerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaInitializerTests.cs
@@ -23,13 +23,13 @@ public class SchemaInitializerTests : SqlIntegrationTestBase
     public async Task InvalidDatabaseName_CreateDatabaseAsync_ThrowsException()
     {
         await Assert.ThrowsAsync<ArgumentException>(
-            () => SchemaInitializer.CreateDatabaseAsync(Connection, "[something] DROP DATABASE Production --", CancellationToken.None));
+            () => SchemaInitializer.CreateDatabaseAsync(ConnectionWrapper, "[something] DROP DATABASE Production --", CancellationToken.None));
     }
 
     [Fact]
     public async Task DatabaseDoesNotExist_DoesDatabaseExistAsync_ReturnsFalse()
     {
-        Assert.False(await SchemaInitializer.DoesDatabaseExistAsync(Connection, "doesnotexist", CancellationToken.None));
+        Assert.False(await SchemaInitializer.DoesDatabaseExistAsync(ConnectionWrapper, "doesnotexist", CancellationToken.None));
     }
 
     [Fact]
@@ -39,9 +39,9 @@ public class SchemaInitializerTests : SqlIntegrationTestBase
 
         try
         {
-            Assert.False(await SchemaInitializer.DoesDatabaseExistAsync(Connection, dbName, CancellationToken.None));
-            Assert.True(await SchemaInitializer.CreateDatabaseAsync(Connection, dbName, CancellationToken.None));
-            Assert.True(await SchemaInitializer.DoesDatabaseExistAsync(Connection, dbName, CancellationToken.None));
+            Assert.False(await SchemaInitializer.DoesDatabaseExistAsync(ConnectionWrapper, dbName, CancellationToken.None));
+            Assert.True(await SchemaInitializer.CreateDatabaseAsync(ConnectionWrapper, dbName, CancellationToken.None));
+            Assert.True(await SchemaInitializer.DoesDatabaseExistAsync(ConnectionWrapper, dbName, CancellationToken.None));
         }
         finally
         {

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/SqlIntegrationTestBase.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/SqlIntegrationTestBase.cs
@@ -4,12 +4,14 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
+using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema;
+using Microsoft.Health.SqlServer.Features.Storage;
 using NSubstitute;
 using Xunit;
 using Xunit.Abstractions;
@@ -43,23 +45,35 @@ public abstract class SqlIntegrationTestBase : IAsyncLifetime
 
     protected ITestOutputHelper Output { get; set; }
 
-    protected SqlConnection Connection { get; set; }
+    protected SqlTransactionHandler TransactionHandler { get; set; }
+
+    protected SqlConnectionWrapperFactory ConnectionFactory { get; set; }
+
+    protected SqlConnectionWrapper ConnectionWrapper { get; set; }
 
     protected SqlServerDataStoreConfiguration Config { get; set; }
 
     public virtual async Task InitializeAsync()
     {
-        var connectionBuilder = new SqlConnectionStringBuilder(Config.ConnectionString) { InitialCatalog = "master" };
-        Connection = new SqlConnection(connectionBuilder.ToString());
-        await Connection.OpenAsync();
-        await SchemaInitializer.CreateDatabaseAsync(Connection, DatabaseName, CancellationToken.None);
-        await Connection.ChangeDatabaseAsync(DatabaseName);
+        TransactionHandler = new SqlTransactionHandler();
+
+        IOptions<SqlServerDataStoreConfiguration> options = Options.Create(Config);
+        ConnectionFactory = new SqlConnectionWrapperFactory(
+            TransactionHandler,
+            new DefaultSqlConnectionBuilder(ConnectionStringProvider, SqlConfigurableRetryFactory.CreateNoneRetryProvider()),
+            SqlConfigurableRetryFactory.CreateFixedRetryProvider(new SqlClientRetryOptions().Settings),
+            options);
+
+        ConnectionWrapper = await ConnectionFactory.ObtainSqlConnectionWrapperAsync("master", CancellationToken.None);
+
+        await SchemaInitializer.CreateDatabaseAsync(ConnectionWrapper, DatabaseName, CancellationToken.None);
+        await ConnectionWrapper.SqlConnection.ChangeDatabaseAsync(DatabaseName);
         Output.WriteLine($"Using database '{DatabaseName}'.");
     }
 
     public virtual async Task DisposeAsync()
     {
-        await Connection.ChangeDatabaseAsync("master");
+        await ConnectionWrapper.SqlConnection.ChangeDatabaseAsync("master");
         try
         {
             await DeleteDatabaseAsync(DatabaseName);
@@ -70,11 +84,11 @@ public abstract class SqlIntegrationTestBase : IAsyncLifetime
             throw;
         }
 
-        await Connection.CloseAsync();
-        await Connection.DisposeAsync();
+        await ConnectionWrapper.SqlConnection.CloseAsync();
+        ConnectionWrapper.Dispose();
+        TransactionHandler.Dispose();
     }
 
-    [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Database name is validated.")]
     protected async Task DeleteDatabaseAsync(string dbName)
     {
         if (!Identifier.IsValidDatabase(dbName))
@@ -82,11 +96,13 @@ public abstract class SqlIntegrationTestBase : IAsyncLifetime
             throw new ArgumentException($"Invalid DB identifier '{dbName}'", nameof(dbName));
         }
 
-        using var deleteDatabaseCommand = new SqlCommand($"ALTER DATABASE {dbName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE {dbName};", Connection);
-        if (Connection.Database == dbName)
+        using SqlCommandWrapper deleteDatabaseCommand = ConnectionWrapper.CreateRetrySqlCommand();
+        deleteDatabaseCommand.CommandText = $"ALTER DATABASE {dbName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE {dbName};";
+
+        if (ConnectionWrapper.SqlConnection.Database == dbName)
         {
             Output.WriteLine($"Switching from '{dbName}' to master prior to delete.");
-            await Connection.ChangeDatabaseAsync("master", CancellationToken.None);
+            await ConnectionWrapper.SqlConnection.ChangeDatabaseAsync("master", CancellationToken.None);
         }
 
         int result = await deleteDatabaseCommand.ExecuteNonQueryAsync(CancellationToken.None);

--- a/tools/SchemaManager/Program.cs
+++ b/tools/SchemaManager/Program.cs
@@ -70,7 +70,7 @@ internal class Program
             };
         });
         services.AddSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>();
-        services.AddSingleton<IBaseSchemaRunner, BaseSchemaRunner>();
+        services.AddScoped<IBaseSchemaRunner, BaseSchemaRunner>();
         services.AddScoped<SqlConnectionWrapperFactory>();
         services.AddScoped<SqlTransactionHandler>();
         services.AddScoped<ISchemaManagerDataStore, SchemaManagerDataStore>();


### PR DESCRIPTION
## Description
- Leverage `SqlConnectionWrapperFactory` in `BaseSchemaRunner` and `SchemaInitializer`
- Add new API to `SqlConnectionWrapper` to override the initial catalog
- Make `BaseSchemaRunner` a scoped service for schema manager

## Related issues
N/A

## Testing
Pipeline

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
