### PR TITLE
Add timer in the httpContext for audit logs

### DIFF
--- a/src/Microsoft.Health.Api/Features/Audit/AuditLoggingFilterAttribute.cs
+++ b/src/Microsoft.Health.Api/Features/Audit/AuditLoggingFilterAttribute.cs
@@ -1,9 +1,10 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using EnsureThat;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -36,6 +37,8 @@ public class AuditLoggingFilterAttribute : ActionFilterAttribute
         EnsureArg.IsNotNull(context, nameof(context));
 
         AuditHelper.LogExecuting(context.HttpContext, ClaimsExtractor);
+
+        context.HttpContext.Items["timer"] = Stopwatch.StartNew();
 
         base.OnActionExecuting(context);
     }


### PR DESCRIPTION
## Description
To populate the duration in the azure monitor audit(shoebox) logs, sticking the timer in the httpContext.

## Related issues
Addresses [108768](https://microsofthealth.visualstudio.com/Health/_workitems/edit/108768)

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
