### PR TITLE
Downgrade blob version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <PackageVersion Include="Azure.Core" Version="1.31.0" />
     <PackageVersion Include="Azure.Identity" Version="1.8.2" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="4.14.1" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.16.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.15.1" />
     <PackageVersion Include="Azure.Storage.Common" Version="12.15.0" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="DistributedLock.SqlServer" Version="1.0.2" />


### PR DESCRIPTION
## Description
Downgraded the blob version to 12.15.1

## Related issues
Addresses [issue # 102678](https://microsofthealth.visualstudio.com/Health/_workitems/edit/102678)

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
