### PR TITLE
Do DBNullChecks for Nullable DateTime columns

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Model/Column.cs
@@ -182,7 +182,7 @@ public class NullableDateTimeColumn : Column<DateTime?>
 
     public override DateTime? Read(SqlDataReader reader, int ordinal)
     {
-        return reader.GetDateTime(Metadata.Name, ordinal);
+        return reader.IsDBNull(Metadata.Name, ordinal) ? default(DateTime?) : reader.GetDateTime(Metadata.Name, ordinal);
     }
 
     public override void Set(SqlDataRecord record, int ordinal, DateTime? value)
@@ -228,7 +228,7 @@ public class NullableDateColumn : Column<DateTime?>
 
     public override DateTime? Read(SqlDataReader reader, int ordinal)
     {
-        return reader.GetDateTime(Metadata.Name, ordinal);
+        return reader.IsDBNull(Metadata.Name, ordinal) ? default(DateTime?) : reader.GetDateTime(Metadata.Name, ordinal);
     }
 
     public override void Set(SqlDataRecord record, int ordinal, DateTime? value)


### PR DESCRIPTION
## Description
NullableDateTimeColumn and NullableDateColumn are missing DBNull checks on reads

## Related issues
[AB#98125](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/98125)

## Testing
Dicom read works with null columns works

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
