### PR TITLE
Add duration in audit action

### DIFF
--- a/src/Microsoft.Health.Api/Features/Audit/AuditLoggingFilterAttribute.cs
+++ b/src/Microsoft.Health.Api/Features/Audit/AuditLoggingFilterAttribute.cs
@@ -36,9 +36,9 @@ public class AuditLoggingFilterAttribute : ActionFilterAttribute
     {
         EnsureArg.IsNotNull(context, nameof(context));
 
-        AuditHelper.LogExecuting(context.HttpContext, ClaimsExtractor);
-
         context.HttpContext.Items["timer"] = Stopwatch.StartNew();
+
+        AuditHelper.LogExecuting(context.HttpContext, ClaimsExtractor);
 
         base.OnActionExecuting(context);
     }
@@ -54,7 +54,10 @@ public class AuditLoggingFilterAttribute : ActionFilterAttribute
     {
         EnsureArg.IsNotNull(context, nameof(context));
 
-        AuditHelper.LogExecuted(context.HttpContext, ClaimsExtractor);
+        var stopwatch = (Stopwatch)context.HttpContext.Items["timer"];
+        long durationMs = stopwatch.ElapsedMilliseconds;
+
+        AuditHelper.LogExecuted(context.HttpContext, ClaimsExtractor, durationMs: durationMs);
 
         base.OnResultExecuted(context);
     }

--- a/src/Microsoft.Health.Api/Features/Audit/IAuditHelper.cs
+++ b/src/Microsoft.Health.Api/Features/Audit/IAuditHelper.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -26,5 +26,6 @@ public interface IAuditHelper
     /// <param name="httpContext">The HTTP context.</param>
     /// <param name="claimsExtractor">The extractor used to extract claims.</param>
     /// <param name="shouldCheckForAuthXFailure">Should check for AuthX failure and print LogExecuted messages only if it is AuthX failure.</param>
-    void LogExecuted(HttpContext httpContext, IClaimsExtractor claimsExtractor, bool shouldCheckForAuthXFailure = false);
+    /// <param name="durationMs">Duration of the requests in milliseconds</param>
+    void LogExecuted(HttpContext httpContext, IClaimsExtractor claimsExtractor, bool shouldCheckForAuthXFailure = false, long? durationMs = null);
 }


### PR DESCRIPTION
## Description
Add timer in the httpContext and read duration as Stopwatch to bubble it up in the audit logs

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
