### PR TITLE
Remove 128 limit from string SQL column

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/ColumnsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/ColumnsTests.cs
@@ -31,7 +31,7 @@ public class ColumnsTests
         Assert.Equal(data2, ((SqlBinary)record.GetSqlValue(0)).Value);
     }
 
-    [Fact]
+    [Fact(Skip="true")]
     public void GivenStringValueGreaterThanColumnMax_WhenSettingStringValue_ThenSqlTruncateExceptionThrown()
     {
         var varCharColumn = new VarCharColumn("text", 10);

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -767,12 +767,6 @@ public abstract class StringColumn : Column<string>
 
         if (value != null)
         {
-            // NVarChar(max) column has -1 length
-            if (Metadata.MaxLength > 0 && Metadata.MaxLength < value.Length)
-            {
-                throw new SqlTruncateException(string.Format(CultureInfo.CurrentCulture, Resources.StringTooLong, value.Length, Metadata.Name, Metadata.MaxLength));
-            }
-
             record.SetString(ordinal, value);
         }
         else


### PR DESCRIPTION
## Description
Do not enforce a limit on a string column length

## Related issues
Addresses [issue [AB#92775](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/92775)].

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
