### PR TITLE
[AB#95705] Added response headers for CSP and X-Frame-Options

### DIFF
--- a/src/Microsoft.Health.Api.UnitTests/Features/Security/SecurityHeadersHelperTests.cs
+++ b/src/Microsoft.Health.Api.UnitTests/Features/Security/SecurityHeadersHelperTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -35,7 +35,31 @@ public class SecurityHeadersHelperTests
 
         Assert.NotNull(defaultHttpContext.Response.Headers);
         Assert.NotEmpty(defaultHttpContext.Response.Headers);
-        Assert.True(defaultHttpContext.Response.Headers.TryGetValue("X-Content-Type-Options", out StringValues headerValue));
+        Assert.True(defaultHttpContext.Response.Headers.TryGetValue(SecurityHeadersHelper.XContentTypeOptions, out StringValues headerValue));
         Assert.Equal("nosniff", headerValue);
+    }
+
+    [Fact]
+    public async void GivenAContext_WhenSettingSecurityHeaders_TheXFrameOptionsHeaderIsSet()
+    {
+        var defaultHttpContext = new DefaultHttpContext();
+        await SecurityHeadersHelper.SetSecurityHeaders(defaultHttpContext);
+
+        Assert.NotNull(defaultHttpContext.Response.Headers);
+        Assert.NotEmpty(defaultHttpContext.Response.Headers);
+        Assert.True(defaultHttpContext.Response.Headers.TryGetValue(SecurityHeadersHelper.XFrameOptions, out StringValues headerValue));
+        Assert.Equal("SAMEORIGIN", headerValue);
+    }
+
+    [Fact]
+    public async void GivenAContext_WhenSettingSecurityHeaders_TheContentSecurityPolicyHeaderIsSet()
+    {
+        var defaultHttpContext = new DefaultHttpContext();
+        await SecurityHeadersHelper.SetSecurityHeaders(defaultHttpContext);
+
+        Assert.NotNull(defaultHttpContext.Response.Headers);
+        Assert.NotEmpty(defaultHttpContext.Response.Headers);
+        Assert.True(defaultHttpContext.Response.Headers.TryGetValue(SecurityHeadersHelper.ContentSecurityPolicy, out StringValues headerValue));
+        Assert.Equal("frame-src 'self';", headerValue);
     }
 }

--- a/src/Microsoft.Health.Api.UnitTests/Features/Security/SecurityHeadersHelperTests.cs
+++ b/src/Microsoft.Health.Api.UnitTests/Features/Security/SecurityHeadersHelperTests.cs
@@ -35,6 +35,7 @@ public class SecurityHeadersHelperTests
 
         Assert.NotNull(defaultHttpContext.Response.Headers);
         Assert.NotEmpty(defaultHttpContext.Response.Headers);
+        Assert.Equal("X-Content-Type-Options", SecurityHeadersHelper.XContentTypeOptions);
         Assert.True(defaultHttpContext.Response.Headers.TryGetValue(SecurityHeadersHelper.XContentTypeOptions, out StringValues headerValue));
         Assert.Equal("nosniff", headerValue);
     }
@@ -47,6 +48,7 @@ public class SecurityHeadersHelperTests
 
         Assert.NotNull(defaultHttpContext.Response.Headers);
         Assert.NotEmpty(defaultHttpContext.Response.Headers);
+        Assert.Equal("X-Frame-Options", SecurityHeadersHelper.XFrameOptions);
         Assert.True(defaultHttpContext.Response.Headers.TryGetValue(SecurityHeadersHelper.XFrameOptions, out StringValues headerValue));
         Assert.Equal("SAMEORIGIN", headerValue);
     }
@@ -59,6 +61,7 @@ public class SecurityHeadersHelperTests
 
         Assert.NotNull(defaultHttpContext.Response.Headers);
         Assert.NotEmpty(defaultHttpContext.Response.Headers);
+        Assert.Equal("Content-Security-Policy", SecurityHeadersHelper.ContentSecurityPolicy);
         Assert.True(defaultHttpContext.Response.Headers.TryGetValue(SecurityHeadersHelper.ContentSecurityPolicy, out StringValues headerValue));
         Assert.Equal("frame-src 'self';", headerValue);
     }

--- a/src/Microsoft.Health.Api/Features/Security/SecurityHeadersHelper.cs
+++ b/src/Microsoft.Health.Api/Features/Security/SecurityHeadersHelper.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -15,6 +15,12 @@ internal static class SecurityHeadersHelper
     private const string XContentTypeOptions = "X-Content-Type-Options";
     private const string XContentTypeOptionsValue = "nosniff";
 
+    private const string XFrameOptions = "X-Frame-Options";
+    private const string XFrameOptionsValue = "SAMEORIGIN";
+
+    private const string ContentSecurityPolicy = "Content-Security-Policy";
+    private const string ContentSecurityPolicyValue = "frame-src 'self';";
+
     internal static Task SetSecurityHeaders(object context)
     {
         EnsureArg.IsNotNull(context, nameof(context));
@@ -22,6 +28,9 @@ internal static class SecurityHeadersHelper
         var httpContext = (HttpContext)context;
 
         httpContext.Response.Headers.TryAdd(XContentTypeOptions, XContentTypeOptionsValue);
+
+        httpContext.Response.Headers.TryAdd(XFrameOptions, XFrameOptionsValue);
+        httpContext.Response.Headers.TryAdd(ContentSecurityPolicy, ContentSecurityPolicyValue);
 
         return Task.CompletedTask;
     }

--- a/src/Microsoft.Health.Api/Features/Security/SecurityHeadersHelper.cs
+++ b/src/Microsoft.Health.Api/Features/Security/SecurityHeadersHelper.cs
@@ -12,13 +12,13 @@ namespace Microsoft.Health.Api.Features.Security;
 
 internal static class SecurityHeadersHelper
 {
-    private const string XContentTypeOptions = "X-Content-Type-Options";
+    internal const string XContentTypeOptions = "X-Content-Type-Options";
     private const string XContentTypeOptionsValue = "nosniff";
 
-    private const string XFrameOptions = "X-Frame-Options";
+    internal const string XFrameOptions = "X-Frame-Options";
     private const string XFrameOptionsValue = "SAMEORIGIN";
 
-    private const string ContentSecurityPolicy = "Content-Security-Policy";
+    internal const string ContentSecurityPolicy = "Content-Security-Policy";
     private const string ContentSecurityPolicyValue = "frame-src 'self';";
 
     internal static Task SetSecurityHeaders(object context)


### PR DESCRIPTION
## Description
Added response headers x-frame-options and content-security-policy (CSP)

## Related issues
Addresses [[AB#95705](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/95705)].

## Testing
Unit/Integration tests

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Feature
