### PR TITLE
Add support for Max pool size in connection string

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionStringProviderTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionStringProviderTests.cs
@@ -31,16 +31,4 @@ public class DefaultSqlConnectionStringProviderTests
 
         Assert.Equal(sqlConnectionString, await sqlConnectionStringProvider.GetSqlConnectionString(CancellationToken.None).ConfigureAwait(false));
     }
-
-    [Theory]
-    [InlineData("server=(local);Initial Catalog=Dicom;Integrated Security=true;Max Pool Size=1000;", 1000)]
-    [InlineData("server=(local);Initial Catalog=Dicom;Integrated Security=true;Max Pool Size=500;", 500)]
-    [InlineData("server=(local);Initial Catalog=Dicom;Integrated Security=true;", null)]
-    public async Task GivenValidSqlServerDataStoreConfigurationWithMaxPoolSize_GetSqlConnectionString_ReturnsConnectionString(string sqlConnectionString, int? maxPoolSize)
-    {
-        var sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration() { ConnectionString = sqlConnectionString, MaxPoolSize = maxPoolSize };
-        ISqlConnectionStringProvider sqlConnectionStringProvider = new DefaultSqlConnectionStringProvider(Options.Create(sqlServerDataStoreConfiguration));
-
-        Assert.Equal(sqlConnectionString, await sqlConnectionStringProvider.GetSqlConnectionString(CancellationToken.None).ConfigureAwait(false));
-    }
 }

--- a/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionStringProviderTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionStringProviderTests.cs
@@ -31,4 +31,16 @@ public class DefaultSqlConnectionStringProviderTests
 
         Assert.Equal(sqlConnectionString, await sqlConnectionStringProvider.GetSqlConnectionString(CancellationToken.None).ConfigureAwait(false));
     }
+
+    [Theory]
+    [InlineData("server=(local);Initial Catalog=Dicom;Integrated Security=true;Max Pool Size=1000;", 1000)]
+    [InlineData("server=(local);Initial Catalog=Dicom;Integrated Security=true;Max Pool Size=500;", 500)]
+    [InlineData("server=(local);Initial Catalog=Dicom;Integrated Security=true;", null)]
+    public async Task GivenValidSqlServerDataStoreConfigurationWithMaxPoolSize_GetSqlConnectionString_ReturnsConnectionString(string sqlConnectionString, int? maxPoolSize)
+    {
+        var sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration() { ConnectionString = sqlConnectionString, MaxPoolSize = maxPoolSize };
+        ISqlConnectionStringProvider sqlConnectionStringProvider = new DefaultSqlConnectionStringProvider(Options.Create(sqlServerDataStoreConfiguration));
+
+        Assert.Equal(sqlConnectionString, await sqlConnectionStringProvider.GetSqlConnectionString(CancellationToken.None).ConfigureAwait(false));
+    }
 }

--- a/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionTests.cs
@@ -57,9 +57,16 @@ public class DefaultSqlConnectionTests
     [Theory]
     [InlineData(10)]
     [InlineData(1000)]
-    public async Task GivenDefaultConnectionTypeWithMaxPoolSize_WhenSqlConnectionRequested_MaxPoolSizeIsSet(int maxPoolSize)
+    [InlineData(null)]
+    public async Task GivenDefaultConnectionTypeWithMaxPoolSize_WhenSqlConnectionRequested_MaxPoolSizeIsSet(int? maxPoolSize)
     {
         SqlConnection sqlConnection = await _sqlConnectionFactory.GetSqlConnectionAsync(maxPoolSize: maxPoolSize).ConfigureAwait(false);
-        Assert.Equal($"Data Source={ServerName};Initial Catalog={DatabaseName};Integrated Security=True;Max Pool Size={maxPoolSize}", sqlConnection.ConnectionString);
+        var connectionString = $"Data Source={ServerName};Initial Catalog={DatabaseName};Integrated Security=True";
+        if (maxPoolSize.HasValue)
+        {
+            connectionString += $";Max Pool Size={maxPoolSize}";
+        }
+
+        Assert.Equal(connectionString, sqlConnection.ConnectionString);
     }
 }

--- a/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/DefaultSqlConnectionTests.cs
@@ -53,4 +53,13 @@ public class DefaultSqlConnectionTests
 
         Assert.Equal(MasterDatabase, sqlConnection.Database);
     }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(1000)]
+    public async Task GivenDefaultConnectionTypeWithMaxPoolSize_WhenSqlConnectionRequested_MaxPoolSizeIsSet(int maxPoolSize)
+    {
+        SqlConnection sqlConnection = await _sqlConnectionFactory.GetSqlConnectionAsync(maxPoolSize: maxPoolSize).ConfigureAwait(false);
+        Assert.Equal($"Data Source={ServerName};Initial Catalog={DatabaseName};Integrated Security=True;Max Pool Size={maxPoolSize}", sqlConnection.ConnectionString);
+    }
 }

--- a/src/Microsoft.Health.SqlServer.UnitTests/ManagedIdentitySqlConnectionTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/ManagedIdentitySqlConnectionTests.cs
@@ -61,4 +61,13 @@ public class ManagedIdentitySqlConnectionTests
 
         Assert.Equal(MasterDatabase, sqlConnection.Database);
     }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(1000)]
+    public async Task GivenDefaultConnectionTypeWithMaxPoolSize_WhenSqlConnectionRequested_MaxPoolSizeIsSet(int maxPoolSize)
+    {
+        SqlConnection sqlConnection = await _sqlConnectionFactory.GetSqlConnectionAsync(maxPoolSize: maxPoolSize).ConfigureAwait(false);
+        Assert.Equal($"Data Source={ServerName};Initial Catalog={DatabaseName};Max Pool Size={maxPoolSize}", sqlConnection.ConnectionString);
+    }
 }

--- a/src/Microsoft.Health.SqlServer.UnitTests/ManagedIdentitySqlConnectionTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/ManagedIdentitySqlConnectionTests.cs
@@ -65,9 +65,16 @@ public class ManagedIdentitySqlConnectionTests
     [Theory]
     [InlineData(10)]
     [InlineData(1000)]
-    public async Task GivenDefaultConnectionTypeWithMaxPoolSize_WhenSqlConnectionRequested_MaxPoolSizeIsSet(int maxPoolSize)
+    [InlineData(null)]
+    public async Task GivenDefaultConnectionTypeWithMaxPoolSize_WhenSqlConnectionRequested_MaxPoolSizeIsSet(int? maxPoolSize)
     {
         SqlConnection sqlConnection = await _sqlConnectionFactory.GetSqlConnectionAsync(maxPoolSize: maxPoolSize).ConfigureAwait(false);
-        Assert.Equal($"Data Source={ServerName};Initial Catalog={DatabaseName};Max Pool Size={maxPoolSize}", sqlConnection.ConnectionString);
+        var connectionString = $"Data Source={ServerName};Initial Catalog={DatabaseName}";
+        if (maxPoolSize.HasValue)
+        {
+            connectionString += $";Max Pool Size={maxPoolSize}";
+        }
+
+        Assert.Equal(connectionString, sqlConnection.ConnectionString);
     }
 }

--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -13,6 +13,16 @@ public class SqlServerDataStoreConfiguration
     /// The default section name used in configurations.
     /// </summary>
     public const string SectionName = "SqlServer";
+
+    /// <summary>
+    /// The max pool size name used in connection string.
+    /// </summary>
+    public const string MaxPoolSizeName = "Max Pool Size";
+
+    /// <summary>
+    /// The maximum max pool size limit.
+    /// </summary>
+    public const int MaxPoolSizeLimit = 30000;
 
     /// <summary>
     /// The SQL Server connection string.
@@ -63,4 +73,9 @@ public class SqlServerDataStoreConfiguration
     /// Specifies the SqlCommand.CommandTimeout
     /// </summary>
     public TimeSpan CommandTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// If set, the maximum number of connections allowed in the pool to use when connecting to SQL.
+    /// </summary>
+    public int? MaxPoolSize { get; set; }
 }

--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -15,16 +15,6 @@ public class SqlServerDataStoreConfiguration
     public const string SectionName = "SqlServer";
 
     /// <summary>
-    /// The max pool size name used in connection string.
-    /// </summary>
-    public const string MaxPoolSizeName = "Max Pool Size";
-
-    /// <summary>
-    /// The maximum max pool size limit.
-    /// </summary>
-    public const int MaxPoolSizeLimit = 30000;
-
-    /// <summary>
     /// The SQL Server connection string.
     /// </summary>
     public string ConnectionString { get; set; }

--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionBuilder.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionBuilder.cs
@@ -31,12 +31,13 @@ public class DefaultSqlConnectionBuilder : ISqlConnectionBuilder
     }
 
     /// <inheritdoc />
-    public Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, CancellationToken cancellationToken = default)
+    public Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, int? maxPoolSize = null, CancellationToken cancellationToken = default)
     {
         return SqlConnectionHelper.GetBaseSqlConnectionAsync(
             _sqlConnectionStringProvider,
             _sqlRetryLogicBaseProvider,
             initialCatalog,
+            maxPoolSize,
             cancellationToken);
     }
 }

--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -22,24 +21,11 @@ public class DefaultSqlConnectionStringProvider : ISqlConnectionStringProvider
     public DefaultSqlConnectionStringProvider(IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration)
     {
         _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
-
-        if (_sqlServerDataStoreConfiguration.MaxPoolSize.HasValue)
-        {
-            EnsureArg.IsGt(_sqlServerDataStoreConfiguration.MaxPoolSize.Value, 0, nameof(_sqlServerDataStoreConfiguration.MaxPoolSize));
-            EnsureArg.IsLt(_sqlServerDataStoreConfiguration.MaxPoolSize.Value, SqlServerDataStoreConfiguration.MaxPoolSizeLimit, nameof(_sqlServerDataStoreConfiguration.MaxPoolSize));
-        }
     }
 
     /// <inheritdoc />
     public Task<string> GetSqlConnectionString(CancellationToken cancellationToken)
     {
-        string connectionString = _sqlServerDataStoreConfiguration.ConnectionString;
-
-        if (_sqlServerDataStoreConfiguration.MaxPoolSize.HasValue && !connectionString.Contains(SqlServerDataStoreConfiguration.MaxPoolSizeName, StringComparison.OrdinalIgnoreCase))
-        {
-            return Task.FromResult($"{connectionString};{SqlServerDataStoreConfiguration.MaxPoolSizeName}={_sqlServerDataStoreConfiguration.MaxPoolSize.Value};");
-        }
-
-        return Task.FromResult(connectionString);
+        return Task.FromResult(_sqlServerDataStoreConfiguration.ConnectionString);
     }
 }

--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionStringProvider.cs
@@ -1,8 +1,9 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -21,11 +22,24 @@ public class DefaultSqlConnectionStringProvider : ISqlConnectionStringProvider
     public DefaultSqlConnectionStringProvider(IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration)
     {
         _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
+
+        if (_sqlServerDataStoreConfiguration.MaxPoolSize.HasValue)
+        {
+            EnsureArg.IsGt(_sqlServerDataStoreConfiguration.MaxPoolSize.Value, 0, nameof(_sqlServerDataStoreConfiguration.MaxPoolSize));
+            EnsureArg.IsLt(_sqlServerDataStoreConfiguration.MaxPoolSize.Value, SqlServerDataStoreConfiguration.MaxPoolSizeLimit, nameof(_sqlServerDataStoreConfiguration.MaxPoolSize));
+        }
     }
 
     /// <inheritdoc />
     public Task<string> GetSqlConnectionString(CancellationToken cancellationToken)
     {
-        return Task.FromResult(_sqlServerDataStoreConfiguration.ConnectionString);
+        string connectionString = _sqlServerDataStoreConfiguration.ConnectionString;
+
+        if (_sqlServerDataStoreConfiguration.MaxPoolSize.HasValue && !connectionString.Contains(SqlServerDataStoreConfiguration.MaxPoolSizeName, StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult($"{connectionString};{SqlServerDataStoreConfiguration.MaxPoolSizeName}={_sqlServerDataStoreConfiguration.MaxPoolSize.Value};");
+        }
+
+        return Task.FromResult(connectionString);
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapper.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapper.cs
@@ -36,6 +36,12 @@ public class SqlConnectionWrapper : IDisposable
 
         _sqlServerDataStoreConfiguration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
 
+        if (_sqlServerDataStoreConfiguration.MaxPoolSize.HasValue)
+        {
+            EnsureArg.IsGt(_sqlServerDataStoreConfiguration.MaxPoolSize.Value, 0, nameof(_sqlServerDataStoreConfiguration.MaxPoolSize));
+            EnsureArg.IsLt(_sqlServerDataStoreConfiguration.MaxPoolSize.Value, SqlConstants.MaxPoolSizeLimit, nameof(_sqlServerDataStoreConfiguration.MaxPoolSize));
+        }
+
         _sqlTransactionHandler = sqlTransactionHandler;
         _enlistInTransactionIfPresent = enlistInTransactionIfPresent;
         _sqlConnectionBuilder = connectionBuilder;
@@ -54,7 +60,7 @@ public class SqlConnectionWrapper : IDisposable
         }
         else
         {
-            SqlConnection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog, cancellationToken: cancellationToken).ConfigureAwait(false);
+            SqlConnection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog, _sqlServerDataStoreConfiguration.MaxPoolSize, cancellationToken: cancellationToken).ConfigureAwait(false);
             SqlConnection.RetryLogicProvider = _sqlRetryLogicBaseProvider;
         }
 

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlConstants.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlConstants.cs
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.SqlServer.Features.Client;
+
+public static class SqlConstants
+{
+    /// <summary>
+    /// The max pool size name used in connection string.
+    /// </summary>
+    public const string MaxPoolSizeName = "Max Pool Size";
+
+    /// <summary>
+    /// The maximum max pool size limit.
+    /// </summary>
+    public const int MaxPoolSizeLimit = 30000;
+}

--- a/src/Microsoft.Health.SqlServer/ISqlConnectionBuilder.cs
+++ b/src/Microsoft.Health.SqlServer/ISqlConnectionBuilder.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -16,7 +16,8 @@ public interface ISqlConnectionBuilder
     /// If initial catalog is not provided, it is determined from the connection string.
     /// </summary>
     /// <param name="initialCatalog">Initial catalog to connect to.</param>
+    /// <param name="maxPoolSize">Max Sql connection pool size</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>SqlConnection object.</returns>
-    Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, CancellationToken cancellationToken = default);
+    Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, int? maxPoolSize = null, CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.Health.SqlServer/ManagedIdentitySqlConnectionBuilder.cs
+++ b/src/Microsoft.Health.SqlServer/ManagedIdentitySqlConnectionBuilder.cs
@@ -35,12 +35,13 @@ public class ManagedIdentitySqlConnectionBuilder : ISqlConnectionBuilder
 
     /// <inheritdoc />
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Callers are responsible for disposal.")]
-    public async Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, CancellationToken cancellationToken = default)
+    public async Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, int? maxPoolSize = null, CancellationToken cancellationToken = default)
     {
         SqlConnection sqlConnection = await SqlConnectionHelper.GetBaseSqlConnectionAsync(
             _sqlConnectionStringProvider,
             _sqlRetryLogicBaseProvider,
             initialCatalog,
+            maxPoolSize,
             cancellationToken).ConfigureAwait(false);
 
         // set managed identity access token

--- a/src/Microsoft.Health.SqlServer/SqlConnectionHelper.cs
+++ b/src/Microsoft.Health.SqlServer/SqlConnectionHelper.cs
@@ -22,6 +22,7 @@ internal static class SqlConnectionHelper
     /// <param name="sqlConnectionStringProvider">sqlConnectionStringProvider</param>
     /// <param name="sqlRetryLogic"><see cref="SqlRetryLogicBaseProvider"/>.</param>
     /// <param name="initialCatalog">initialCatalog</param>
+    /// <param name="maxPoolSize">Max SQL connection pool size</param>
     /// <param name="cancellationToken">cancellationToken</param>
     /// <returns>SqlConnection</returns>
     /// <exception cref="InvalidOperationException">Empty sql connection string</exception>
@@ -29,6 +30,7 @@ internal static class SqlConnectionHelper
         ISqlConnectionStringProvider sqlConnectionStringProvider,
         SqlRetryLogicBaseProvider sqlRetryLogic,
         string initialCatalog = null,
+        int? maxPoolSize = null,
         CancellationToken cancellationToken = default)
     {
         string sqlConnectionString = await sqlConnectionStringProvider.GetSqlConnectionString(cancellationToken).ConfigureAwait(false);
@@ -42,6 +44,11 @@ internal static class SqlConnectionHelper
         if (initialCatalog != null)
         {
             connectionStringBuilder.InitialCatalog = initialCatalog;
+        }
+
+        if (maxPoolSize.HasValue)
+        {
+            connectionStringBuilder.MaxPoolSize = maxPoolSize.Value;
         }
 
         return new SqlConnection(connectionStringBuilder.ToString()) { RetryLogicProvider = sqlRetryLogic };

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
@@ -37,7 +37,7 @@ public sealed class SchemaUpgradeRunnerTests : SqlIntegrationTestBase, IDisposab
         await base.InitializeAsync().ConfigureAwait(false);
 
         var sqlConnection = Substitute.For<ISqlConnectionBuilder>();
-        sqlConnection.GetSqlConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs((x) => GetSqlConnection());
+        sqlConnection.GetSqlConnectionAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs((x) => GetSqlConnection());
         var config = Options.Create(new SqlServerDataStoreConfiguration());
 
         SqlRetryLogicBaseProvider sqlRetryLogicBaseProvider = SqlConfigurableRetryFactory.CreateFixedRetryProvider(new SqlClientRetryOptions().Settings);


### PR DESCRIPTION
## Description
Add support for Max pool size in connection string to allow more connections compared to default 100.

## Related issues
Addresses [[AB#104385](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/104385)].

## Testing
Unit tests were added to ensure the connection strings are properly formed.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
