### PR TITLE
[Test] Creating new trait for Owning Team

### DIFF
--- a/test/Microsoft.Health.Test.Common/Traits.cs
+++ b/test/Microsoft.Health.Test.Common/Traits.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -7,6 +7,9 @@ namespace Microsoft.Health.Test.Utilities;
 
 public static class Traits
 {
-    public const string Priority = "Priority";
-    public const string Category = "Category";
+    public const string Category = nameof(Category);
+
+    public const string OwningTeam = nameof(OwningTeam);
+
+    public const string Priority = nameof(Priority);
 }


### PR DESCRIPTION
Creating new trait for Owning Team.

This new trait will be used internally to split CI pipelines per owning team. 