### PR TITLE
Upgrade IdentityModelTokenPackageVersion back to 7.0.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <HighEntropyVA>true</HighEntropyVA>
-    <IdentityModelTokenPackageVersion>6.32.3</IdentityModelTokenPackageVersion>
+    <IdentityModelTokenPackageVersion>7.0.2</IdentityModelTokenPackageVersion>
     <IsPackable>true</IsPackable>
     <LangVersion>latest</LangVersion>
     <LtsVersion>net6.0</LtsVersion>


### PR DESCRIPTION
## Description
This is to revert the downgrade https://github.com/microsoft/healthcare-shared-components/pull/827

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
