### PR TITLE
Enable Workload Identity for SQL and Azure Blob Storage

### DIFF
--- a/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
+++ b/src/Microsoft.Health.Blob/Configs/BlobServiceClientOptions.cs
@@ -1,8 +1,9 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using Azure.Identity;
 using Azure.Storage.Blobs;
 
@@ -33,9 +34,19 @@ public class BlobServiceClientOptions : BlobClientOptions
     /// and value separated by an equal sign (=) like in the following example:
     /// <c>"DefaultEndpointsProtocol=https;AccountName=myAccountName;AccountKey=myAccountKey"</c>.
     /// </para>
+    /// <para>
+    /// <see cref="ConnectionString"/> and <see cref="ServiceUri"/> are mutually exclusive.
+    /// </para>
     /// </remarks>
     /// <value>The connection string key-value pairs.</value>
     public string ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Azure Blob Storage service URI.
+    /// </summary>
+    /// <remarks><see cref="ConnectionString"/> and <see cref="ServiceUri"/> are mutually exclusive.</remarks>
+    /// <value>The URI for the Azure Blob Storage service if specified; otherwise <see langword="null"/>.</value>
+    public Uri ServiceUri { get; set; }
 
     /// <summary>
     /// Gets or sets the type of credential used to authenticate the client.

--- a/src/Microsoft.Health.SqlServer.UnitTests/WorkloadIdentityAuthenticationProviderTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/WorkloadIdentityAuthenticationProviderTests.cs
@@ -1,0 +1,183 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using Microsoft.Data.SqlClient;
+using NSubstitute;
+using NSubstitute.Core;
+using Xunit;
+
+namespace Microsoft.Health.SqlServer.UnitTests;
+
+public class WorkloadIdentityAuthenticationProviderTests
+{
+    private const string DefaultAuthority = "https://login.microsoftonline.com/";
+    private const string DefaultResource = "https://database.windows.net/.default";
+
+    private readonly WorkloadIdentityCredential _credential = Substitute.For<WorkloadIdentityCredential>();
+
+    [Theory]
+    [InlineData("https://database.windows.net")]
+    [InlineData("https://database.windows.net/.default")]
+    public async Task GivenDifferentResources_WhenFetchingToken_ThenNormalizeScope(string resource)
+    {
+        AccessToken accessToken = new(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
+
+        _credential
+            .GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(accessToken);
+
+        WorkloadIdentityAuthenticationProvider provider = new(o => _credential);
+
+        await provider
+            .AcquireTokenAsync(new MockSqlAuthenticationParameters(resource: resource))
+            .ConfigureAwait(false);
+
+        await _credential
+            .Received(1)
+            .GetTokenAsync(Arg.Is<TokenRequestContext>(c => c.Scopes.Single() == DefaultResource), Arg.Any<CancellationToken>())
+            .ConfigureAwait(false);
+    }
+
+    [Theory]
+    [InlineData("https://login.microsoftonline.com/foo", "https://login.microsoftonline.com/")]
+    [InlineData("https://login.microsoftonline.us/", "https://login.microsoftonline.us/")]
+    public async Task GivenDifferentAuthorities_WhenFetchingToken_ThenTrimAfterFinalSlash(string authority, string expected)
+    {
+        AccessToken accessToken = new(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
+
+        _credential
+            .GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(accessToken);
+
+        WorkloadIdentityAuthenticationProvider provider = new(o =>
+        {
+            Assert.Equal(expected, o.AuthorityHost.OriginalString);
+            return _credential;
+        });
+
+        SqlAuthenticationToken actual = await provider
+            .AcquireTokenAsync(new MockSqlAuthenticationParameters(authority: authority))
+            .ConfigureAwait(false);
+
+        Assert.Equal(accessToken.Token, actual.AccessToken);
+    }
+
+    [Fact]
+    public async Task GivenNoUserId_WhenFetchingToken_ThenNoClientId()
+    {
+        AccessToken accessToken = new(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
+
+        _credential
+            .GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(accessToken);
+
+        WorkloadIdentityAuthenticationProvider provider = new(o =>
+        {
+            Assert.Null(o.ClientId);
+            return _credential;
+        });
+
+        SqlAuthenticationToken actual = await provider
+            .AcquireTokenAsync(new MockSqlAuthenticationParameters(userId: null))
+            .ConfigureAwait(false);
+
+        Assert.Equal(accessToken.Token, actual.AccessToken);
+        Assert.Equal(accessToken.ExpiresOn, actual.ExpiresOn);
+
+        await _credential
+            .Received(1)
+            .GetTokenAsync(Arg.Is<TokenRequestContext>(c => c.Scopes.Single() == DefaultResource), Arg.Any<CancellationToken>())
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task GivenUserId_WhenFetchingToken_ThenUseAsClientId()
+    {
+        string UserId = Guid.NewGuid().ToString();
+        AccessToken accessToken = new(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
+
+        _credential
+            .GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(accessToken);
+
+        WorkloadIdentityAuthenticationProvider provider = new(o =>
+        {
+            Assert.Equal(UserId, o.ClientId);
+            return _credential;
+        });
+
+        SqlAuthenticationToken actual = await provider
+            .AcquireTokenAsync(new MockSqlAuthenticationParameters(userId: UserId))
+            .ConfigureAwait(false);
+
+        Assert.Equal(accessToken.Token, actual.AccessToken);
+        Assert.Equal(accessToken.ExpiresOn, actual.ExpiresOn);
+
+        await _credential
+            .Received(1)
+            .GetTokenAsync(Arg.Is<TokenRequestContext>(c => c.Scopes.Single() == DefaultResource), Arg.Any<CancellationToken>())
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    [SuppressMessage("Reliability", "CA2012:Use ValueTasks correctly", Justification = "ValueTask only used once.")]
+    public async Task GivenTimeout_WhenFetchingToken_ThenThrowException()
+    {
+        string UserId = Guid.NewGuid().ToString();
+        AccessToken accessToken = new(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
+
+        _credential
+            .GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(GetTokenAsync);
+
+        WorkloadIdentityAuthenticationProvider provider = new(o => _credential);
+
+        await Assert
+            .ThrowsAsync<TaskCanceledException>(
+                () => provider.AcquireTokenAsync(new MockSqlAuthenticationParameters(connectionTimeout: 1)))
+            .ConfigureAwait(false);
+
+        static async ValueTask<AccessToken> GetTokenAsync(CallInfo callInfo)
+        {
+            await Task.Delay(-1, callInfo.ArgAt<CancellationToken>(1)).ConfigureAwait(false);
+            return new AccessToken();
+        }
+    }
+
+    [Theory]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, true)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryMSI, true)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryDefault, false)]
+    public void GivenAuthenticationMethod_WhenCheckSupport_ThenReturnTrueForManagedIdentity(SqlAuthenticationMethod authenticationMethod, bool expected)
+        => Assert.Equal(expected, new WorkloadIdentityAuthenticationProvider().IsSupported(authenticationMethod));
+
+    private sealed class MockSqlAuthenticationParameters : SqlAuthenticationParameters
+    {
+        public MockSqlAuthenticationParameters(
+            SqlAuthenticationMethod authenticationMethod = SqlAuthenticationMethod.ActiveDirectoryManagedIdentity,
+            string resource = DefaultResource,
+            string authority = DefaultAuthority,
+            string userId = null,
+            int connectionTimeout = -1)
+            : base(
+                  authenticationMethod,
+                  serverName: null,
+                  databaseName: null,
+                  resource: resource,
+                  authority: authority,
+                  userId: userId,
+                  password: null,
+                  connectionId: Guid.NewGuid(),
+                  connectionTimeout: connectionTimeout)
+        { }
+    }
+}

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -147,6 +147,23 @@ public static class SqlServerBaseRegistrationExtensions
     }
 
     /// <summary>
+    /// Replaces the SQL authentication provider for managed identity to use workload identity instead.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to be updated.</param>
+    /// <returns>The <paramref name="services"/> for additional method invocations.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="services"/> is <see langword="null"/>.
+    /// </exception>
+    public static IServiceCollection EnableWorkloadManagedIdentity(this IServiceCollection services)
+    {
+        EnsureArg.IsNotNull(services, nameof(services));
+
+        SqlAuthenticationProvider.SetProvider(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, new WorkloadIdentityAuthenticationProvider());
+
+        return services;
+    }
+
+    /// <summary>
     /// Adds an <see cref="SqlRetryLogicBaseProvider"/> to be used by SqlConnection and SqlCommand
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to be updated.</param>

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -149,6 +149,10 @@ public static class SqlServerBaseRegistrationExtensions
     /// <summary>
     /// Replaces the SQL authentication provider for managed identity to use workload identity instead.
     /// </summary>
+    /// <remarks>
+    /// The authentication type must either be <see cref="SqlAuthenticationMethod.ActiveDirectoryManagedIdentity"/>
+    /// or <see cref="SqlAuthenticationMethod.ActiveDirectoryMSI"/>.
+    /// </remarks>
     /// <param name="services">The <see cref="IServiceCollection"/> to be updated.</param>
     /// <returns>The <paramref name="services"/> for additional method invocations.</returns>
     /// <exception cref="ArgumentNullException">

--- a/src/Microsoft.Health.SqlServer/WorkloadIdentityAuthenticationProvider.cs
+++ b/src/Microsoft.Health.SqlServer/WorkloadIdentityAuthenticationProvider.cs
@@ -34,7 +34,8 @@ internal sealed class WorkloadIdentityAuthenticationProvider : SqlAuthentication
         EnsureArg.IsNotNull(parameters, nameof(parameters));
 
         using CancellationTokenSource cts = new();
-        cts.CancelAfter(parameters.ConnectionTimeout * 1000); // Convert to milliseconds
+        if (parameters.ConnectionTimeout > 0)
+            cts.CancelAfter(parameters.ConnectionTimeout * 1000); // Convert to milliseconds
 
         string scope = parameters.Resource.EndsWith(DefaultScopeSuffix, StringComparison.Ordinal) ? parameters.Resource : parameters.Resource + DefaultScopeSuffix;
         string[] scopes = new string[] { scope };

--- a/src/Microsoft.Health.SqlServer/WorkloadIdentityAuthenticationProvider.cs
+++ b/src/Microsoft.Health.SqlServer/WorkloadIdentityAuthenticationProvider.cs
@@ -1,0 +1,59 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using EnsureThat;
+using Microsoft.Data.SqlClient;
+
+namespace Microsoft.Health.SqlServer;
+
+internal sealed class WorkloadIdentityAuthenticationProvider : SqlAuthenticationProvider
+{
+    private const string DefaultScopeSuffix = "/.default";
+
+    // SQL Client doesn't integrate with DI today, so we'll use this factory for testing
+    private readonly Func<WorkloadIdentityCredentialOptions, WorkloadIdentityCredential> _createCredential;
+
+    public WorkloadIdentityAuthenticationProvider()
+        : this(o => new WorkloadIdentityCredential(o))
+    { }
+
+    internal WorkloadIdentityAuthenticationProvider(Func<WorkloadIdentityCredentialOptions, WorkloadIdentityCredential> createCredential)
+        => _createCredential = EnsureArg.IsNotNull(createCredential, nameof(createCredential));
+
+    public override async Task<SqlAuthenticationToken> AcquireTokenAsync(SqlAuthenticationParameters parameters)
+    {
+        // Logic is based on the existing ActiveDirectoryAuthenticationProvider
+        // https://github.com/dotnet/SqlClient/blob/111033e65625c435295cea500508a13e00a3d764/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
+        EnsureArg.IsNotNull(parameters, nameof(parameters));
+
+        using CancellationTokenSource cts = new();
+        cts.CancelAfter(parameters.ConnectionTimeout * 1000); // Convert to milliseconds
+
+        string scope = parameters.Resource.EndsWith(DefaultScopeSuffix, StringComparison.Ordinal) ? parameters.Resource : parameters.Resource + DefaultScopeSuffix;
+        string[] scopes = new string[] { scope };
+        TokenRequestContext tokenRequestContext = new(scopes);
+
+        int seperatorIndex = parameters.Authority.LastIndexOf('/');
+        string authority = parameters.Authority.Remove(seperatorIndex + 1);
+        string clientId = string.IsNullOrWhiteSpace(parameters.UserId) ? null : parameters.UserId;
+
+        WorkloadIdentityCredentialOptions options = new()
+        {
+            AuthorityHost = new Uri(authority),
+            ClientId = clientId,
+        };
+
+        AccessToken accessToken = await _createCredential(options).GetTokenAsync(tokenRequestContext, cts.Token).ConfigureAwait(false);
+        return new SqlAuthenticationToken(accessToken.Token, accessToken.ExpiresOn);
+    }
+
+    public override bool IsSupported(SqlAuthenticationMethod authenticationMethod)
+        => authenticationMethod is SqlAuthenticationMethod.ActiveDirectoryManagedIdentity or SqlAuthenticationMethod.ActiveDirectoryMSI;
+}


### PR DESCRIPTION
## Description
Update registration APIs to optionally allow workload identity for both Azure Blob Storage and SQL Server

## Related issues
[AB#106459](https://microsofthealth.visualstudio.com/Health/_workitems/edit/106459/)
[AB#106461](https://microsofthealth.visualstudio.com/Health/_workitems/edit/106461/)

## Testing
New test for workload identity SQL auth provider

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Feature
