### PR TITLE
Fix multi-target in test.csproj

### DIFF
--- a/tools/Microsoft.Health.Tools.Sql.Tasks.Tests/Microsoft.Health.Tools.Sql.Tasks.Tests.csproj
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks.Tests/Microsoft.Health.Tools.Sql.Tasks.Tests.csproj
@@ -28,10 +28,8 @@
     <GeneratedFullScriptPath>Schema\$(LatestSchemaVersion).sql</GeneratedFullScriptPath>
   </PropertyGroup>
 
-  <Target Name="PublishSqlTasks" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Core' Or '$(MSBuildRuntimeType)' == 'Mono'">
+  <Target Name="PublishSqlTasks" BeforeTargets="CoreCompile">
     <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=netstandard2.1" />
-  </Target>
-  <Target Name="PublishSqlTasks" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Full' ">
     <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=net462" />
   </Target>
  

--- a/tools/Microsoft.Health.Tools.Sql.Tasks.Tests/Microsoft.Health.Tools.Sql.Tasks.Tests.csproj
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks.Tests/Microsoft.Health.Tools.Sql.Tasks.Tests.csproj
@@ -28,8 +28,10 @@
     <GeneratedFullScriptPath>Schema\$(LatestSchemaVersion).sql</GeneratedFullScriptPath>
   </PropertyGroup>
 
-  <Target Name="PublishSqlTasks" BeforeTargets="CoreCompile">
+  <Target Name="PublishSqlTasks1" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Core' Or '$(MSBuildRuntimeType)' == 'Mono'">
     <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=netstandard2.1" />
+  </Target>
+  <Target Name="PublishSqlTasks2" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Full' ">
     <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=net462" />
   </Target>
  

--- a/tools/Microsoft.Health.Tools.Sql.Tasks.Tests/Microsoft.Health.Tools.Sql.Tasks.Tests.csproj
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks.Tests/Microsoft.Health.Tools.Sql.Tasks.Tests.csproj
@@ -28,10 +28,10 @@
     <GeneratedFullScriptPath>Schema\$(LatestSchemaVersion).sql</GeneratedFullScriptPath>
   </PropertyGroup>
 
-  <Target Name="PublishSqlTasks1" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Core' Or '$(MSBuildRuntimeType)' == 'Mono'">
+  <Target Name="PublishSqlTasksCoreOrMono" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Core' Or '$(MSBuildRuntimeType)' == 'Mono'">
     <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=netstandard2.1" />
   </Target>
-  <Target Name="PublishSqlTasks2" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Full' ">
+  <Target Name="PublishSqlTasksFull" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Full' ">
     <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=net462" />
   </Target>
  

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Microsoft.Health.Tools.Sql.Tasks.csproj
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Microsoft.Health.Tools.Sql.Tasks.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
@@ -19,11 +19,9 @@
     <NuspecProperties>publishDir=$([MSBuild]::NormalizeDirectory($(IntermediatePackDir)));version=$(PackageVersion)</NuspecProperties>
   </PropertyGroup>
 
-  <Target Name="PublishSqlTasks1" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Core' Or '$(MSBuildRuntimeType)' == 'Mono'">
-    <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=netstandard2.1" />
+  <Target Name="PublishAll" BeforeTargets="GenerateNuspec">
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=net462" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=netstandard2.1" />
   </Target>
-  <Target Name="PublishSqlTasks2" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Full' ">
-    <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=net462" />
-  </Target>
-  
+
 </Project>

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Microsoft.Health.Tools.Sql.Tasks.csproj
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Microsoft.Health.Tools.Sql.Tasks.csproj
@@ -19,9 +19,11 @@
     <NuspecProperties>publishDir=$([MSBuild]::NormalizeDirectory($(IntermediatePackDir)));version=$(PackageVersion)</NuspecProperties>
   </PropertyGroup>
 
-  <Target Name="PublishAll" BeforeTargets="GenerateNuspec">
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=net462" />
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=netstandard2.1" />
+  <Target Name="PublishSqlTasks1" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Core' Or '$(MSBuildRuntimeType)' == 'Mono'">
+    <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=netstandard2.1" />
+  </Target>
+  <Target Name="PublishSqlTasks2" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Full' ">
+    <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=net462" />
   </Target>
   
 </Project>


### PR DESCRIPTION
## Description
The prior PR failed in CI build. I found that the netstandard2.1 folder did not build in publish and it caused the error. We restored this error in local environment and checked the log, found that the target name should be different from another one to avoid conflict. Thus, we try to rename the target in test.csproj.

## Related issues
Addresses [issue #582].


## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
