### PR TITLE
ServiceCollection Registration updates

### DIFF
--- a/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
+++ b/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />

--- a/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
+++ b/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />

--- a/src/Microsoft.Health.EventGrid.UnitTests/Microsoft.Health.EventGrid.UnitTests.csproj
+++ b/src/Microsoft.Health.EventGrid.UnitTests/Microsoft.Health.EventGrid.UnitTests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />

--- a/src/Microsoft.Health.EventGrid.UnitTests/Microsoft.Health.EventGrid.UnitTests.csproj
+++ b/src/Microsoft.Health.EventGrid.UnitTests/Microsoft.Health.EventGrid.UnitTests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/Microsoft.Health.Extensions.DependencyInjection.UnitTests.csproj
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/Microsoft.Health.Extensions.DependencyInjection.UnitTests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/Microsoft.Health.Extensions.DependencyInjection.UnitTests.csproj
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/Microsoft.Health.Extensions.DependencyInjection.UnitTests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TypeRegistrationTests.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TypeRegistrationTests.cs
@@ -79,20 +79,13 @@ public class TypeRegistrationTests
     {
         _collection.Add<StringReader>()
             .Transient()
-            .AsSelf()
             .AsImplementedInterfaces();
 
-        _collection.Add<StringReader>()
+        _collection.Add<StringWriter>()
             .Transient()
-            .AsSelf()
-            .AsImplementedInterfaces();
+            .AsImplementedInterfaces();        
 
-        Assert.True(_collection.Count == 1);
-
-        Assert.Collection(_collection, x =>
-        {
-            Assert.Equal(typeof(StringReader), x.ImplementationType);
-        });
+        Assert.True(TypeRegistrationBuilder.RegistrationWarnings.Count == 2);
     }
 
     [Fact]

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TypeRegistrationTests.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TypeRegistrationTests.cs
@@ -78,11 +78,11 @@ public class TypeRegistrationTests
     public void GivenAType_WhenAddingTypeMultipleTimes_ThenOnlyOnlyOneInstanceIsRegistered()
     {
         _collection.Add<StringReader>()
-            .Transient()
+            .Singleton()
             .AsImplementedInterfaces();
 
         _collection.Add<StringWriter>()
-            .Transient()
+            .Singleton()
             .AsImplementedInterfaces();        
 
         Assert.True(TypeRegistrationBuilder.RegistrationWarnings.Count == 2);

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TypeRegistrationTests.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TypeRegistrationTests.cs
@@ -75,6 +75,27 @@ public class TypeRegistrationTests
     }
 
     [Fact]
+    public void GivenAType_WhenAddingTypeMultipleTimes_ThenOnlyOnlyOneInstanceIsRegistered()
+    {
+        _collection.Add<StringReader>()
+            .Transient()
+            .AsSelf()
+            .AsImplementedInterfaces();
+
+        _collection.Add<StringReader>()
+            .Transient()
+            .AsSelf()
+            .AsImplementedInterfaces();
+
+        Assert.True(_collection.Count == 1);
+
+        Assert.Collection(_collection, x =>
+        {
+            Assert.Equal(typeof(StringReader), x.ImplementationType);
+        });
+    }
+
+    [Fact]
     public void GivenAFactory_WhenReplacingSelf_ThenOnlyTheNewServiceIsRegistered()
     {
         _collection

--- a/src/Microsoft.Health.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -30,10 +29,11 @@ public static class ServiceCollectionExtensions
         EnsureArg.IsNotNull(collection, nameof(collection));
 
         var moduleType = typeof(T);
-        Debug.Assert(moduleType.IsClass && !moduleType.IsAbstract, "Module should be non-abstract class");
+        bool assertion = moduleType.IsClass && !moduleType.IsAbstract;
+        Debug.Assert(assertion, "Module should be non-abstract class");
 
         // have the registration follow same rules as fn RegisterAssemblyModules
-        if (moduleType.IsClass && !moduleType.IsAbstract)
+        if (assertion)
         {
             collection.RegisterModule(moduleType, constructorParams);
         }
@@ -55,25 +55,6 @@ public static class ServiceCollectionExtensions
         {
             collection.RegisterModule(moduleType, constructorParams);
         }
-    }
-
-    public static ICollection<string> CheckIssues(this IServiceCollection collection)
-    {
-        var issues = new List<string>();
-        var multipleRegisteredServices = collection
-            .GroupBy(x => (x.ServiceType, x.ImplementationType, x.ImplementationInstance, x.ImplementationFactory))
-            .Where(x => x.Count() > 1)
-            .ToArray();
-
-        if (multipleRegisteredServices.Any())
-        {
-            foreach (var service in multipleRegisteredServices)
-            {
-                issues.Add($"** IoC Config Warning: Service implementation '{service.Key.ImplementationType ?? service.Key.ImplementationInstance ?? service.Key.ImplementationFactory}' was registered multiple times.");
-            }
-        }
-
-        return issues;
     }
 
     private static void RegisterModule(this IServiceCollection collection, Type moduleType, params object[] constructorParams)

--- a/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationBuilder.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationBuilder.cs
@@ -218,7 +218,7 @@ public class TypeRegistrationBuilder
         }
         else
         {
-            _serviceCollection.Add(serviceDescriptor);
+            _serviceCollection.TryAdd(serviceDescriptor);
         }
     }
 

--- a/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationBuilder.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationBuilder.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -45,6 +46,11 @@ public class TypeRegistrationBuilder
     public TypeRegistrationBuilder AsService<T>() => AsService(typeof(T));
 
     /// <summary>
+    /// Keeps track of the Debug.Assert items
+    /// </summary>
+    public static ICollection<string> RegistrationWarnings { get; } = new List<string>();
+
+    /// <summary>
     /// Creates a service registration for the specified interface
     /// </summary>
     /// <param name="serviceType">The service type to be registered</param>
@@ -53,7 +59,14 @@ public class TypeRegistrationBuilder
     {
         EnsureArg.IsNotNull(serviceType, nameof(serviceType));
 
-        Debug.Assert(serviceType != _type, $"The \"AsSelf()\" registration should be used instead of \"AsService<{_type.Name}>()\".");
+        bool assertion = serviceType != _type;
+        string msg = $"The \"AsSelf()\" registration should be used instead of \"AsService<{_type.Name}>()\".";
+        Debug.Assert(assertion, msg);
+
+        if (!assertion)
+        {
+            RegistrationWarnings.Add(msg);
+        }
 
         RegisterType(serviceType);
 
@@ -122,9 +135,14 @@ public class TypeRegistrationBuilder
     /// <exception cref="NotSupportedException">Throws when Type was not explicitly defined</exception>
     public TypeRegistrationBuilder AsImplementedInterfaces(Predicate<Type> interfaceFilter = null)
     {
-        Debug.Assert(
-            _firstRegisteredType != null || _registrationMode == TypeRegistration.RegistrationMode.Transient,
-            $"Using \"AsImplementedInterfaces()\" without calling \"AsSelf()\" first in registration for \"{_type.Name}\" could have inconsistent results.");
+        bool assertion = _firstRegisteredType != null || _registrationMode == TypeRegistration.RegistrationMode.Transient;
+        string msg = $"Using \"AsImplementedInterfaces()\" without calling \"AsSelf()\" first in registration for \"{_type.Name}\" could have inconsistent results.";
+        Debug.Assert(assertion, msg);
+
+        if (!assertion)
+        {
+            RegistrationWarnings.Add(msg);
+        }
 
         if (interfaceFilter == null)
         {
@@ -148,7 +166,14 @@ public class TypeRegistrationBuilder
     /// <exception cref="NotSupportedException">Throws when Type was not explicitly defined</exception>
     public TypeRegistrationBuilder AsSelf()
     {
-        Debug.Assert(_firstRegisteredType == null, $"The \"AsSelf()\" registration for \"{_type.Name}\" should come first.");
+        bool assertion = _firstRegisteredType == null;
+        string msg = $"The \"AsSelf()\" registration for \"{_type.Name}\" should come first.";
+        Debug.Assert(assertion, msg);
+
+        if (!assertion)
+        {
+            RegistrationWarnings.Add(msg);
+        }
 
         RegisterType(_type);
 
@@ -162,7 +187,14 @@ public class TypeRegistrationBuilder
     /// <exception cref="NotSupportedException">Throws when Type was not explicitly defined</exception>
     public TypeRegistrationBuilder ReplaceSelf()
     {
-        Debug.Assert(_firstRegisteredType == null, $"The \"ReplaceSelf()\" registration for \"{_type.Name}\" should come first.");
+        bool assertion = _firstRegisteredType == null;
+        string msg = $"The \"ReplaceSelf()\" registration for \"{_type.Name}\" should come first.";
+        Debug.Assert(assertion, msg);
+
+        if (!assertion)
+        {
+            RegistrationWarnings.Add(msg);
+        }
 
         RegisterType(_type, replace: true);
 

--- a/src/Microsoft.Health.Operations.UnitTests/Microsoft.Health.Operations.UnitTests.csproj
+++ b/src/Microsoft.Health.Operations.UnitTests/Microsoft.Health.Operations.UnitTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Microsoft.Health.Operations.UnitTests/Microsoft.Health.Operations.UnitTests.csproj
+++ b/src/Microsoft.Health.Operations.UnitTests/Microsoft.Health.Operations.UnitTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>

--- a/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
+++ b/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>

--- a/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
+++ b/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Added a new collection that has the same messages that the Debug.Assert functions were raising when services were not correctly registered. The point of this is to merely expose these messages that already provided guidance on how they should be used.
Revised the services.Add() to be services.TryAdd() to prevent duplicates getting added.
Added a unit test.

## Related issues
Addresses [92947](https://microsofthealth.visualstudio.com/Health/_workitems/edit/92947)

## Testing
Added a new unit test and locally successfully ran all tests in Microsoft.Health.Extensions.DependencyInjection.UnitTests (net6.0)

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature
