### PR TITLE
Add Identity Model to SQL Package Dependencies

### DIFF
--- a/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
+++ b/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
@@ -41,6 +41,12 @@
     <PackageReference Include="System.Drawing.Common" PrivateAssets="All" />
   </ItemGroup>
 
+  <!-- These aren't truly direct dependencies, but we'll treat them as such to enforce the package tree in downstream dependencies -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Abstractions\Microsoft.Health.Abstractions.csproj" />
     <ProjectReference Include="..\Microsoft.Health.Core\Microsoft.Health.Core.csproj" />


### PR DESCRIPTION
## Description
Until the SQL library updates its version of the Identity Model packages, we'll force them to update via `PackageReference`.

## Related issues
N/A

## Testing
Existing tests

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
