### PR TITLE
Update client cert provider to include x5c header.

### DIFF
--- a/src/Microsoft.Health.Client.UnitTests/CredentialProviderTests.cs
+++ b/src/Microsoft.Health.Client.UnitTests/CredentialProviderTests.cs
@@ -180,7 +180,7 @@ public class CredentialProviderTests
 
             X509Certificate2 certificate = request.CreateSelfSigned(new DateTimeOffset(DateTime.UtcNow.AddDays(-1)), new DateTimeOffset(DateTime.UtcNow.AddDays(1)));
 
-            return new X509Certificate2(certificate.Export(X509ContentType.Pfx, "exampleString"), "exampleString", X509KeyStorageFlags.MachineKeySet);
+            return new X509Certificate2(certificate.Export(X509ContentType.Pfx, "exampleString"), "exampleString", X509KeyStorageFlags.Exportable);
         }
     }
 

--- a/src/Microsoft.Health.Client/Authentication/OAuth2ClientCertificateCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/Authentication/OAuth2ClientCertificateCredentialProvider.cs
@@ -64,8 +64,8 @@ public class OAuth2ClientCertificateCredentialProvider : CredentialProvider
             expires: DateTime.Now.AddMinutes(10),
             signingCredentials: signingCredentials);
 
-        string exportedCertificate = Convert.ToBase64String(oAuth2ClientCertificateCredentialOptions.Certificate.Export(X509ContentType.Cert));
-        jwtSecurityToken.Header.Add(JwtHeaderParameterNames.X5c, exportedCertificate);
+        string publicCertificateChain = Convert.ToBase64String(oAuth2ClientCertificateCredentialOptions.Certificate.Export(X509ContentType.Cert));
+        jwtSecurityToken.Header.Add(JwtHeaderParameterNames.X5c, publicCertificateChain);
 
         var handler = new JwtSecurityTokenHandler();
         var encodedCert = handler.WriteToken(jwtSecurityToken);

--- a/src/Microsoft.Health.Client/Authentication/OAuth2ClientCertificateCredentialProvider.cs
+++ b/src/Microsoft.Health.Client/Authentication/OAuth2ClientCertificateCredentialProvider.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
 using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -62,6 +63,9 @@ public class OAuth2ClientCertificateCredentialProvider : CredentialProvider
             notBefore: DateTime.Now,
             expires: DateTime.Now.AddMinutes(10),
             signingCredentials: signingCredentials);
+
+        string exportedCertificate = Convert.ToBase64String(oAuth2ClientCertificateCredentialOptions.Certificate.Export(X509ContentType.Cert));
+        jwtSecurityToken.Header.Add(JwtHeaderParameterNames.X5c, exportedCertificate);
 
         var handler = new JwtSecurityTokenHandler();
         var encodedCert = handler.WriteToken(jwtSecurityToken);

--- a/src/Microsoft.Health.Client/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Health.Client/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Health.Client.UnitTests")]


### PR DESCRIPTION
## Description
Updates the client certificate auth provider to include the `x5c` header.

## Related issues
Addresses [AB#103917](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/103917).

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
