### PR TITLE
Update MI credential provider to be able to specify clientid

### DIFF
--- a/src/Microsoft.Health.Client/Authentication/ManagedIdentityCredentialOptions.cs
+++ b/src/Microsoft.Health.Client/Authentication/ManagedIdentityCredentialOptions.cs
@@ -22,7 +22,20 @@ public class ManagedIdentityCredentialOptions
         TenantId = tenantId;
     }
 
+    public ManagedIdentityCredentialOptions(string resource, string tenantId, string clientId)
+    {
+        EnsureArg.IsNotNullOrWhiteSpace(resource, nameof(resource));
+        EnsureArg.IsNotNullOrWhiteSpace(tenantId, nameof(tenantId));
+        EnsureArg.IsNotNullOrWhiteSpace(clientId, nameof(clientId));
+
+        Resource = resource;
+        TenantId = tenantId;
+        ClientId = clientId;
+    }
+
     public string Resource { get; set; }
 
     public string TenantId { get; set; }
+
+    public string ClientId { get; set; }
 }

--- a/src/Microsoft.Health.Client/Authentication/ManagedIdentityCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/Authentication/ManagedIdentityCredentialProvider.cs
@@ -35,7 +35,6 @@ public class ManagedIdentityCredentialProvider : CredentialProvider
     {
         ManagedIdentityCredentialOptions managedIdentityCredentialOptions = _managedIdentityCredentialOptionsMonitor.Get(_optionsName);
 
-
         var defaultAzureCredentialOptions = new DefaultAzureCredentialOptions();        
 
         if (!string.IsNullOrEmpty(managedIdentityCredentialOptions.ClientId))

--- a/src/Microsoft.Health.Client/Authentication/ManagedIdentityCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/Authentication/ManagedIdentityCredentialProvider.cs
@@ -35,12 +35,15 @@ public class ManagedIdentityCredentialProvider : CredentialProvider
     {
         ManagedIdentityCredentialOptions managedIdentityCredentialOptions = _managedIdentityCredentialOptionsMonitor.Get(_optionsName);
 
-        var defaultAzureCredential = new DefaultAzureCredential();
+
+        var defaultAzureCredentialOptions = new DefaultAzureCredentialOptions();        
 
         if (!string.IsNullOrEmpty(managedIdentityCredentialOptions.ClientId))
         {
-            defaultAzureCredential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = managedIdentityCredentialOptions.ClientId });
+            defaultAzureCredentialOptions.ManagedIdentityClientId = managedIdentityCredentialOptions.ClientId;
         }
+        
+        var defaultAzureCredential = new DefaultAzureCredential(defaultAzureCredentialOptions);
 
         var tokenRequestContext = new TokenRequestContext(
             scopes: new[] { managedIdentityCredentialOptions.Resource },

--- a/src/Microsoft.Health.Client/Authentication/ManagedIdentityCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/Authentication/ManagedIdentityCredentialProvider.cs
@@ -36,6 +36,12 @@ public class ManagedIdentityCredentialProvider : CredentialProvider
         ManagedIdentityCredentialOptions managedIdentityCredentialOptions = _managedIdentityCredentialOptionsMonitor.Get(_optionsName);
 
         var defaultAzureCredential = new DefaultAzureCredential();
+
+        if (!string.IsNullOrEmpty(managedIdentityCredentialOptions.ClientId))
+        {
+            defaultAzureCredential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = managedIdentityCredentialOptions.ClientId });
+        }
+
         var tokenRequestContext = new TokenRequestContext(
             scopes: new[] { managedIdentityCredentialOptions.Resource },
             tenantId: managedIdentityCredentialOptions.TenantId);


### PR DESCRIPTION
## Description
Since we now have multiple MIs in dicom, we need to be able to specify the MI's client id

## Related issues
Addresses #93318

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
