### PR TITLE
Support .NET Standard 2.0 for Operations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,10 @@
     <WarningsAsErrors />
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="$(RootDirectory)\lang\*" Visible="false" />
+  </ItemGroup>
+
   <Choose>
     <When Condition="$(MSBuildProjectName.Contains('Test'))">
       <PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,6 +73,7 @@
     <PackageVersion Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19174.3" />
     <PackageVersion Include="System.CommandLine.Rendering" Version="0.2.0-alpha.19174.3" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.6" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="Xunit.DependencyInjection" Version="8.5.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/lang/IsExternalInit.cs
+++ b/lang/IsExternalInit.cs
@@ -1,0 +1,23 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+// This file defines the IsExternalInit static class used to implement init-only properties.
+//
+// Documentation: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/init
+// Source: https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/Common/src/System/Runtime/CompilerServices/IsExternalInit.cs
+
+#if NETSTANDARD2_0
+
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.CompilerServices;
+
+[ExcludeFromCodeCoverage]
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal static class IsExternalInit
+{ }
+
+#endif

--- a/src/Microsoft.Health.Operations/Microsoft.Health.Operations.csproj
+++ b/src/Microsoft.Health.Operations/Microsoft.Health.Operations.csproj
@@ -1,13 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Abstractions for long-running operations used by Microsoft Health.</Description>
-    <TargetFrameworks>$(LtsVersion)</TargetFrameworks>
+    <TargetFrameworks>$(LtsVersion);netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description
- Add .NET Standard 2.0 support for function operations

## Related issues
N/A

## Testing
Existing tests and compilation

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
