### PR TITLE
Adds schema upgrade notification

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
@@ -11,10 +11,12 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using MediatR;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
+using Microsoft.Health.SqlServer.Features.Schema.Extensions;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Exceptions;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Model;
 using Microsoft.SqlServer.Management.Common;
@@ -29,6 +31,7 @@ public class SqlSchemaManager : ISchemaManager
     private readonly ISchemaManagerDataStore _schemaManagerDataStore;
     private readonly ISchemaClient _schemaClient;
     private readonly ILogger<SqlSchemaManager> _logger;
+    private readonly IMediator _mediator;
 
     private TimeSpan _retrySleepDuration = TimeSpan.FromSeconds(20);
     private const int RetryAttempts = 3;
@@ -38,12 +41,14 @@ public class SqlSchemaManager : ISchemaManager
         IBaseSchemaRunner baseSchemaRunner,
         ISchemaManagerDataStore schemaManagerDataStore,
         ISchemaClient schemaClient,
+        IMediator mediator,
         ILogger<SqlSchemaManager> logger)
     {
         _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
         _baseSchemaRunner = EnsureArg.IsNotNull(baseSchemaRunner, nameof(baseSchemaRunner));
         _schemaManagerDataStore = EnsureArg.IsNotNull(schemaManagerDataStore, nameof(schemaManagerDataStore));
         _schemaClient = EnsureArg.IsNotNull(schemaClient, nameof(schemaClient));
+        _mediator = EnsureArg.IsNotNull(mediator, nameof(mediator));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));
     }
 
@@ -288,6 +293,10 @@ public class SqlSchemaManager : ISchemaManager
         await _schemaManagerDataStore.ExecuteScriptAndCompleteSchemaVersionAsync(script, version, applyFullSchemaSnapshot, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation("Schema migration completed successfully for the version : {Version}.", version);
+
+        // this notification is used by the fhir service to initialized the dictionaries
+        await _mediator.NotifySchemaUpgradedAsync(version, applyFullSchemaSnapshot);
+        _logger.LogInformation("Schema upgrade notification sent for version: {Version}, applyFullSchemaSnapshot: {ApplyFullSchemaSnapshot}", version, applyFullSchemaSnapshot);
     }
 
     private async Task ValidateInstancesVersionAsync(int version, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
@@ -294,7 +294,8 @@ public class SqlSchemaManager : ISchemaManager
 
         _logger.LogInformation("Schema migration completed successfully for the version : {Version}.", version);
 
-        // this notification is used by the fhir service to initialized the dictionaries
+        // It is to publish the SchemaUpgraded event to notify the service that schema initialization or upgrade is completed to this version
+        // for e.g. fhir service listents to this event and initialize its dictionaries after schema is initialized.
         await _mediator.NotifySchemaUpgradedAsync(version, applyFullSchemaSnapshot);
         _logger.LogInformation("Schema upgrade notification sent for version: {Version}, applyFullSchemaSnapshot: {ApplyFullSchemaSnapshot}", version, applyFullSchemaSnapshot);
     }

--- a/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
+++ b/test/SchemaManager.Core.UnitTests/SqlSchemaManagerTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
@@ -26,6 +27,7 @@ public class SqlSchemaManagerTests
     private readonly ISchemaManagerDataStore _schemaManagerDataStore = Substitute.For<ISchemaManagerDataStore>();
     private readonly ISchemaClient _client = Substitute.For<ISchemaClient>();
     private readonly IBaseSchemaRunner _baseSchemaRunner = Substitute.For<IBaseSchemaRunner>();
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
 
     public SqlSchemaManagerTests()
     {
@@ -36,7 +38,7 @@ public class SqlSchemaManagerTests
 
         _baseSchemaRunner.EnsureBaseSchemaExistsAsync(default).ReturnsForAnyArgs(Task.FromResult(true));
         _baseSchemaRunner.EnsureInstanceSchemaRecordExistsAsync(default).ReturnsForAnyArgs(Task.FromResult(true));
-        _sqlSchemaManager = new SqlSchemaManager(Options.Create(_configuration), _baseSchemaRunner, _schemaManagerDataStore, _client, NullLogger<SqlSchemaManager>.Instance);
+        _sqlSchemaManager = new SqlSchemaManager(Options.Create(_configuration), _baseSchemaRunner, _schemaManagerDataStore, _client, _mediator, NullLogger<SqlSchemaManager>.Instance);
     }
 
     [Fact]

--- a/tools/SchemaManager/Program.cs
+++ b/tools/SchemaManager/Program.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using MediatR;
 using System;
 using System.CommandLine;
 using System.CommandLine.Builder;
@@ -18,6 +19,7 @@ using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using Microsoft.Health.SqlServer.Features.Storage;
+using Microsoft.Health.SqlServer.Features.Schema.Messages.Notifications;
 
 namespace SchemaManager;
 
@@ -75,6 +77,7 @@ internal class Program
         services.AddScoped<ISchemaManagerDataStore, SchemaManagerDataStore>();
         services.AddSingleton<ISchemaClient, SchemaClient>();
         services.AddSingleton<ISchemaManager, SqlSchemaManager>();
+        services.AddMediatR(typeof(SchemaUpgradedNotification).Assembly);
         services.AddLogging(configure => configure.AddConsole());
         return services.BuildServiceProvider();
     }

--- a/tools/SchemaManager/SchemaManager.csproj
+++ b/tools/SchemaManager/SchemaManager.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19174.3" />
     <PackageReference Include="System.CommandLine.Rendering" Version="0.2.0-alpha.19174.3" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
This PR adds schemaUpgradedNotification to be sent out whenever the schema is initialized/upgraded so that the fhir-service can initialize dictionaries when schema is not null.

## Related issues
Addresses[ #91880](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=91880)

## Testing
Tested locally

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
