### PR TITLE
[SQL] SQL connection async methods

### DIFF
--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionBuilder.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionBuilder.cs
@@ -106,6 +106,6 @@ public class DefaultSqlConnectionBuilder : ISqlConnectionBuilder
     /// <param name="initialCatalog">An optional initial catalog that may be used to override the default value.</param>
     /// <param name="maxPoolSize">An optional maximum for the SQL connection pool size.</param>
     /// <returns>A <see cref="SqlConnectionStringBuilder"/> representing the current connection string.</returns>
-    protected virtual async Task<SqlConnectionStringBuilder> GetConnectionStringBuilderAsync(string initialCatalog = null, int? maxPoolSize = null)
-        => await Task.FromResult(GetConnectionStringBuilder(initialCatalog, maxPoolSize)).ConfigureAwait(false);
+    protected virtual Task<SqlConnectionStringBuilder> GetConnectionStringBuilderAsync(string initialCatalog = null, int? maxPoolSize = null)
+        => Task.FromResult(GetConnectionStringBuilder(initialCatalog, maxPoolSize));
 }

--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionBuilder.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionBuilder.cs
@@ -58,6 +58,7 @@ public class DefaultSqlConnectionBuilder : ISqlConnectionBuilder
     public string DefaultDatabase { get; }
 
     /// <inheritdoc />
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller must dispose result.")]
     public SqlConnection GetSqlConnection(string initialCatalog = null, int? maxPoolSize = null)
     {
         SqlConnectionStringBuilder builder = GetConnectionStringBuilder(initialCatalog, maxPoolSize);
@@ -65,10 +66,12 @@ public class DefaultSqlConnectionBuilder : ISqlConnectionBuilder
     }
 
     /// <inheritdoc />
-    [Obsolete($"Use {nameof(GetSqlConnection)} instead.")]
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller must dispose result.")]
-    public Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, int? maxPoolSize = null, CancellationToken cancellationToken = default)
-        => Task.FromResult(GetSqlConnection(initialCatalog, maxPoolSize));
+    public async Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, int? maxPoolSize = null, CancellationToken cancellationToken = default)
+    {
+        SqlConnectionStringBuilder builder = await GetConnectionStringBuilderAsync(initialCatalog, maxPoolSize).ConfigureAwait(false);
+        return new SqlConnection(builder.ToString()) { RetryLogicProvider = _retryProvider };
+    }
 
     /// <summary>
     /// Creates a <see cref="SqlConnectionStringBuilder"/> using the configured connection string and modified based on the input.
@@ -96,4 +99,13 @@ public class DefaultSqlConnectionBuilder : ISqlConnectionBuilder
 
         return builder;
     }
+
+    /// <summary>
+    /// Creates a <see cref="SqlConnectionStringBuilder"/> using the configured connection string and modified based on the input.
+    /// </summary>
+    /// <param name="initialCatalog">An optional initial catalog that may be used to override the default value.</param>
+    /// <param name="maxPoolSize">An optional maximum for the SQL connection pool size.</param>
+    /// <returns>A <see cref="SqlConnectionStringBuilder"/> representing the current connection string.</returns>
+    protected virtual async Task<SqlConnectionStringBuilder> GetConnectionStringBuilderAsync(string initialCatalog = null, int? maxPoolSize = null)
+        => await Task.FromResult(GetConnectionStringBuilder(initialCatalog, maxPoolSize)).ConfigureAwait(false);
 }

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapper.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapper.cs
@@ -60,7 +60,7 @@ public class SqlConnectionWrapper : IDisposable
         }
         else
         {
-            SqlConnection = _sqlConnectionBuilder.GetSqlConnection(initialCatalog, _sqlServerDataStoreConfiguration.MaxPoolSize);
+            SqlConnection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog, _sqlServerDataStoreConfiguration.MaxPoolSize, cancellationToken).ConfigureAwait(false);
         }
 
         if (_enlistInTransactionIfPresent && _sqlTransactionHandler.SqlTransactionScope != null && _sqlTransactionHandler.SqlTransactionScope.SqlConnection == null)

--- a/src/Microsoft.Health.SqlServer/ISqlConnectionBuilder.cs
+++ b/src/Microsoft.Health.SqlServer/ISqlConnectionBuilder.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
@@ -29,7 +28,6 @@ public interface ISqlConnectionBuilder
     /// <param name="maxPoolSize">Max Sql connection pool size</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>SqlConnection object.</returns>
-    [Obsolete($"Use {nameof(GetSqlConnection)} instead.")]
     Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, int? maxPoolSize = null, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
@@ -38,6 +38,7 @@ public sealed class SchemaUpgradeRunnerTests : SqlIntegrationTestBase, IDisposab
 
         var sqlConnection = Substitute.For<ISqlConnectionBuilder>();
         sqlConnection.GetSqlConnection(Arg.Any<string>(), Arg.Any<int?>()).ReturnsForAnyArgs((x) => GetSqlConnection());
+        sqlConnection.GetSqlConnectionAsync(Arg.Any<string>(), Arg.Any<int?>()).ReturnsForAnyArgs((x) => GetSqlConnection());
         var config = Options.Create(new SqlServerDataStoreConfiguration());
 
         SqlRetryLogicBaseProvider sqlRetryLogicBaseProvider = SqlConfigurableRetryFactory.CreateFixedRetryProvider(new SqlClientRetryOptions().Settings);


### PR DESCRIPTION
Adding back SQL connection async methods to support FHIR operations and avoid context switch between sync and async method calls. 