### PR TITLE
Update location of AuditAction to be in core.

### DIFF
--- a/src/Microsoft.Health.Core/Features/Audit/AuditAction.cs
+++ b/src/Microsoft.Health.Core/Features/Audit/AuditAction.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-namespace Microsoft.Health.Api.Features.Audit;
+namespace Microsoft.Health.Core.Features.Audit;
 
 public enum AuditAction
 {


### PR DESCRIPTION
## Description
This PR updates the location of the `AuditAction` enum to be in the core library. This makes it so that we can leverage the auditing outside of the API layer.

## Related issues
Addresses [AB#99436](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/99436).

## Testing
Tested manually downstream.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
