### PR TITLE
Catch errors where sql db is inacessible

### DIFF
--- a/src/Microsoft.Health.Core/Features/Health/HealthStatusReason.cs
+++ b/src/Microsoft.Health.Core/Features/Health/HealthStatusReason.cs
@@ -20,6 +20,7 @@ public enum HealthStatusReason
     /// Degraded status reasons, in order of most healthy to least healthy
     /// </summary>
     ServiceDegraded,
+    DataStoreStateDegraded,
     CustomerManagedKeyAccessLost,
 
     /// <summary>

--- a/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Core.Features.Health;
@@ -51,14 +52,27 @@ public class SqlServerHealthCheck : IHealthCheck
                 new Dictionary<string, object> { { "Reason", cmkStatus.Reason } });
         }
 
-        using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken).ConfigureAwait(false);
-        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
+        try
+        {
+            using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken).ConfigureAwait(false);
+            using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
 
-        sqlCommandWrapper.CommandText = "select @@DBTS";
+            sqlCommandWrapper.CommandText = "select @@DBTS";
 
-        await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
 
-        _logger.LogInformation("Successfully connected to SQL database.");
-        return HealthCheckResult.Healthy("Successfully connected.");
+            _logger.LogInformation("Successfully connected to SQL database.");
+            return HealthCheckResult.Healthy("Successfully connected.");
+        }
+        // Error: Can not connect to the database in its current state. This error can be for various DB states (recovering, inacessible) but we assume that our DB will only hit this for Inaccessible state
+        catch (SqlException ex) when (ex.ErrorCode == 40925)
+        {
+            // DB is status in Inaccessible because the encryption key was inacessible for > 30 mins. User must reprovision or we need to revalidate key on SQL DB. 
+            return new HealthCheckResult(
+                HealthStatus.Degraded,
+                DegradedDescription,
+                ex,
+                new Dictionary<string, object> { { "Reason", HealthStatusReason.DataStoreStateDegraded } });
+        }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -89,6 +89,12 @@ public class SchemaJobWorker
             catch (SqlException se) when (se.Number == SqlErrorCodes.CouldNotFoundStoredProc && schemaInformation.Current == null)
             {
                 // this could happen during schema initialization until base schema is not executed so can be ignored
+            }
+            // Error: "Can not connect to the database in its current state". This error can be for various DB states (recovering, inacessible) but we assume that our DB will only hit this for Inaccessible state
+            catch (SqlException ex) when (ex.ErrorCode == 40925)
+            {
+                // this can happen when a user has misconfigured CMK for > 30 min, which results in the DB having a status of "Inacessible".
+                _logger.LogInformation(ex, "The SQL database cannot be accessed in its current state.");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Description
Scenario missed in health state:
- cmk is enabled
- customer misconfigures cmk, and leaves it misconfigured for 30 mins
- we report Degraded status because we cannot access the key
- customer fixes their cmk configuration, but does not reprovision the service in order to revalidate the key on the SQL DB
- we are able to access the key, so health checks will pass the CMK check, try to connect to the SQL DB, and fail

Adding a new state here so we can display more details to the customer about why their service might be in this state, and what they can do to fix it (reprovision/update)

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
