### PR TITLE
Add TokenCredential as option to create eventgrid publisher

### DIFF
--- a/src/Microsoft.Health.EventGrid.UnitTests/Events/EventPublisherTests.cs
+++ b/src/Microsoft.Health.EventGrid.UnitTests/Events/EventPublisherTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -40,7 +40,13 @@ public class EventPublisherTests
         Assert.Throws<ArgumentNullException>(() =>
         {
             var testTopicEndPoint = new Uri("https://microsoft-healthcareapis-workspaces.westus2-1.eventgrid-int.azure.net/eventGrid/api/events");
-            var eventGridPublisher = new EventGridPublisher(testTopicEndPoint, null);
+            var eventGridPublisher = new EventGridPublisher(testTopicEndPoint, key: null);
+        });
+
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            var testTopicEndPoint = new Uri("https://microsoft-healthcareapis-workspaces.westus2-1.eventgrid-int.azure.net/eventGrid/api/events");
+            var eventGridPublisher = new EventGridPublisher(testTopicEndPoint, credential: null);
         });
 
         Assert.Throws<ArgumentNullException>(() =>

--- a/src/Microsoft.Health.EventGrid/EventGridPublisher.cs
+++ b/src/Microsoft.Health.EventGrid/EventGridPublisher.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
+using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Messaging.EventGrid;
 using EnsureThat;
@@ -53,6 +54,19 @@ public class EventGridPublisher : IEventGridPublisher
         };
 
         _client = new EventGridPublisherClient(endpoint, new AzureKeyCredential(keyCredentialName), options);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventGridPublisher"/> class.
+    /// </summary>
+    /// <param name="endpoint">Uri of topic</param>
+    /// <param name="credential">credential with permission to write to event grid endpoint</param>
+    public EventGridPublisher(Uri endpoint, TokenCredential credential)
+    {
+        EnsureArg.IsNotNull(endpoint, nameof(endpoint));
+        EnsureArg.IsNotNull(credential, nameof(credential));
+
+        _client = new EventGridPublisherClient(endpoint, credential);
     }
 
     /// <summary>


### PR DESCRIPTION
This should allow us to create an eventgrid publisher by using local credentials or a managed identity