### PR TITLE
Downgrade  Microsoft.IdentityModel.Tokens 6.17.0 to 6.18.0

### DIFF
--- a/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
+++ b/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Client/Microsoft.Health.Client.csproj
+++ b/src/Microsoft.Health.Client/Microsoft.Health.Client.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.18.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.18.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.17.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.17.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.17.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description
Getting token is broken in 6.18.0
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1861

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
