### PR TITLE
Throw more specific schema exceptions

### DIFF
--- a/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
+++ b/src/Microsoft.Health.Client.UnitTests/Microsoft.Health.Client.UnitTests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />

--- a/src/Microsoft.Health.EventGrid.UnitTests/Microsoft.Health.EventGrid.UnitTests.csproj
+++ b/src/Microsoft.Health.EventGrid.UnitTests/Microsoft.Health.EventGrid.UnitTests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/Microsoft.Health.Extensions.DependencyInjection.UnitTests.csproj
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/Microsoft.Health.Extensions.DependencyInjection.UnitTests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />

--- a/src/Microsoft.Health.Operations.UnitTests/Microsoft.Health.Operations.UnitTests.csproj
+++ b/src/Microsoft.Health.Operations.UnitTests/Microsoft.Health.Operations.UnitTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Microsoft.Health.SqlServer.Api.UnitTests/Features/CompatibilityVersionHandlerTests.cs
+++ b/src/Microsoft.Health.SqlServer.Api.UnitTests/Features/CompatibilityVersionHandlerTests.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.SqlServer.Api.Features;
 using Microsoft.Health.SqlServer.Features.Schema;
@@ -29,7 +28,7 @@ public class CompatibilityVersionHandlerTests
     {
         _schemaMigrationDataStore = Substitute.For<ISchemaDataStore>();
         var collection = new ServiceCollection();
-        collection.Add(sp => new CompatibilityVersionHandler(_schemaMigrationDataStore)).Singleton().AsSelf().AsImplementedInterfaces();
+        collection.Add(_ => new CompatibilityVersionHandler(_schemaMigrationDataStore)).Singleton().AsSelf().AsImplementedInterfaces();
 
         ServiceProvider provider = collection.BuildServiceProvider();
         _mediator = new Mediator(type => provider.GetService(type));

--- a/src/Microsoft.Health.SqlServer/Features/Exceptions/CompatibleVersionsNotFoundException.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Exceptions/CompatibleVersionsNotFoundException.cs
@@ -1,0 +1,14 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.SqlServer.Features.Exceptions;
+
+public class CompatibleVersionsNotFoundException : SqlRecordNotFoundException
+{
+    public CompatibleVersionsNotFoundException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/BaseSchemaRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/BaseSchemaRunner.cs
@@ -89,7 +89,7 @@ public class BaseSchemaRunner : IBaseSchemaRunner
         {
             if (!await _schemaManagerDataStore.InstanceSchemaRecordExistsAsync(cancellationToken))
             {
-                throw new SchemaManagerException(Resources.InstanceSchemaRecordErrorMessage);
+                throw new InstanceSchemaNotFoundException(Resources.InstanceSchemaRecordErrorMessage);
             }
         }
         catch (SqlException e) when (e.Message.Contains("Invalid object name", StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/Exceptions/InstanceSchemaNotFoundException.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/Exceptions/InstanceSchemaNotFoundException.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.SqlServer.Features.Schema.Manager.Exceptions;
+
+public class InstanceSchemaNotFoundException : SchemaManagerException
+{
+    public InstanceSchemaNotFoundException(string message)
+        : base(message)
+    {
+    }
+
+    public InstanceSchemaNotFoundException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
@@ -57,7 +57,7 @@ internal class SqlServerSchemaDataStore : ISchemaDataStore
                 }
                 else
                 {
-                    throw new SqlRecordNotFoundException(Resources.CompatibilityRecordNotFound);
+                    throw new CompatibleVersionsNotFoundException(Resources.CompatibilityRecordNotFound);
                 }
             }
 
@@ -68,7 +68,7 @@ internal class SqlServerSchemaDataStore : ISchemaDataStore
         {
             if (o == DBNull.Value)
             {
-                throw new SqlRecordNotFoundException(Resources.CompatibilityRecordNotFound);
+                throw new CompatibleVersionsNotFoundException(Resources.CompatibilityRecordNotFound);
             }
             else
             {

--- a/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
+++ b/test/Microsoft.Health.Test.Common.Tests/Microsoft.Health.Test.Utilities.UnitTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Throws more specific exceptions when instance schema information is not found in the DB.

## Related issues
Addresses [AB#93113](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/93113)

## Testing
Manual testing downstream.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
