### PR TITLE
Add Method for Configuring Azure Functions Telemetry

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="MediatR" Version="9.0.0" />
     <PackageVersion Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.20.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(SdkPackageVersion)" />

--- a/src/Microsoft.Health.Functions.Extensions/Microsoft.Health.Functions.Extensions.csproj
+++ b/src/Microsoft.Health.Functions.Extensions/Microsoft.Health.Functions.Extensions.csproj
@@ -8,11 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" />
+    <PackageReference Include="Microsoft.ApplicationInsights" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/src/Microsoft.Health.Functions.Extensions/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Functions.Extensions/WebJobsServiceCollectionExtensions.cs
@@ -1,0 +1,53 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// A collection of <see langword="static" /> methods for configuring Azure Functions services.
+/// </summary>
+public static class WebJobsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Configures the application insights telemetry for Azure Functions applications.
+    /// </summary>
+    /// <param name="services">The collection of services.</param>
+    /// <param name="configure">A delegate for modifying the <see cref="TelemetryConfiguration"/> instance.</param>
+    /// <returns>The given <paramref name="services"/> for additional methods to use.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.
+    /// </exception>
+    public static IServiceCollection ConfigureWebJobsTelemetry(this IServiceCollection services, Action<IServiceProvider, TelemetryConfiguration> configure)
+    {
+        EnsureArg.IsNotNull(services, nameof(services));
+        EnsureArg.IsNotNull(configure, nameof(configure));
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ITelemetryModule, TelemetryConfigurationModule>(
+                p => new TelemetryConfigurationModule(c => configure(p, c))));
+
+        return services;
+    }
+
+    private sealed class TelemetryConfigurationModule : ITelemetryModule
+    {
+        private readonly Action<TelemetryConfiguration> _configure;
+
+        public TelemetryConfigurationModule(Action<TelemetryConfiguration> configure)
+            => _configure = EnsureArg.IsNotNull(configure, nameof(configure));
+
+        public void Initialize(TelemetryConfiguration configuration)
+            => _configure.Invoke(configuration);
+    }
+}


### PR DESCRIPTION
## Description
- Add new method for configuring Azure Functions (often included with Web Jobs) app insights configs

## Related issues
- [AB#91542](https://microsofthealth.visualstudio.com/Health/_workitems/edit/91542/)

## Testing
Ad-hoc testing in PAAS

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Feature
