### PR TITLE
Skip c# type generation for views.

### DIFF
--- a/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.diff.sql
+++ b/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.diff.sql
@@ -25,29 +25,3 @@ CREATE TABLE dbo.Table2
 )
 
 GO
-
-CREATE VIEW dbo.MyView
-	WITH SCHEMABINDING
-	AS
-
-	SELECT 
-        t1.Id, 
-        t1.Name, 
-        t2.City AS TheCity
-	FROM dbo.Table1 t1
-	INNER JOIN dbo.Table2 t2 ON t1.Id = t2.Id
-GO
-
-CREATE UNIQUE CLUSTERED INDEX IXC_View12 ON dbo.MyView
-(
-    Id,
-    Name,
-    TheCity
-)
-WITH (DATA_COMPRESSION = PAGE)
-
-CREATE NONCLUSTERED INDEX IX_View12_City ON dbo.MyView
-(	
-    TheCity
-)
-WITH (DATA_COMPRESSION = PAGE)

--- a/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.sql
+++ b/test/Microsoft.Health.SqlServer.Web/Features/Schema/Migrations/3.sql
@@ -49,29 +49,3 @@ CREATE TABLE dbo.Table2
 )
 
 GO
-
-CREATE VIEW dbo.MyView
-	WITH SCHEMABINDING
-	AS
-
-	SELECT 
-        t1.Id, 
-        t1.Name, 
-        t2.City AS TheCity
-	FROM dbo.Table1 t1
-	INNER JOIN dbo.Table2 t2 ON t1.Id = t2.Id
-GO
-
-CREATE UNIQUE CLUSTERED INDEX IXC_View12 ON dbo.MyView
-(
-    Id,
-    Name,
-    TheCity
-)
-WITH (DATA_COMPRESSION = PAGE)
-
-CREATE NONCLUSTERED INDEX IX_View12_City ON dbo.MyView
-(	
-    TheCity
-)
-WITH (DATA_COMPRESSION = PAGE)

--- a/test/Microsoft.Health.SqlServer.Web/Features/Schema/Model/VLatest.Generated.cs
+++ b/test/Microsoft.Health.SqlServer.Web/Features/Schema/Model/VLatest.Generated.cs
@@ -13,24 +13,10 @@ namespace Microsoft.Health.SqlServer.Web.Features.Schema.Model
 
     internal class VLatest
     {
-        internal readonly static MyViewView MyView = new MyViewView();
         internal readonly static Table1Table Table1 = new Table1Table();
         internal readonly static Table2Table Table2 = new Table2Table();
         internal readonly static InsertNumbersProcedure InsertNumbers = new InsertNumbersProcedure();
         internal readonly static MyProcedureProcedure MyProcedure = new MyProcedureProcedure();
-
-        internal class MyViewView : Table
-        {
-            internal MyViewView() : base("dbo.MyView")
-            {
-            }
-
-            internal readonly IntColumn Id = new IntColumn("Id");
-            internal readonly NVarCharColumn Name = new NVarCharColumn("Name", 20);
-            internal readonly NVarCharColumn TheCity = new NVarCharColumn("TheCity", 20);
-            internal readonly Index IXC_View12 = new Index("IXC_View12");
-            internal readonly Index IX_View12_City = new Index("IX_View12_City");
-        }
 
         internal class Table1Table : Table
         {


### PR DESCRIPTION
## Description
FHIR does not use views. DICOM wants to use and ran into a issue with scalar column in views.
I am skipping the type creation of views for now since they are not used in the conversion layer

## Related issues
AB#99514

## Testing
Build with unit tests pass

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
