### PR TITLE
Fix for branches with # symbol in name.

### DIFF
--- a/scripts/Publish-LocalChanges.ps1
+++ b/scripts/Publish-LocalChanges.ps1
@@ -89,7 +89,7 @@ Push-Location $RepoRootPath
 
 try {
     $branchName = &git rev-parse --abbrev-ref HEAD
-    $branchNameParts = $branchName.Split("/")
+    $branchNameParts = $branchName.Replace('#', '').Split("/")
     $version = "1.0.0-$($branchNameParts[$branchNameParts.Length - 1])-$(Get-Date -Format yyyyMMdd-HHmmss)-preview"
 
     # Find all projects in the components.


### PR DESCRIPTION
Currently, the script returns the error message "X is not a valid version string" when run against a branch with a # symbol in its name.

This PR fixes this issue by adding .Replace('#', '') to remove the offending character.

Full example error message:
error : '1.0.0-[AB#91764](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/91764)-ISchemaClientChange-20220525-110134-preview' is not a valid version string. (Parameter 'value')