### PR TITLE
Remove validate check for decimal/float

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/ColumnsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/ColumnsTests.cs
@@ -62,7 +62,8 @@ public class ColumnsTests
         Assert.True(record.GetSqlString(0).Value.Equals("text", System.StringComparison.Ordinal));
     }
 
-    [Fact]
+
+    [Fact(Skip = "Renable after User Story 92202")]
     public void GivenDecimalValueGreaterThanDefinedColumnPrecisionAndScaleMax_WhenSettingDecimalValue_ThenSqlTruncateExceptionThrown()
     {
         var decimalColumn = new DecimalColumn("decimalColumn", 18, 6);

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -287,7 +287,10 @@ public class DecimalColumn : Column<decimal>
     public override void Set(SqlDataRecord record, int ordinal, decimal value)
     {
         EnsureArg.IsNotNull(record, nameof(record));
-        ColumnUtilities.ValidateLength(Metadata, value);
+
+        // TODO: restore the validation once we handle the error appropriately on the FHIR server, user story 92202
+        // ColumnUtilities.ValidateLength(Metadata, value);
+
         record.SetDecimal(ordinal, value);
     }
 }
@@ -532,7 +535,9 @@ public class NullableDecimalColumn : Column<decimal?>
 
         if (value.HasValue)
         {
-            ColumnUtilities.ValidateLength(Metadata, value.Value);
+            // TODO: restore the validation once we handle the error appropriately on the FHIR server, user story 92202
+            //ColumnUtilities.ValidateLength(Metadata, value.Value);
+
             record.SetDecimal(ordinal, value.Value);
         }
         else


### PR DESCRIPTION
## Description
Currently we throw an exception if we attempt to store a float/decimal of too high a precision in a column that won't support it.   This is blocking data from coming in.

## Related issues
Addresses [issue [AB#92204](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/92204)].

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
