### PR TITLE
Add health signals publisher

### DIFF
--- a/src/Microsoft.Health.Blob.UnitTests/Features/Health/BlobHealthCheckTests.cs
+++ b/src/Microsoft.Health.Blob.UnitTests/Features/Health/BlobHealthCheckTests.cs
@@ -76,7 +76,7 @@ public class BlobHealthCheckTests
         _customerKeyHealthCache.Set(new CustomerKeyHealth
         {
             IsHealthy = false,
-            Reason = ExternalHealthReason.CustomerManagedKeyAccessLost,
+            Reason = HealthStatusReason.CustomerManagedKeyAccessLost,
         });
 
         HealthCheckResult result = await _healthCheck.CheckHealthAsync(new HealthCheckContext()).ConfigureAwait(false);

--- a/src/Microsoft.Health.Core.UnitTests/Features/HealthPublisher/HealthCheckMetricPublisherTests.cs
+++ b/src/Microsoft.Health.Core.UnitTests/Features/HealthPublisher/HealthCheckMetricPublisherTests.cs
@@ -1,0 +1,144 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Core.Features.Health;
+using Microsoft.Health.Core.Features.HealthPublisher;
+using Microsoft.Health.Core.Features.Metric;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Core.UnitTests.Features.HealthPublisher;
+
+public class HealthCheckMetricPublisherTests
+{
+    private readonly IResourceHealthSignalProvider _resourceHealthSignalProvider = Substitute.For<IResourceHealthSignalProvider>();
+    private readonly IOptions<ResourceHealthDimensionOptions> _resourceHealthDimensionOptions = Substitute.For<IOptions<ResourceHealthDimensionOptions>>();
+
+    private readonly ResourceHealthDimensionOptions _resourceHealthDimensions;
+
+    private readonly HealthCheckMetricPublisher _healthCheckMetricPublisher;
+
+    public HealthCheckMetricPublisherTests()
+    {
+        _resourceHealthDimensions = new ResourceHealthDimensionOptions()
+        {
+            ArmGeoLocation = "westus2",
+            ArmResourceId = "someResourceId",
+            ResourceType = "workspaces/dicomservices"
+        };
+
+        _resourceHealthDimensionOptions.Value.Returns(_resourceHealthDimensions);
+        _healthCheckMetricPublisher = new HealthCheckMetricPublisher(_resourceHealthSignalProvider, _resourceHealthDimensionOptions, new NullLogger<HealthCheckMetricPublisher>());
+    }
+
+    [Fact]
+    public void GivenReportWithServiceUnavailable_PublishAsync_ServiceUnavailableIsPublished()
+    {
+        HealthReport report = CreateDummyHealthReport(
+            HealthStatus.Unhealthy,
+            new HealthStatusReason[] {
+                HealthStatusReason.ServiceUnavailable,
+                HealthStatusReason.CustomerManagedKeyAccessLost,
+                HealthStatusReason.None });
+
+        _healthCheckMetricPublisher.PublishAsync(report, CancellationToken.None);
+
+        _resourceHealthSignalProvider.Received(1).EmitHealthMetric(HealthStatusReason.ServiceUnavailable, _resourceHealthDimensions);
+    }
+
+    [Fact]
+    public void GivenReportWithCMKAccessLost_PublishAsync_CMKAccessLostIsPublished()
+    {
+        HealthReport report = CreateDummyHealthReport(
+            HealthStatus.Degraded,
+            new HealthStatusReason[] {
+                HealthStatusReason.ServiceDegraded,
+                HealthStatusReason.CustomerManagedKeyAccessLost,
+                HealthStatusReason.None });
+
+        _healthCheckMetricPublisher.PublishAsync(report, CancellationToken.None);
+
+        _resourceHealthSignalProvider.Received(1).EmitHealthMetric(HealthStatusReason.CustomerManagedKeyAccessLost, _resourceHealthDimensions);
+    }
+
+    [Fact]
+    public void GivenReportWithServiceDegraded_PublishAsync_ServiceDegradedIsPublished()
+    {
+        HealthReport report = CreateDummyHealthReport(
+            HealthStatus.Degraded,
+            new HealthStatusReason[] {
+                HealthStatusReason.ServiceDegraded,
+                HealthStatusReason.None });
+
+        _healthCheckMetricPublisher.PublishAsync(report, CancellationToken.None);
+
+        _resourceHealthSignalProvider.Received(1).EmitHealthMetric(HealthStatusReason.ServiceDegraded, _resourceHealthDimensions);
+    }
+
+    [Fact]
+    public void GivenReportWithNone_PublishAsync_NoneIsPublished()
+    {
+        HealthReport report = CreateDummyHealthReport(
+            HealthStatus.Healthy,
+            new HealthStatusReason[] {
+                HealthStatusReason.None,
+                HealthStatusReason.None });
+
+        _healthCheckMetricPublisher.PublishAsync(report, CancellationToken.None);
+
+        _resourceHealthSignalProvider.Received(1).EmitHealthMetric(HealthStatusReason.None, _resourceHealthDimensions);
+    }
+
+    [Fact]
+    public void GivenDegradedReportWithNoneReason_PublishAsync_ServiceDegradedIsPublished()
+    {
+        HealthReport report = CreateDummyHealthReport(
+            HealthStatus.Degraded,
+            new HealthStatusReason[] {
+                HealthStatusReason.None,
+                HealthStatusReason.None });
+
+        _healthCheckMetricPublisher.PublishAsync(report, CancellationToken.None);
+
+        _resourceHealthSignalProvider.Received(1).EmitHealthMetric(HealthStatusReason.ServiceDegraded, _resourceHealthDimensions);
+    }
+
+    [Fact]
+    public void GivenUnhealthyReportWithNoneReason_PublishAsync_ServiceUnavailableIsPublished()
+    {
+        HealthReport report = CreateDummyHealthReport(
+            HealthStatus.Unhealthy,
+            new HealthStatusReason[] {
+                HealthStatusReason.None,
+                HealthStatusReason.None });
+
+        _healthCheckMetricPublisher.PublishAsync(report, CancellationToken.None);
+
+        _resourceHealthSignalProvider.Received(1).EmitHealthMetric(HealthStatusReason.ServiceUnavailable, _resourceHealthDimensions);
+    }
+
+    private static HealthReport CreateDummyHealthReport(HealthStatus overallStatus, HealthStatusReason[] includedStatusAndReasons)
+    {
+        Dictionary<string, HealthReportEntry> entries = new Dictionary<string, HealthReportEntry>();
+
+        foreach (var includedReason in includedStatusAndReasons)
+        {
+            entries.Add($"someEntry{entries.Count}", new HealthReportEntry(
+                HealthStatus.Healthy,
+                "some description",
+                TimeSpan.Zero,
+                exception: null,
+                data: new Dictionary<string, object>() { { "Reason", includedReason } }));
+        }
+
+        return new HealthReport(entries, overallStatus, TimeSpan.Zero);
+    }
+}

--- a/src/Microsoft.Health.Core.UnitTests/Features/HealthPublisher/HealthCheckMetricPublisherTests.cs
+++ b/src/Microsoft.Health.Core.UnitTests/Features/HealthPublisher/HealthCheckMetricPublisherTests.cs
@@ -31,8 +31,7 @@ public class HealthCheckMetricPublisherTests
         _resourceHealthDimensions = new ResourceHealthDimensionOptions()
         {
             ArmGeoLocation = "westus2",
-            ArmResourceId = "someResourceId",
-            ResourceType = "workspaces/dicomservices"
+            ArmResourceId = "someResourceId"
         };
 
         _resourceHealthDimensionOptions.Value.Returns(_resourceHealthDimensions);

--- a/src/Microsoft.Health.Core/Features/Health/HealthReportExtensions.cs
+++ b/src/Microsoft.Health.Core/Features/Health/HealthReportExtensions.cs
@@ -1,0 +1,32 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Health.Core.Features.Health;
+
+internal static class HealthReportExtensions
+{
+    public static HealthStatusReason GetHighestSeverityReason(this HealthReport healthReport, HealthStatusReason defaultReason)
+    {
+        HealthStatusReason worstReason = defaultReason;
+
+        foreach (var entry in healthReport.Entries)
+        {
+            if (entry.Value.Data.TryGetValue("Reason", out object reason))
+            {
+                HealthStatusReason healthStatusReason = Enum.Parse<HealthStatusReason>(reason.ToString());
+
+                if (healthStatusReason > worstReason)
+                {
+                    worstReason = healthStatusReason;
+                }
+            }
+        }
+
+        return worstReason;
+    }
+}

--- a/src/Microsoft.Health.Core/Features/Health/HealthStatusReason.cs
+++ b/src/Microsoft.Health.Core/Features/Health/HealthStatusReason.cs
@@ -5,8 +5,13 @@
 
 namespace Microsoft.Health.Core.Features.Health;
 
-public enum ExternalHealthReason
+/// <summary>
+/// The reason why the service is in its current health state. In order of severity
+/// </summary>
+public enum HealthStatusReason
 {
     None,
+    ServiceDegraded,
     CustomerManagedKeyAccessLost,
+    ServiceUnavailable
 }

--- a/src/Microsoft.Health.Core/Features/Health/HealthStatusReason.cs
+++ b/src/Microsoft.Health.Core/Features/Health/HealthStatusReason.cs
@@ -6,12 +6,24 @@
 namespace Microsoft.Health.Core.Features.Health;
 
 /// <summary>
-/// The reason why the service is in its current health state. In order of severity
+/// The reason why the service is in its current health state.
+/// The values of this enum are ordered from most healthy to least healthy
 /// </summary>
 public enum HealthStatusReason
 {
+    /// <summary>
+    /// Healthy status reasons, in order of most healthy to least healthy
+    /// </summary>
     None,
+
+    /// <summary>
+    /// Degraded status reasons, in order of most healthy to least healthy
+    /// </summary>
     ServiceDegraded,
     CustomerManagedKeyAccessLost,
+
+    /// <summary>
+    /// Unhealthy status reasons, in order of most healthy to least healthy
+    /// </summary>
     ServiceUnavailable
 }

--- a/src/Microsoft.Health.Core/Features/HealthPublisher/HealthCheckMetricPublisher.cs
+++ b/src/Microsoft.Health.Core/Features/HealthPublisher/HealthCheckMetricPublisher.cs
@@ -1,0 +1,53 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Core.Features.Health;
+using Microsoft.Health.Core.Features.Metric;
+
+namespace Microsoft.Health.Core.Features.HealthPublisher;
+internal class HealthCheckMetricPublisher : IHealthCheckPublisher
+{
+    private readonly IResourceHealthSignalProvider _resourceHealthMeter;
+    private readonly ResourceHealthDimensionOptions _resourceHealthDimensionOptions;
+
+    public HealthCheckMetricPublisher(IResourceHealthSignalProvider resourceHealthMeter, IOptions<ResourceHealthDimensionOptions> resourceHealthDimensionOptions)
+    {
+        EnsureArg.IsNotNull(resourceHealthDimensionOptions, nameof(resourceHealthDimensionOptions));
+
+        _resourceHealthDimensionOptions = EnsureArg.IsNotNull(resourceHealthDimensionOptions.Value, nameof(resourceHealthDimensionOptions.Value));
+        _resourceHealthMeter = EnsureArg.IsNotNull(resourceHealthMeter, nameof(resourceHealthMeter));
+
+        EnsureArg.IsNotNull(_resourceHealthDimensionOptions.ArmGeoLocation, nameof(_resourceHealthDimensionOptions.ArmGeoLocation));
+        EnsureArg.IsNotNull(_resourceHealthDimensionOptions.ResourceType, nameof(_resourceHealthDimensionOptions.ResourceType));
+        EnsureArg.IsNotNull(_resourceHealthDimensionOptions.ArmResourceId, nameof(_resourceHealthDimensionOptions.ArmResourceId));
+    }
+
+    public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
+    {
+        EnsureArg.IsNotNull(report, nameof(report));
+
+        switch (report.Status)
+        {
+            case HealthStatus.Healthy:
+                _resourceHealthMeter.EmitHealthMetric(HealthStatusReason.None, _resourceHealthDimensionOptions);
+                break;
+            case HealthStatus.Degraded:
+                HealthStatusReason reason = report.GetHighestSeverityReason(defaultReason: HealthStatusReason.ServiceDegraded);
+                _resourceHealthMeter.EmitHealthMetric(reason, _resourceHealthDimensionOptions);
+                break;
+            case HealthStatus.Unhealthy:
+            default:
+                _resourceHealthMeter.EmitHealthMetric(HealthStatusReason.ServiceUnavailable, _resourceHealthDimensionOptions);
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Microsoft.Health.Core/Features/HealthPublisher/HealthCheckPublisherExtensions.cs
+++ b/src/Microsoft.Health.Core/Features/HealthPublisher/HealthCheckPublisherExtensions.cs
@@ -30,14 +30,17 @@ public static class HealthCheckPublisherExtensions
         return services;
     }
 
-    public static IServiceCollection AddHealthCheckPublishers(this IServiceCollection services, Action<HealthCheckPublisherOptions> configure = null, Action<ResourceHealthDimensionOptions> configureDimensions = null)
+    public static IServiceCollection AddHealthCheckMetricPublisher(this IServiceCollection services, Action<HealthCheckPublisherOptions> configure = null, Action<ResourceHealthDimensionOptions> configureDimensions = null)
     {
         EnsureArg.IsNotNull(configure, nameof(configure));
 
-        services.AddHealthCheckCachePublisher(configure);
-
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthCheckPublisher, HealthCheckMetricPublisher>());
         services.TryAddSingleton<IResourceHealthSignalProvider, DefaultResourceHealthSignalProvider>();
+
+        if (configure != null)
+        {
+            services.Configure(configure);
+        }
 
         if (configureDimensions != null)
         {

--- a/src/Microsoft.Health.Core/Features/HealthPublisher/HealthCheckPublisherExtensions.cs
+++ b/src/Microsoft.Health.Core/Features/HealthPublisher/HealthCheckPublisherExtensions.cs
@@ -8,12 +8,14 @@ using EnsureThat;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Health.Core.Features.HealthPublisher;
+using Microsoft.Health.Core.Features.Metric;
 
 namespace Microsoft.Health.Core.Features.Health;
 
 public static class HealthCheckPublisherExtensions
 {
-    public static IServiceCollection AddHealthCheckPublisher(this IServiceCollection services, Action<HealthCheckPublisherOptions> configure = null)
+    public static IServiceCollection AddHealthCheckCachePublisher(this IServiceCollection services, Action<HealthCheckPublisherOptions> configure = null)
     {
         EnsureArg.IsNotNull(configure, nameof(configure));
 
@@ -23,6 +25,23 @@ public static class HealthCheckPublisherExtensions
         if (configure != null)
         {
             services.Configure(configure);
+        }
+
+        return services;
+    }
+
+    public static IServiceCollection AddHealthCheckPublishers(this IServiceCollection services, Action<HealthCheckPublisherOptions> configure = null, Action<ResourceHealthDimensionOptions> configureDimensions = null)
+    {
+        EnsureArg.IsNotNull(configure, nameof(configure));
+
+        services.AddHealthCheckCachePublisher(configure);
+
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthCheckPublisher, HealthCheckMetricPublisher>());
+        services.TryAddSingleton<IResourceHealthSignalProvider, DefaultResourceHealthSignalProvider>();
+
+        if (configureDimensions != null)
+        {
+            services.Configure(configureDimensions);
         }
 
         return services;

--- a/src/Microsoft.Health.Core/Features/Metric/DefaultResourceHealthSignalProvider.cs
+++ b/src/Microsoft.Health.Core/Features/Metric/DefaultResourceHealthSignalProvider.cs
@@ -1,0 +1,29 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Core.Features.Health;
+
+namespace Microsoft.Health.Core.Features.Metric;
+
+internal class DefaultResourceHealthSignalProvider : IResourceHealthSignalProvider
+{
+    private readonly ILogger<DefaultResourceHealthSignalProvider> _logger;
+
+    public DefaultResourceHealthSignalProvider(ILogger<DefaultResourceHealthSignalProvider> logger)
+    {
+        _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+    }
+
+    public void EmitHealthMetric(HealthStatusReason reason, ResourceHealthDimensionOptions resourceHealthDimension)
+    {
+        _logger.LogInformation("No signal provider has been configured to emit resource health metric with dimensions: {ArmResourceId}, {ArmGeoLocation}, {ResourceType}, {Reason}",
+            resourceHealthDimension.ArmResourceId,
+            resourceHealthDimension.ArmGeoLocation,
+            resourceHealthDimension.ResourceType,
+            reason);
+    }
+}

--- a/src/Microsoft.Health.Core/Features/Metric/DefaultResourceHealthSignalProvider.cs
+++ b/src/Microsoft.Health.Core/Features/Metric/DefaultResourceHealthSignalProvider.cs
@@ -20,10 +20,9 @@ internal class DefaultResourceHealthSignalProvider : IResourceHealthSignalProvid
 
     public void EmitHealthMetric(HealthStatusReason reason, ResourceHealthDimensionOptions resourceHealthDimension)
     {
-        _logger.LogInformation("No signal provider has been configured to emit resource health metric with dimensions: {ArmResourceId}, {ArmGeoLocation}, {ResourceType}, {Reason}",
+        _logger.LogInformation("No signal provider has been configured to emit resource health metric with dimensions: {ArmResourceId}, {ArmGeoLocation}, {Reason}",
             resourceHealthDimension.ArmResourceId,
             resourceHealthDimension.ArmGeoLocation,
-            resourceHealthDimension.ResourceType,
             reason);
     }
 }

--- a/src/Microsoft.Health.Core/Features/Metric/IResourceHealthSignalProvider.cs
+++ b/src/Microsoft.Health.Core/Features/Metric/IResourceHealthSignalProvider.cs
@@ -1,0 +1,14 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Core.Features.Health;
+
+namespace Microsoft.Health.Core.Features.Metric;
+
+internal interface IResourceHealthSignalProvider
+
+{
+    void EmitHealthMetric(HealthStatusReason reason, ResourceHealthDimensionOptions resourceHealthDimension);
+}

--- a/src/Microsoft.Health.Core/Features/Metric/IResourceHealthSignalProvider.cs
+++ b/src/Microsoft.Health.Core/Features/Metric/IResourceHealthSignalProvider.cs
@@ -7,8 +7,7 @@ using Microsoft.Health.Core.Features.Health;
 
 namespace Microsoft.Health.Core.Features.Metric;
 
-internal interface IResourceHealthSignalProvider
-
+public interface IResourceHealthSignalProvider
 {
     void EmitHealthMetric(HealthStatusReason reason, ResourceHealthDimensionOptions resourceHealthDimension);
 }

--- a/src/Microsoft.Health.Core/Features/Metric/ResourceHealthDimensionOptions.cs
+++ b/src/Microsoft.Health.Core/Features/Metric/ResourceHealthDimensionOptions.cs
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Core.Features.Metric;
+
+/// <summary>
+/// Defines required dimensions for reporting metrics to Geneva Health
+/// </summary>
+public class ResourceHealthDimensionOptions
+{
+    public const string SectionName = "ResourceHealthDimension";
+
+    public string ResourceType { get; set; }
+
+    public string ArmGeoLocation { get; set; }
+
+    public string ArmResourceId { get; set; }
+}

--- a/src/Microsoft.Health.Core/Features/Metric/ResourceHealthDimensionOptions.cs
+++ b/src/Microsoft.Health.Core/Features/Metric/ResourceHealthDimensionOptions.cs
@@ -12,8 +12,6 @@ public class ResourceHealthDimensionOptions
 {
     public const string SectionName = "ResourceHealthDimension";
 
-    public string ResourceType { get; set; }
-
     public string ArmGeoLocation { get; set; }
 
     public string ArmResourceId { get; set; }

--- a/src/Microsoft.Health.Encryption.UnitTests/CustomerKeyValidationBackgroundServiceTests.cs
+++ b/src/Microsoft.Health.Encryption.UnitTests/CustomerKeyValidationBackgroundServiceTests.cs
@@ -53,7 +53,7 @@ public class CustomerKeyValidationBackgroundServiceTests : IDisposable
         CustomerKeyHealth cmkHealth = await _customerKeyHealthCache.GetAsync().ConfigureAwait(false);
         Assert.True(cmkHealth.IsHealthy);
         Assert.Null(cmkHealth.Exception);
-        Assert.Equal(ExternalHealthReason.None, cmkHealth.Reason);
+        Assert.Equal(HealthStatusReason.None, cmkHealth.Reason);
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class CustomerKeyValidationBackgroundServiceTests : IDisposable
         CustomerKeyHealth cmkHealth = await _customerKeyHealthCache.GetAsync().ConfigureAwait(false);
         Assert.False(cmkHealth.IsHealthy);
         Assert.Equal(customerKeyInaccessibleException, cmkHealth.Exception);
-        Assert.Equal(ExternalHealthReason.CustomerManagedKeyAccessLost, cmkHealth.Reason);
+        Assert.Equal(HealthStatusReason.CustomerManagedKeyAccessLost, cmkHealth.Reason);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class CustomerKeyValidationBackgroundServiceTests : IDisposable
         CustomerKeyHealth cmkHealth = await cmkHealthTask.ConfigureAwait(false);
         Assert.True(cmkHealth.IsHealthy);
         Assert.Null(cmkHealth.Exception);
-        Assert.Equal(ExternalHealthReason.None, cmkHealth.Reason);
+        Assert.Equal(HealthStatusReason.None, cmkHealth.Reason);
     }
 
     protected virtual void Dispose(bool disposing)

--- a/src/Microsoft.Health.Encryption/Customer/Health/CustomerKeyHealth.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/CustomerKeyHealth.cs
@@ -21,7 +21,7 @@ public class CustomerKeyHealth
     /// <summary>
     /// Gets or sets a reason for the health state
     /// </summary>
-    public ExternalHealthReason Reason { get; set; }
+    public HealthStatusReason Reason { get; set; }
 
     /// <summary>
     /// Gets or sets the exception captured from an unhealthy state

--- a/src/Microsoft.Health.Encryption/Customer/Health/CustomerKeyValidationBackgroundService.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/CustomerKeyValidationBackgroundService.cs
@@ -78,7 +78,7 @@ internal class CustomerKeyValidationBackgroundService : BackgroundService
         _customerManagedKeyHealth.Set(new CustomerKeyHealth
         {
             IsHealthy = false,
-            Reason = ExternalHealthReason.CustomerManagedKeyAccessLost,
+            Reason = HealthStatusReason.CustomerManagedKeyAccessLost,
             Exception = ex,
         });
     }
@@ -88,7 +88,7 @@ internal class CustomerKeyValidationBackgroundService : BackgroundService
         _customerManagedKeyHealth.Set(new CustomerKeyHealth
         {
             IsHealthy = true,
-            Reason = ExternalHealthReason.None,
+            Reason = HealthStatusReason.None,
             Exception = null,
         });
     }


### PR DESCRIPTION
## Description
Add another health check publisher which will use the report to publish signals based on the result.

## Related issues
Addresses [104770].

## Testing
Testing by pulling these changes into dicom paas, implementing a signal provider, and testing on a cluster. Confirmed the metrics show up in geneva as expected

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
