### PR TITLE
Revert "Bump Azure.Core from 1.28.0 to 1.29.0"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageVersion Include="Azure.Core" Version="1.29.0" />
+    <PackageVersion Include="Azure.Core" Version="1.28.0" />
     <PackageVersion Include="Azure.Identity" Version="1.8.2" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="4.14.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.15.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(CodeAnalysisPackageVersion)" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.6.2" />
+    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.6.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(SdkPackageVersion)" />


### PR DESCRIPTION
Reverts microsoft/healthcare-shared-components#675

https://github.com/Azure/azure-sdk-for-net/issues/34784
https://github.com/Azure/azure-sdk-for-net/pull/34800/files