### PR TITLE
Skip ValidateInstancesVersionAsync when apply schema command is forced

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManager.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManager.cs
@@ -19,7 +19,7 @@ public interface ISchemaManager
     /// <param name="force">Forces the apply schema</param>
     /// <param name="token">A cancellation token.</param>
     /// <returns>A task.</returns>
-    public Task ApplySchema(MutuallyExclusiveType type, bool force, CancellationToken token = default);
+    public Task ApplySchema(MutuallyExclusiveType type, bool force = false, CancellationToken token = default);
 
     /// <summary>
     /// Gets a list of available schema versions.

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManager.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/ISchemaManager.cs
@@ -16,9 +16,10 @@ public interface ISchemaManager
     /// Applies SQL schemas specified by the range in <paramref name="type"/>.
     /// </summary>
     /// <param name="type">The schema version to apply.</param>
+    /// <param name="force">Forces the apply schema</param>
     /// <param name="token">A cancellation token.</param>
     /// <returns>A task.</returns>
-    public Task ApplySchema(MutuallyExclusiveType type, CancellationToken token = default);
+    public Task ApplySchema(MutuallyExclusiveType type, bool force, CancellationToken token = default);
 
     /// <summary>
     /// Gets a list of available schema versions.

--- a/tools/SchemaManager/Commands/ApplyCommand.cs
+++ b/tools/SchemaManager/Commands/ApplyCommand.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ public class ApplyCommand : Command
             return Task.CompletedTask;
         }
 
-        return _schemaManager.ApplySchema(exclusiveType, cancellationToken);
+        return _schemaManager.ApplySchema(exclusiveType, force, cancellationToken);
     }
 
     private bool EnsureForce()


### PR DESCRIPTION
## Description
Given that the service is not running (meaning SchemaJobWorker is also not running which is responsible to update CurrentVersion in InstanceSchema table). If the current schemaVersion is set to x and we want to upgrade it to version x+5 then after applying first version x+1 we will start getting an error to verify if all the instances are running the previous version
This could happen for services that are in Warned or Suspended state. Forcing the apply schema by skipping the ValidateInstancesVersionAsync
                

## Related issues
Addresses [AB93732](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=93732)

## Testing
1. Unit test
2. With FHIR service - 
   -   Run FHIR service with SchemaVersionConstant.Max to 32 and enable auto upgrade. This will add an entry to the SchemaVersion and InstanceSchema table.
   -   Stop FHIR server. Update the SchemaVersionConstant.Max to 35.
   -   Set SchemaManager.Console project as a startup project. Update the launchsettings version to 35 and add --force true flag
   -   Run SchemaManager.Console and the SchemaVersion table should be updated with version 35.
   -   Run FHIR service again and now the SchemaJobWorker will also run updating the InstanceSchema table

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
