### PR TITLE
Replace Microsoft.Azure.Services.AppAuthentication with Azure Identity

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="2.14.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Core" Version="3.0.37" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions" Version="5.0.0" />

--- a/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Registration/SqlServerBaseRegistrationExtensionsTests.cs
@@ -4,7 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using Microsoft.Azure.Services.AppAuthentication;
+using Azure.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Abstractions.Features.Transactions;
@@ -39,7 +39,7 @@ public class SqlServerBaseRegistrationExtensionsTests
         Assert.True(services.ContainsScoped<SqlServerSchemaDataStore>());
         Assert.True(services.ContainsScoped<SqlTransactionHandler>());
 
-        Assert.True(services.ContainsSingleton<AzureServiceTokenProvider>());
+        Assert.True(services.ContainsSingleton<DefaultAzureCredential>());
         Assert.True(services.ContainsSingleton<BaseScriptProvider>());
         Assert.True(services.ContainsSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>());
         Assert.True(services.ContainsSingleton<IAccessTokenHandler, WorkloadIdentityAccessTokenHandler>());
@@ -67,7 +67,7 @@ public class SqlServerBaseRegistrationExtensionsTests
         Assert.True(services.ContainsScoped<SqlTransactionHandler>());
         Assert.True(services.ContainsScoped<ITransactionHandler, SqlTransactionHandler>());
 
-        Assert.True(services.ContainsSingleton<AzureServiceTokenProvider>());
+        Assert.True(services.ContainsSingleton<DefaultAzureCredential>());
         Assert.True(services.ContainsSingleton<IAccessTokenHandler, ManagedIdentityAccessTokenHandler>());
         Assert.True(services.ContainsSingleton<IAccessTokenHandler, WorkloadIdentityAccessTokenHandler>());
         Assert.True(services.ContainsSingleton<ISqlConnectionBuilder>());

--- a/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
+++ b/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Ensure.That" />
     <PackageReference Include="MediatR" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />


### PR DESCRIPTION
## Description
Microsoft.Azure.Services.AppAuthentication is no longer supported and is flagged by component governance as a security risk.  Removing references to it and replacing with Azure.Identity.

## Related issues
Addresses [issue [AB#109328](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/109328)].

## Testing
Current automated tests.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
