### PR TITLE
Downgrade IdentityModelTokenPackageVersion from 7.0.0 to  6.32.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <HighEntropyVA>true</HighEntropyVA>
-    <IdentityModelTokenPackageVersion>7.0.2</IdentityModelTokenPackageVersion>
+    <IdentityModelTokenPackageVersion>6.32.3</IdentityModelTokenPackageVersion>
     <IsPackable>true</IsPackable>
     <LangVersion>latest</LangVersion>
     <LtsVersion>net6.0</LtsVersion>


### PR DESCRIPTION
## Description
After consuming the latest package version in health-paas, fhir auth functional tests are failing the CI pipeline
https://microsofthealth.visualstudio.com/Health/_build/results?buildId=335998&view=ms.vss-test-web.build-test-results-tab

Upon final investigation, looks like Microsoft.IdentityModel.S2S.* packages does not have support for the package(Microsoft.IdentityModel.JsonWebTokens) version > 7.0.0 as ran into below error while trying to upgrade locally

Microsoft.Health.Fhir.Cloud.FhirService.Core -> Microsoft.Health.Cloud.SchemaManager.Core.Paas -> Microsoft.SqlServer.SqlManagementObjects 170.21.0 -> Microsoft.Data.SqlClient 5.1.1 -> Microsoft.IdentityModel.JsonWebTokens 7.0.2 -> Microsoft.IdentityModel.Tokens 7.0.2 -> Microsoft.IdentityModel.Logging 7.0.2 -> Microsoft.IdentityModel.Abstractions (>= 7.0.2)
 Microsoft.Health.Cloud.FhirService.UnitTest -> Microsoft.Health.Cloud.FhirService -> Microsoft.Health.Fhir.Cloud.FhirService.Core -> Microsoft.IdentityModel.S2S 3.51.1 -> Microsoft.IdentityModel.Abstractions (>= 6.33.0 && < 7.0.0).

For the time being(to unblock fhir release, I am downgrading the version to good known version and then will create another PR to brin the version back to 7.0.2)

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
