### PR TITLE
Added a toggle to test out the workloadidentity in prod regions

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -42,6 +42,7 @@ public class SqlServerBaseRegistrationExtensionsTests
         Assert.True(services.ContainsSingleton<AzureServiceTokenProvider>());
         Assert.True(services.ContainsSingleton<BaseScriptProvider>());
         Assert.True(services.ContainsSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>());
+        Assert.True(services.ContainsSingleton<IAccessTokenHandler, WorkloadIdentityAccessTokenHandler>());
         Assert.True(services.ContainsSingleton<IBaseScriptProvider, BaseScriptProvider>());
         Assert.True(services.ContainsSingleton<IHostedService, SchemaInitializer>());
         Assert.True(services.ContainsScoped<ISchemaManagerDataStore>());
@@ -68,6 +69,7 @@ public class SqlServerBaseRegistrationExtensionsTests
 
         Assert.True(services.ContainsSingleton<AzureServiceTokenProvider>());
         Assert.True(services.ContainsSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>());
+        Assert.True(services.ContainsSingleton<IAccessTokenHandler, WorkloadIdentityAccessTokenHandler>());
         Assert.True(services.ContainsSingleton<ISqlConnectionBuilder>());
         Assert.True(services.ContainsSingleton<ISqlConnectionStringProvider, DefaultSqlConnectionStringProvider>());
         Assert.True(services.ContainsScoped<IReadOnlySchemaManagerDataStore, SchemaManagerDataStore>());

--- a/src/Microsoft.Health.SqlServer.UnitTests/WorkloadidentitySqlconnectionTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/WorkloadidentitySqlconnectionTests.cs
@@ -11,8 +11,7 @@ using NSubstitute;
 using Xunit;
 
 namespace Microsoft.Health.SqlServer.UnitTests;
-
-public class ManagedIdentitySqlConnectionTests
+public class WorkloadIdentitySqlconnectionTests
 {
     private const string DatabaseName = "Dicom";
     private const string ServerName = "(local)";
@@ -21,15 +20,18 @@ public class ManagedIdentitySqlConnectionTests
 
     private readonly ManagedIdentitySqlConnectionBuilder _sqlConnectionFactory;
 
-    public ManagedIdentitySqlConnectionTests()
+    public WorkloadIdentitySqlconnectionTests()
     {
         var accessTokenHandler = Substitute.For<IAccessTokenHandler>();
+
+        accessTokenHandler.AuthenticationType.Returns(SqlServerAuthenticationType.WorkloadIdentity);
         accessTokenHandler.GetAccessTokenAsync().Returns(Task.FromResult(TestAccessToken));
+
 
         SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration = new SqlServerDataStoreConfiguration
         {
             ConnectionString = $"Server={ServerName};Database={DatabaseName};",
-            AuthenticationType = SqlServerAuthenticationType.ManagedIdentity,
+            AuthenticationType = SqlServerAuthenticationType.WorkloadIdentity,
         };
 
         var sqlConfigOptions = Options.Create(sqlServerDataStoreConfiguration);
@@ -60,20 +62,5 @@ public class ManagedIdentitySqlConnectionTests
 
         Assert.Equal(MasterDatabase, sqlConnection.Database);
     }
-
-    [Theory]
-    [InlineData(10)]
-    [InlineData(1000)]
-    [InlineData(null)]
-    public async Task GivenDefaultConnectionTypeWithMaxPoolSize_WhenSqlConnectionRequested_MaxPoolSizeIsSet(int? maxPoolSize)
-    {
-        SqlConnection sqlConnection = await _sqlConnectionFactory.GetSqlConnectionAsync(maxPoolSize: maxPoolSize).ConfigureAwait(false);
-        var connectionString = $"Data Source={ServerName};Initial Catalog={DatabaseName}";
-        if (maxPoolSize.HasValue)
-        {
-            connectionString += $";Max Pool Size={maxPoolSize}";
-        }
-
-        Assert.Equal(connectionString, sqlConnection.ConnectionString);
-    }
 }
+

--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerAuthenticationType.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerAuthenticationType.cs
@@ -17,5 +17,8 @@ public enum SqlServerAuthenticationType
     /// </summary>
     ConnectionString,
 
+    /// <summary>
+    ///  Works for Workloadidentitycredential. It needs AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_FEDERATED_TOKEN_FILE to be specified in the environment.
+    /// </summary>
     WorkloadIdentity,
 }

--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerAuthenticationType.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerAuthenticationType.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -16,4 +16,6 @@ public enum SqlServerAuthenticationType
     /// as they both completely rely on the connection string.
     /// </summary>
     ConnectionString,
+
+    WorkloadIdentity,
 }

--- a/src/Microsoft.Health.SqlServer/IAccessTokenHandler.cs
+++ b/src/Microsoft.Health.SqlServer/IAccessTokenHandler.cs
@@ -17,7 +17,7 @@ public interface IAccessTokenHandler
     SqlServerAuthenticationType AuthenticationType { get; }
 
     /// <summary>
-    /// Deletermines the scope that is needed by the type of tokencredential used in the given implementation
+    /// Determines the scope that is needed by the type of tokencredential used in the given implementation
     /// </summary>
     string AzureScope { get; }
 

--- a/src/Microsoft.Health.SqlServer/IAccessTokenHandler.cs
+++ b/src/Microsoft.Health.SqlServer/IAccessTokenHandler.cs
@@ -11,7 +11,15 @@ namespace Microsoft.Health.SqlServer;
 
 public interface IAccessTokenHandler
 {
+    /// <summary>
+    /// Determines the type of SqlServiceAuthenticationType. This correlates with the type of token credential that will be used by the implementation.
+    /// </summary>
     SqlServerAuthenticationType AuthenticationType { get; }
+
+    /// <summary>
+    /// Deletermines the scope that is needed by the type of tokencredential used in the given implementation
+    /// </summary>
+    string AzureScope { get; }
 
     /// <summary>
     /// Get access token for the resource.

--- a/src/Microsoft.Health.SqlServer/IAccessTokenHandler.cs
+++ b/src/Microsoft.Health.SqlServer/IAccessTokenHandler.cs
@@ -1,8 +1,9 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Microsoft.Health.SqlServer.Configs;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,11 +11,12 @@ namespace Microsoft.Health.SqlServer;
 
 public interface IAccessTokenHandler
 {
+    SqlServerAuthenticationType AuthenticationType { get; }
+
     /// <summary>
     /// Get access token for the resource.
     /// </summary>
-    /// <param name="resource">Resource.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Task returning token.</returns>
-    Task<string> GetAccessTokenAsync(string resource, CancellationToken cancellationToken = default);
+    Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.Health.SqlServer/ManagedIdentityAccessTokenHandler.cs
+++ b/src/Microsoft.Health.SqlServer/ManagedIdentityAccessTokenHandler.cs
@@ -13,10 +13,11 @@ namespace Microsoft.Health.SqlServer;
 
 public class ManagedIdentityAccessTokenHandler : IAccessTokenHandler
 {
-    private readonly string _resource = "https://database.windows.net/";
     private readonly AzureServiceTokenProvider _azureServiceTokenProvider;
 
     public SqlServerAuthenticationType AuthenticationType => SqlServerAuthenticationType.ManagedIdentity;
+
+    public string AzureScope => "https://database.windows.net/";
 
     public ManagedIdentityAccessTokenHandler(AzureServiceTokenProvider azureServiceTokenProvider)
     {
@@ -28,6 +29,6 @@ public class ManagedIdentityAccessTokenHandler : IAccessTokenHandler
     /// <inheritdoc />
     public Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)
     {
-        return _azureServiceTokenProvider.GetAccessTokenAsync(_resource, cancellationToken: cancellationToken);
+        return _azureServiceTokenProvider.GetAccessTokenAsync(AzureScope, cancellationToken: cancellationToken);
     }
 }

--- a/src/Microsoft.Health.SqlServer/ManagedIdentityAccessTokenHandler.cs
+++ b/src/Microsoft.Health.SqlServer/ManagedIdentityAccessTokenHandler.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -7,12 +7,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Health.SqlServer.Configs;
 
 namespace Microsoft.Health.SqlServer;
 
 public class ManagedIdentityAccessTokenHandler : IAccessTokenHandler
 {
+    private readonly string _resource = "https://database.windows.net/";
     private readonly AzureServiceTokenProvider _azureServiceTokenProvider;
+
+    public SqlServerAuthenticationType AuthenticationType => SqlServerAuthenticationType.ManagedIdentity;
 
     public ManagedIdentityAccessTokenHandler(AzureServiceTokenProvider azureServiceTokenProvider)
     {
@@ -22,8 +26,8 @@ public class ManagedIdentityAccessTokenHandler : IAccessTokenHandler
     }
 
     /// <inheritdoc />
-    public Task<string> GetAccessTokenAsync(string resource, CancellationToken cancellationToken)
+    public Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)
     {
-        return _azureServiceTokenProvider.GetAccessTokenAsync(resource, cancellationToken: cancellationToken);
+        return _azureServiceTokenProvider.GetAccessTokenAsync(_resource, cancellationToken: cancellationToken);
     }
 }

--- a/src/Microsoft.Health.SqlServer/ManagedIdentitySqlConnectionBuilder.cs
+++ b/src/Microsoft.Health.SqlServer/ManagedIdentitySqlConnectionBuilder.cs
@@ -16,7 +16,6 @@ public class ManagedIdentitySqlConnectionBuilder : ISqlConnectionBuilder
     private readonly ISqlConnectionStringProvider _sqlConnectionStringProvider;
     private readonly IAccessTokenHandler _accessTokenHandler;
     private readonly SqlRetryLogicBaseProvider _sqlRetryLogicBaseProvider;
-    private readonly string _azureResource = "https://database.windows.net/";
 
     public ManagedIdentitySqlConnectionBuilder(
         ISqlConnectionStringProvider sqlConnectionStringProvider,
@@ -45,7 +44,7 @@ public class ManagedIdentitySqlConnectionBuilder : ISqlConnectionBuilder
             cancellationToken).ConfigureAwait(false);
 
         // set managed identity access token
-        sqlConnection.AccessToken = await _accessTokenHandler.GetAccessTokenAsync(_azureResource, cancellationToken).ConfigureAwait(false);
+        sqlConnection.AccessToken = await _accessTokenHandler.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
         return sqlConnection;
     }
 }

--- a/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
+++ b/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Ensure.That" />
     <PackageReference Include="MediatR" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -76,13 +76,26 @@ public static class SqlServerBaseRegistrationExtensions
                  SqlServerDataStoreConfiguration config = sqlServerDataStoreConfigOption.Value;
                  ISqlConnectionStringProvider sqlConnectionStringProvider = p.GetRequiredService<ISqlConnectionStringProvider>();
                  SqlRetryLogicBaseProvider sqlRetryLogic = p.GetRequiredService<SqlRetryLogicBaseProvider>();
-                 return config.AuthenticationType == SqlServerAuthenticationType.ManagedIdentity
-                     ? new ManagedIdentitySqlConnectionBuilder(sqlConnectionStringProvider, p.GetRequiredService<IAccessTokenHandler>(), sqlRetryLogic)
-                     : new DefaultSqlConnectionBuilder(sqlConnectionStringProvider, sqlRetryLogic);
+                 var accessTokenHandlers = p.GetServices<IAccessTokenHandler>();
+
+                 if (config.AuthenticationType == SqlServerAuthenticationType.ManagedIdentity)
+                 {
+                     return new ManagedIdentitySqlConnectionBuilder(sqlConnectionStringProvider, accessTokenHandlers.FirstOrDefault(dpp => dpp.AuthenticationType == SqlServerAuthenticationType.ManagedIdentity), sqlRetryLogic);
+                 }
+                 else if (config.AuthenticationType == SqlServerAuthenticationType.WorkloadIdentity)
+                 {
+                     return new ManagedIdentitySqlConnectionBuilder(sqlConnectionStringProvider, accessTokenHandlers.FirstOrDefault(dpp => dpp.AuthenticationType == SqlServerAuthenticationType.WorkloadIdentity), sqlRetryLogic);
+                 }
+                 else
+                 {
+                     return new DefaultSqlConnectionBuilder(sqlConnectionStringProvider, sqlRetryLogic);
+                 }
              });
 
         // The following are only used in case of managed identity
         services.AddSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>();
+        services.AddSingleton<IAccessTokenHandler, WorkloadIdentityAccessTokenHandler>();
+
         services.AddSingleton<AzureServiceTokenProvider>(p =>
         {
             SqlServerDataStoreConfiguration config = p.GetRequiredService<IOptions<SqlServerDataStoreConfiguration>>().Value;

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -78,13 +78,9 @@ public static class SqlServerBaseRegistrationExtensions
                  SqlRetryLogicBaseProvider sqlRetryLogic = p.GetRequiredService<SqlRetryLogicBaseProvider>();
                  var accessTokenHandlers = p.GetServices<IAccessTokenHandler>();
 
-                 if (config.AuthenticationType == SqlServerAuthenticationType.ManagedIdentity)
+                 if (config.AuthenticationType == SqlServerAuthenticationType.ManagedIdentity || config.AuthenticationType == SqlServerAuthenticationType.WorkloadIdentity)
                  {
-                     return new ManagedIdentitySqlConnectionBuilder(sqlConnectionStringProvider, accessTokenHandlers.FirstOrDefault(dpp => dpp.AuthenticationType == SqlServerAuthenticationType.ManagedIdentity), sqlRetryLogic);
-                 }
-                 else if (config.AuthenticationType == SqlServerAuthenticationType.WorkloadIdentity)
-                 {
-                     return new ManagedIdentitySqlConnectionBuilder(sqlConnectionStringProvider, accessTokenHandlers.FirstOrDefault(dpp => dpp.AuthenticationType == SqlServerAuthenticationType.WorkloadIdentity), sqlRetryLogic);
+                     return new ManagedIdentitySqlConnectionBuilder(sqlConnectionStringProvider, accessTokenHandlers.FirstOrDefault(dpp => dpp.AuthenticationType == config.AuthenticationType), sqlRetryLogic);
                  }
                  else
                  {

--- a/src/Microsoft.Health.SqlServer/WorkloadIdentityAccessTokenHandler.cs
+++ b/src/Microsoft.Health.SqlServer/WorkloadIdentityAccessTokenHandler.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.SqlServer
+{
+    public class WorkloadIdentityAccessTokenHandler: IAccessTokenHandler
+    {
+        private const string AzureResource = "https://database.windows.net/.default";
+
+        public SqlServerAuthenticationType AuthenticationType => SqlServerAuthenticationType.WorkloadIdentity;
+
+        public async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+        {
+            WorkloadIdentityCredential credential = new WorkloadIdentityCredential();
+
+            var token = await credential.GetTokenAsync(new TokenRequestContext(new[] { AzureResource }), CancellationToken.None).ConfigureAwait(false);
+
+            return token.Token;
+        }
+    }
+}

--- a/src/Microsoft.Health.SqlServer/WorkloadIdentityAccessTokenHandler.cs
+++ b/src/Microsoft.Health.SqlServer/WorkloadIdentityAccessTokenHandler.cs
@@ -20,6 +20,8 @@ public class WorkloadIdentityAccessTokenHandler : IAccessTokenHandler
 
     public async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
     {
+        // Creates a new instance of the WorkloadIdentityCredential with the default options.
+        // When no options are specified AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_FEDERATED_TOKEN_FILE must be specified in the environment.
         WorkloadIdentityCredential credential = new WorkloadIdentityCredential();
 
         var token = await credential.GetTokenAsync(new TokenRequestContext(new[] { AzureResource }), CancellationToken.None).ConfigureAwait(false);

--- a/src/Microsoft.Health.SqlServer/WorkloadIdentityAccessTokenHandler.cs
+++ b/src/Microsoft.Health.SqlServer/WorkloadIdentityAccessTokenHandler.cs
@@ -14,9 +14,9 @@ using Microsoft.Health.SqlServer.Configs;
 namespace Microsoft.Health.SqlServer;
 public class WorkloadIdentityAccessTokenHandler : IAccessTokenHandler
 {
-    private const string AzureResource = "https://database.windows.net/.default";
-
     public SqlServerAuthenticationType AuthenticationType => SqlServerAuthenticationType.WorkloadIdentity;
+
+    public string AzureScope => "https://database.windows.net/.default";
 
     public async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
     {
@@ -24,7 +24,7 @@ public class WorkloadIdentityAccessTokenHandler : IAccessTokenHandler
         // When no options are specified AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_FEDERATED_TOKEN_FILE must be specified in the environment.
         WorkloadIdentityCredential credential = new WorkloadIdentityCredential();
 
-        var token = await credential.GetTokenAsync(new TokenRequestContext(new[] { AzureResource }), CancellationToken.None).ConfigureAwait(false);
+        var token = await credential.GetTokenAsync(new TokenRequestContext(new[] { AzureScope }), CancellationToken.None).ConfigureAwait(false);
 
         return token.Token;
     }

--- a/src/Microsoft.Health.SqlServer/WorkloadIdentityAccessTokenHandler.cs
+++ b/src/Microsoft.Health.SqlServer/WorkloadIdentityAccessTokenHandler.cs
@@ -1,24 +1,29 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using Microsoft.Health.SqlServer.Configs;
 
-namespace Microsoft.Health.SqlServer
+namespace Microsoft.Health.SqlServer;
+public class WorkloadIdentityAccessTokenHandler : IAccessTokenHandler
 {
-    public class WorkloadIdentityAccessTokenHandler: IAccessTokenHandler
+    private const string AzureResource = "https://database.windows.net/.default";
+
+    public SqlServerAuthenticationType AuthenticationType => SqlServerAuthenticationType.WorkloadIdentity;
+
+    public async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
     {
-        private const string AzureResource = "https://database.windows.net/.default";
+        WorkloadIdentityCredential credential = new WorkloadIdentityCredential();
 
-        public SqlServerAuthenticationType AuthenticationType => SqlServerAuthenticationType.WorkloadIdentity;
+        var token = await credential.GetTokenAsync(new TokenRequestContext(new[] { AzureResource }), CancellationToken.None).ConfigureAwait(false);
 
-        public async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
-        {
-            WorkloadIdentityCredential credential = new WorkloadIdentityCredential();
-
-            var token = await credential.GetTokenAsync(new TokenRequestContext(new[] { AzureResource }), CancellationToken.None).ConfigureAwait(false);
-
-            return token.Token;
-        }
+        return token.Token;
     }
 }


### PR DESCRIPTION
## Description
In this PR, i have added a new sqlauthentication type called workloadidenityt in order to allow the testing of workloadidentity support in production. By default all the dicom services uses managedidentity option. Authentication type can be updated in appsettings to toggle between managed identity and workload identity

## Related issues
Addresses [issue #105436](https://microsofthealth.visualstudio.com/Health/_workitems/edit/105436)

## Testing
Unit tests are written, And tested the integration end to end. 

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
