### PR TITLE
Add support to skip purging instances

### DIFF
--- a/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using DurableTask.Core;
 using EnsureThat;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
@@ -82,7 +81,8 @@ public class PurgeOrchestrationInstanceHistoryTests
         _purgeConfig.InstancesToSkipPurging = new string[] { instanceId1 };
         _purgeTask = new PurgeOrchestrationInstanceHistory(Options.Create(_purgeConfig));
 
-        var durableOrchestrationState = new List<DurableOrchestrationStatus> {
+        var durableOrchestrationState = new List<DurableOrchestrationStatus> 
+        {
             new DurableOrchestrationStatus { InstanceId = instanceId1, Name = instanceId1 },
             new DurableOrchestrationStatus { InstanceId = instanceId2, Name = instanceId2 }
         };

--- a/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
@@ -77,13 +77,15 @@ public class PurgeOrchestrationInstanceHistoryTests
     {
         var instanceId1 = Guid.NewGuid().ToString();
         var instanceId2 = Guid.NewGuid().ToString();
+        var instanceName1 = "Re-Index";
+        var instanceName2 = "CopyInstance";
 
-        _purgeConfig.InstancesToSkipPurging = new string[] { instanceId1 };
+        _purgeConfig.ExcludeFunctions = new string[] { instanceName2 };
 
         var durableOrchestrationState = new List<DurableOrchestrationStatus> 
         {
-            new DurableOrchestrationStatus { InstanceId = instanceId1, Name = instanceId1 },
-            new DurableOrchestrationStatus { InstanceId = instanceId2, Name = instanceId2 }
+            new DurableOrchestrationStatus { InstanceId = instanceId1, Name = instanceName1 },
+            new DurableOrchestrationStatus { InstanceId = instanceId2, Name = instanceName2 }
         };
 
         _durableClient
@@ -94,7 +96,7 @@ public class PurgeOrchestrationInstanceHistoryTests
             });
 
         _durableClient
-            .PurgeInstanceHistoryAsync(instanceId2)
+            .PurgeInstanceHistoryAsync(instanceId1)
             .Returns(new PurgeHistoryResult(1));
 
         using (Mock.Property(() => ClockResolver.UtcNowFunc, () => _utcNow))
@@ -104,7 +106,7 @@ public class PurgeOrchestrationInstanceHistoryTests
 
         await _durableClient
             .Received(1)
-            .PurgeInstanceHistoryAsync(instanceId2);
+            .PurgeInstanceHistoryAsync(instanceId1);
     }
 
     private bool AreConditionEqual(OrchestrationStatusQueryCondition condition)

--- a/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
@@ -27,7 +27,7 @@ public class PurgeOrchestrationInstanceHistoryTests
     private readonly TimerInfo _timer;
     private readonly PurgeHistoryOptions _purgeConfig;
     private readonly IDurableOrchestrationClient _durableClient;
-    private PurgeOrchestrationInstanceHistory _purgeTask;
+    private readonly PurgeOrchestrationInstanceHistory _purgeTask;
 
     public PurgeOrchestrationInstanceHistoryTests()
     {
@@ -79,7 +79,6 @@ public class PurgeOrchestrationInstanceHistoryTests
         var instanceId2 = Guid.NewGuid().ToString();
 
         _purgeConfig.InstancesToSkipPurging = new string[] { instanceId1 };
-        _purgeTask = new PurgeOrchestrationInstanceHistory(Options.Create(_purgeConfig));
 
         var durableOrchestrationState = new List<DurableOrchestrationStatus> 
         {

--- a/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
@@ -110,9 +110,7 @@ public class PurgeOrchestrationInstanceHistoryTests
 
     private bool AreConditionEqual(OrchestrationStatusQueryCondition condition)
     {
-        EnsureArg.IsNotNull(_purgeConfig.Statuses, nameof(_purgeConfig.Statuses));
-
-        return condition.RuntimeStatus.SequenceEqual(_purgeConfig.Statuses)
+        return condition.RuntimeStatus.SequenceEqual(_purgeConfig.Statuses!)
             && condition.CreatedTimeFrom == DateTime.MinValue
             && condition.CreatedTimeTo == _utcNow.AddDays(-_purgeConfig.MinimumAgeDays);
     }

--- a/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/Management/PurgeOrchestrationInstanceHistoryTests.cs
@@ -48,12 +48,18 @@ public class PurgeOrchestrationInstanceHistoryTests
     [InlineData(12)]
     public async Task GivenOrchestrationInstances_WhenPurgeCompletedDurableFunctionsHistory_ThenOrchestrationsPurgedAsync(int count)
     {
+        OrchestrationStatusQueryCondition condition = new OrchestrationStatusQueryCondition
+        {
+            CreatedTimeFrom = DateTime.MinValue,
+            CreatedTimeTo = _utcNow.AddDays(-_purgeConfig.MinimumAgeDays),
+            RuntimeStatus = _purgeConfig.Statuses,
+        };
         var instanceId = Guid.NewGuid().ToString();
 
         var durableOrchestrationState = Enumerable.Repeat(new DurableOrchestrationStatus { InstanceId = instanceId }, count);
 
         _durableClient
-            .ListInstancesAsync(Arg.Any<OrchestrationStatusQueryCondition>(), Arg.Any<CancellationToken>())
+            .ListInstancesAsync(condition, Arg.Any<CancellationToken>())
             .Returns(new OrchestrationStatusQueryResult
             {
                 DurableOrchestrationState = durableOrchestrationState

--- a/src/Microsoft.Health.Operations.Functions/Management/PurgeHistoryOptions.cs
+++ b/src/Microsoft.Health.Operations.Functions/Management/PurgeHistoryOptions.cs
@@ -49,5 +49,5 @@ public class PurgeHistoryOptions
     ///  Gets or sets the collection of orchestration names which should be skipped for cleanup
     /// </summary>
     /// <value>A set of one or more <see cref="string"/></value>
-    public IReadOnlyCollection<string>? InstancesToSkipPurging { get; set; }
+    public IReadOnlyCollection<string>? ExcludeFunctions { get; set; }
 }

--- a/src/Microsoft.Health.Operations.Functions/Management/PurgeHistoryOptions.cs
+++ b/src/Microsoft.Health.Operations.Functions/Management/PurgeHistoryOptions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using DurableTask.Core;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 
 namespace Microsoft.Health.Operations.Functions.Management;
 
@@ -23,10 +24,10 @@ public class PurgeHistoryOptions
     /// <summary>
     /// Gets or sets the collection of statuses which should be considered for deletion.
     /// </summary>
-    /// <value>A set of at least one <see cref="OrchestrationStatus"/>.</value>
+    /// <value>A set of at least one <see cref="OrchestrationRuntimeStatus"/>.</value>
     [Required]
     [MinLength(1)]
-    public IReadOnlyCollection<OrchestrationStatus>? Statuses { get; set; } = new OrchestrationStatus[] { OrchestrationStatus.Completed };
+    public IReadOnlyCollection<OrchestrationRuntimeStatus>? Statuses { get; set; } = new OrchestrationRuntimeStatus[] { OrchestrationRuntimeStatus.Completed };
 
     /// <summary>
     /// Gets or sets the minimum amount of time from when the orchestration was created
@@ -43,4 +44,10 @@ public class PurgeHistoryOptions
     /// <value>A value cron expression</value>
     [Required]
     public string? Frequency { get; set; }
+
+    /// <summary>
+    ///  Gets or sets the collection of orchestration ids which should be skipped for cleanup
+    /// </summary>
+    /// <value>A set of one or more <see cref="string"/></value>
+    public IReadOnlyCollection<string>? InstancesToSkipPurging { get; set; } = Array.Empty<string>();
 }

--- a/src/Microsoft.Health.Operations.Functions/Management/PurgeHistoryOptions.cs
+++ b/src/Microsoft.Health.Operations.Functions/Management/PurgeHistoryOptions.cs
@@ -46,8 +46,8 @@ public class PurgeHistoryOptions
     public string? Frequency { get; set; }
 
     /// <summary>
-    ///  Gets or sets the collection of orchestration ids which should be skipped for cleanup
+    ///  Gets or sets the collection of orchestration names which should be skipped for cleanup
     /// </summary>
     /// <value>A set of one or more <see cref="string"/></value>
-    public IReadOnlyCollection<string>? InstancesToSkipPurging { get; set; } = Array.Empty<string>();
+    public IReadOnlyCollection<string>? InstancesToSkipPurging { get; set; }
 }

--- a/src/Microsoft.Health.Operations.Functions/Management/PurgeOrchestrationInstanceHistory.cs
+++ b/src/Microsoft.Health.Operations.Functions/Management/PurgeOrchestrationInstanceHistory.cs
@@ -24,10 +24,7 @@ namespace Microsoft.Health.Operations.Functions.Management;
 /// </summary>
 public sealed class PurgeOrchestrationInstanceHistory
 {
-    private readonly IReadOnlyCollection<OrchestrationRuntimeStatus> _statuses;
-    private readonly TimeSpan _minimumAge;
-    private readonly IReadOnlyCollection<string> _instancesToSkipPurging;
-
+    private readonly PurgeHistoryOptions _options;
     private const string PurgeFrequencyVariable = $"%{AzureFunctionsJobHost.RootSectionName}:{PurgeHistoryOptions.SectionName}:{nameof(PurgeHistoryOptions.Frequency)}%";
 
     /// <summary>
@@ -42,10 +39,7 @@ public sealed class PurgeOrchestrationInstanceHistory
     /// </exception>
     public PurgeOrchestrationInstanceHistory(IOptions<PurgeHistoryOptions> options)
     {
-        PurgeHistoryOptions value = EnsureArg.IsNotNull(options?.Value, nameof(options));
-        _statuses = EnsureArg.HasItems(value.Statuses, nameof(options));
-        _minimumAge = TimeSpan.FromDays(EnsureArg.IsGt(value.MinimumAgeDays, 0, nameof(options)));
-        _instancesToSkipPurging = value.InstancesToSkipPurging == null ? Array.Empty<string>() : value.InstancesToSkipPurging;
+        _options = EnsureArg.IsNotNull(options?.Value, nameof(options));
     }
 
     /// <summary>
@@ -61,6 +55,9 @@ public sealed class PurgeOrchestrationInstanceHistory
         EnsureArg.IsNotNull(client, nameof(client));
         EnsureArg.IsNotNull(myTimer, nameof(myTimer));
         EnsureArg.IsNotNull(log, nameof(log));
+        IReadOnlyCollection<OrchestrationRuntimeStatus>? statuses = EnsureArg.HasItems(_options.Statuses, nameof(_options.Statuses));
+        TimeSpan minimumAge = TimeSpan.FromDays(EnsureArg.IsGt(_options.MinimumAgeDays, 0, nameof(_options.MinimumAgeDays)));
+        IReadOnlyCollection<string>? instancesToSkipPurging = _options.InstancesToSkipPurging == null ? Array.Empty<string>() : _options.InstancesToSkipPurging;
 
         log.LogInformation("Purging orchestration instance history at: {Timestamp}", Clock.UtcNow);
         if (myTimer.IsPastDue)
@@ -68,22 +65,22 @@ public sealed class PurgeOrchestrationInstanceHistory
             log.LogWarning("Current function invocation is running late.");
         }
 
-        DateTimeOffset end = Clock.UtcNow - _minimumAge;
+        DateTimeOffset end = Clock.UtcNow - minimumAge;
         log.LogInformation("Purging all orchestration instances with status in {{{Statuses}}} that started before '{End}' and not in {{{ListofInstanceToSkipPurging}}}.",
-            string.Join(", ", _statuses),
+            string.Join(", ", statuses),
             end,
-            string.Join(", ", _instancesToSkipPurging));
+            string.Join(", ", instancesToSkipPurging));
 
         OrchestrationStatusQueryCondition condition = new OrchestrationStatusQueryCondition
         {
             CreatedTimeFrom = DateTime.MinValue,
             CreatedTimeTo = end.UtcDateTime,
-            RuntimeStatus = _statuses
+            RuntimeStatus = statuses
         };
 
         var instances = await client.ListInstancesAsync(condition, CancellationToken.None);
 
-        var instancesToPurge = instances.DurableOrchestrationState.Where(x => !_instancesToSkipPurging.Contains(x.Name, StringComparer.OrdinalIgnoreCase));
+        var instancesToPurge = instances.DurableOrchestrationState.Where(x => !instancesToSkipPurging.Contains(x.Name, StringComparer.OrdinalIgnoreCase));
 
         foreach(var instance in instancesToPurge)
         {

--- a/src/Microsoft.Health.Operations.Functions/Management/PurgeOrchestrationInstanceHistory.cs
+++ b/src/Microsoft.Health.Operations.Functions/Management/PurgeOrchestrationInstanceHistory.cs
@@ -59,7 +59,7 @@ public sealed class PurgeOrchestrationInstanceHistory
 
         IReadOnlyCollection<OrchestrationRuntimeStatus> statuses = _options.Statuses!;
         TimeSpan minimumAge = TimeSpan.FromDays(_options.MinimumAgeDays);
-        IReadOnlyCollection<string> instancesToSkipPurging = _options.InstancesToSkipPurging == null ? Array.Empty<string>() : _options.InstancesToSkipPurging;
+        IReadOnlyCollection<string> excludeFunctions = _options.ExcludeFunctions == null ? Array.Empty<string>() : _options.ExcludeFunctions;
 
         log.LogInformation("Purging orchestration instance history at: {Timestamp}", Clock.UtcNow);
         if (myTimer.IsPastDue)
@@ -71,7 +71,7 @@ public sealed class PurgeOrchestrationInstanceHistory
         log.LogInformation("Purging all orchestration instances with status in {{{Statuses}}} that started before '{End}' and not in {{{ListofInstanceToSkipPurging}}}.",
             string.Join(", ", statuses),
             end,
-            string.Join(", ", instancesToSkipPurging));
+            string.Join(", ", excludeFunctions));
 
         OrchestrationStatusQueryCondition condition = new OrchestrationStatusQueryCondition
         {
@@ -82,7 +82,7 @@ public sealed class PurgeOrchestrationInstanceHistory
 
         OrchestrationStatusQueryResult instances = await client.ListInstancesAsync(condition, CancellationToken.None);
 
-        IEnumerable<DurableOrchestrationStatus> instancesToPurge = instances.DurableOrchestrationState.Where(x => !instancesToSkipPurging.Contains(x.Name, StringComparer.OrdinalIgnoreCase));
+        IEnumerable<DurableOrchestrationStatus> instancesToPurge = instances.DurableOrchestrationState.Where(x => !excludeFunctions.Contains(x.Name, StringComparer.OrdinalIgnoreCase));
 
         int purgedInstances = 0;
         foreach (DurableOrchestrationStatus instance in instancesToPurge)

--- a/src/Microsoft.Health.Operations.Functions/Management/PurgeOrchestrationInstanceHistory.cs
+++ b/src/Microsoft.Health.Operations.Functions/Management/PurgeOrchestrationInstanceHistory.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using DurableTask.Core;
 using EnsureThat;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;


### PR DESCRIPTION
## Description
This PR adds support to skip purging instances. This is useful if we want to keep the state of the orchestration in the table storage.

## Related issues
Addresses [[AB#91768](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/91768)].

## Testing
Add unit tests

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
