### PR TITLE
Add Missing OperationIdJsonConverter for Operation State

### DIFF
--- a/src/Microsoft.Health.Operations.UnitTests/OperationStateTests.cs
+++ b/src/Microsoft.Health.Operations.UnitTests/OperationStateTests.cs
@@ -25,12 +25,9 @@ public class OperationStateTests
     public void GivenState_WhenSerializing_OperationIdUsesProperFormat(Type type, IOperationState<int> state)
     {
         string json = JsonSerializer.Serialize(state, type);
-        AssertOperationId(JsonSerializer.Deserialize<JsonElement>(json), state.OperationId.ToString(OperationId.FormatSpecifier));
-    }
+        JsonElement element = JsonSerializer.Deserialize<JsonElement>(json);
 
-    private static void AssertOperationId(JsonElement element, string expected)
-    {
         Assert.True(element.TryGetProperty(nameof(IOperationState<int>.OperationId), out JsonElement property));
-        Assert.Equal(expected, property.GetString());
+        Assert.Equal(state.OperationId.ToString(OperationId.FormatSpecifier), property.GetString());
     }
 }

--- a/src/Microsoft.Health.Operations.UnitTests/OperationStateTests.cs
+++ b/src/Microsoft.Health.Operations.UnitTests/OperationStateTests.cs
@@ -1,0 +1,35 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text.Json;
+using Xunit;
+
+namespace Microsoft.Health.Operations.UnitTests;
+
+public class OperationStateTests
+{
+    [Fact]
+    public void GivenState_WhenSerializing_OperationIdUsesProperFormat()
+    {
+        string json;
+
+        // No payload
+        var s1 = new OperationState<int> { OperationId = Guid.NewGuid() };
+        json = JsonSerializer.Serialize(s1);
+        AssertOperationId(JsonSerializer.Deserialize<JsonElement>(json), s1.OperationId.ToString(OperationId.FormatSpecifier));
+
+        // With payload
+        var s2 = new OperationState<int, string> { OperationId = Guid.NewGuid(), Results = "Hello World" };
+        json = JsonSerializer.Serialize(s2);
+        AssertOperationId(JsonSerializer.Deserialize<JsonElement>(json), s2.OperationId.ToString(OperationId.FormatSpecifier));
+    }
+
+    private static void AssertOperationId(JsonElement element, string expected)
+    {
+        Assert.True(element.TryGetProperty(nameof(IOperationState<int>.OperationId), out JsonElement property));
+        Assert.Equal(expected, property.GetString());
+    }
+}

--- a/src/Microsoft.Health.Operations/OperationState.cs
+++ b/src/Microsoft.Health.Operations/OperationState.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Microsoft.Health.Operations.Serialization;
 
 namespace Microsoft.Health.Operations;
 
@@ -15,6 +17,7 @@ namespace Microsoft.Health.Operations;
 public sealed class OperationState<T> : IOperationState<T>
 {
     /// <inheritdoc cref="IOperationState{T}.OperationId"/>
+    [JsonConverter(typeof(OperationIdJsonConverter))]
     public Guid OperationId { get; init; }
 
     /// <inheritdoc cref="IOperationState{T}.Type"/>
@@ -47,6 +50,7 @@ public sealed class OperationState<T> : IOperationState<T>
 public sealed class OperationState<TType, TResults> : IOperationState<TType>
 {
     /// <inheritdoc cref="IOperationState{T}.OperationId"/>
+    [JsonConverter(typeof(OperationIdJsonConverter))]
     public Guid OperationId { get; init; }
 
     /// <inheritdoc cref="IOperationState{T}.Type"/>


### PR DESCRIPTION
## Description
- Add missing `OperationIdJsonConverter` for operation IDs in state

## Related issues
N/A

## Testing
N/A

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
