### PR TITLE
Adds TypeRegistrationBuilder.ReplaceServiceExact

### DIFF
--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TypeRegistrationTests.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TypeRegistrationTests.cs
@@ -104,6 +104,49 @@ public class TypeRegistrationTests
     }
 
     [Fact]
+    public void GivenAType_WhenRegisteringAndRemoveExactService_ThenTheOldRegistrationIsRemoved()
+    {
+        new TypeRegistration(_collection, typeof(StreamReader))
+            .Transient()
+            .AsService<TextReader>();
+
+        new TypeRegistration(_collection, typeof(StreamReader))
+            .Singleton()
+            .RemoveServiceExact<TextReader>()
+            .AsService<TextReader>();
+
+        Assert.Collection(_collection,
+            x =>
+            {
+                Assert.Equal(typeof(StreamReader), x.ImplementationType);
+                Assert.Equal(typeof(TextReader), x.ServiceType);
+                Assert.Equal(ServiceLifetime.Singleton, x.Lifetime);
+            });
+    }
+
+    [Fact]
+    public void GivenAType_WhenRegisteringAndRemoveAllForSelf_ThenTheOldRegistrationsAreRemoved()
+    {
+        new TypeRegistration(_collection, typeof(StreamReader))
+            .Transient()
+            .AsService<TextReader>()
+            .AsService<IDisposable>();
+
+        new TypeRegistration(_collection, typeof(StreamReader))
+            .Singleton()
+            .RemoveAllRegistrationsForSelf()
+            .AsService<TextReader>();
+
+        Assert.Collection(_collection,
+            x =>
+            {
+                Assert.Equal(typeof(StreamReader), x.ImplementationType);
+                Assert.Equal(typeof(TextReader), x.ServiceType);
+                Assert.Equal(ServiceLifetime.Singleton, x.Lifetime);
+            });
+    }
+
+    [Fact]
     public void GivenAType_WhenRegisteringAndReplacingExactServiceWithDelegateRegistration_ThenAnExceptionIsThrown()
     {
         Assert.Throws<InvalidOperationException>(() =>

--- a/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TypeRegistrationTests.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection.UnitTests/TypeRegistrationTests.cs
@@ -75,6 +75,44 @@ public class TypeRegistrationTests
     }
 
     [Fact]
+    public void GivenAType_WhenRegisteringAndReplacingExactService_ThenTheNewServicesIsRegisteredAndOtherInstanceRemain()
+    {
+        new TypeRegistration(_collection, typeof(StringReader))
+            .Transient()
+            .AsService<TextReader>();
+
+        new TypeRegistration(_collection, typeof(StreamReader))
+            .Transient()
+            .AsService<TextReader>();
+
+        new TypeRegistration(_collection, typeof(StringReader))
+            .Singleton()
+            .ReplaceServiceExact<TextReader>();
+
+        Assert.Collection(_collection, x =>
+            {
+                Assert.Equal(typeof(StreamReader), x.ImplementationType);
+                Assert.Equal(typeof(TextReader), x.ServiceType);
+                Assert.Equal(ServiceLifetime.Transient, x.Lifetime);
+            },
+            x =>
+            {
+                Assert.Equal(typeof(StringReader), x.ImplementationType);
+                Assert.Equal(typeof(TextReader), x.ServiceType);
+                Assert.Equal(ServiceLifetime.Singleton, x.Lifetime);
+            });
+    }
+
+    [Fact]
+    public void GivenAType_WhenRegisteringAndReplacingExactServiceWithDelegateRegistration_ThenAnExceptionIsThrown()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            _collection.Add(x => (StringReader)null)
+                .Singleton()
+                .ReplaceServiceExact<TextReader>());
+    }
+
+    [Fact]
     public void GivenAFactory_WhenReplacingSelf_ThenOnlyTheNewServiceIsRegistered()
     {
         _collection

--- a/src/Microsoft.Health.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -76,4 +76,20 @@ public static class ServiceCollectionExtensions
         var module = (IStartupModule)constructor.Invoke(constructorArguments);
         module.Load(collection);
     }
+
+    public static IServiceCollection RemoveServiceTypeExact(this IServiceCollection serviceCollection, Type concreteClass, Type serviceType)
+    {
+        EnsureArg.IsNotNull(serviceCollection, nameof(serviceCollection));
+
+        for (int i = serviceCollection.Count - 1; i >= 0; i--)
+        {
+            ServiceDescriptor descriptor = serviceCollection[i];
+            if (descriptor.ServiceType == serviceType && descriptor.ImplementationType == concreteClass)
+            {
+                serviceCollection.RemoveAt(i);
+            }
+        }
+
+        return serviceCollection;
+    }
 }

--- a/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationBuilder.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationBuilder.cs
@@ -103,13 +103,33 @@ public class TypeRegistrationBuilder
     }
 
     /// <summary>
-    /// Replaces a service registration for the specified interface
+    /// Replaces the first occurrence of a service registration for the specified interface
     /// </summary>
     /// <typeparam name="T">Type of service to be registered</typeparam>
     /// <returns>The registration builder</returns>
     public TypeRegistrationBuilder ReplaceService<T>()
     {
         RegisterType(typeof(T), true);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Removes all instances of a service registration for the specified interface and registered type and adds a new registration
+    /// </summary>
+    /// <typeparam name="TServiceType">Type of service to be replaced</typeparam>
+    /// <returns>The registration builder</returns>
+    /// <remarks>This method checks for the exact implementation to replace instead of checking only the service type.</remarks>
+    public TypeRegistrationBuilder ReplaceServiceExact<TServiceType>()
+    {
+        if (_delegateRegistration != null)
+        {
+            throw new InvalidOperationException("Cannot replace a service when using a delegate registration.");
+        }
+
+        _serviceCollection.RemoveServiceTypeExact(_type, typeof(TServiceType));
+
+        RegisterType(typeof(TServiceType));
 
         return this;
     }

--- a/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationBuilder.cs
+++ b/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationBuilder.cs
@@ -135,6 +135,48 @@ public class TypeRegistrationBuilder
     }
 
     /// <summary>
+    /// Removes all instances of a service registration for the specified interface
+    /// </summary>
+    /// <typeparam name="TServiceType">Type of service to be removed</typeparam>
+    /// <returns>The registration builder</returns>
+    /// <remarks>This method checks for the exact implementation to replace instead of checking only the service type.</remarks>
+    public TypeRegistrationBuilder RemoveServiceExact<TServiceType>()
+    {
+        if (_delegateRegistration != null)
+        {
+            throw new InvalidOperationException("Cannot replace a service when using a delegate registration.");
+        }
+
+        _serviceCollection.RemoveServiceTypeExact(_type, typeof(TServiceType));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Removes all instances of a service registration for the specified interface
+    /// </summary>
+    /// <returns>The registration builder</returns>
+    /// <remarks>This method checks for the exact implementation to replace instead of checking only the service type.</remarks>
+    public TypeRegistrationBuilder RemoveAllRegistrationsForSelf()
+    {
+        if (_delegateRegistration != null)
+        {
+            throw new InvalidOperationException("Cannot remove when using a delegate registration.");
+        }
+
+        for (int i = _serviceCollection.Count - 1; i >= 0; i--)
+        {
+            ServiceDescriptor descriptor = _serviceCollection[i];
+            if (descriptor.ImplementationType == _type)
+            {
+                _serviceCollection.RemoveAt(i);
+            }
+        }
+
+        return this;
+    }
+
+    /// <summary>
     /// Creates a service registration for all interfaces implemented by the type
     /// </summary>
     /// <param name="interfaceFilter">A predicate specifying which interfaces to register.</param>


### PR DESCRIPTION
## Description
TypeRegistrationBuilder.ReplaceServiceExact - Removes all instances of a service registration for the specified interface and registered type and adds a new registration. This method checks for the exact implementation to replace instead of checking only the service type.

## Testing
Adds tests

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
