### PR TITLE
Add Missing Client Id When Using Retryable Credential

### DIFF
--- a/src/Microsoft.Health.Core/Extensions/IAzureClientBuilderExtensions.cs
+++ b/src/Microsoft.Health.Core/Extensions/IAzureClientBuilderExtensions.cs
@@ -50,20 +50,15 @@ public static class IAzureClientBuilderExtensions
         // TODO: Support other credential types if necessary
         if (string.Equals(credentialType, "managedidentity", StringComparison.OrdinalIgnoreCase))
         {
-            ManagedIdentityCredentialOptions options = new() { ClientId = clientId };
+            TokenCredentialOptions options = new();
             configuration
                 .GetSection(RetrySection)
                 .Bind(options.Retry);
 
-            ManagedIdentityCredential credential = new(options.ClientId, options);
+            ManagedIdentityCredential credential = new(clientId, options);
             return builder.WithCredential(credential);
         }
 
         return builder;
-    }
-
-    private sealed class ManagedIdentityCredentialOptions : TokenCredentialOptions
-    {
-        public string ClientId { get; set; }
     }
 }

--- a/src/Microsoft.Health.Core/Extensions/IAzureClientBuilderExtensions.cs
+++ b/src/Microsoft.Health.Core/Extensions/IAzureClientBuilderExtensions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Health.Core.Extensions;
 /// </summary>
 public static class IAzureClientBuilderExtensions
 {
+    private const string ClientIdKey = "clientId";
     private const string CredentialKey = "credential";
     private const string RetrySection = "credentialRetry";
 
@@ -43,18 +44,18 @@ public static class IAzureClientBuilderExtensions
         EnsureArg.IsNotNull(builder, nameof(builder));
         EnsureArg.IsNotNull(configuration, nameof(configuration));
 
+        string clientId = configuration[ClientIdKey];
         string credentialType = configuration[CredentialKey];
 
         // TODO: Support other credential types if necessary
         if (string.Equals(credentialType, "managedidentity", StringComparison.OrdinalIgnoreCase))
         {
-            ManagedIdentityCredentialOptions options = new();
+            ManagedIdentityCredentialOptions options = new() { ClientId = clientId };
             configuration
                 .GetSection(RetrySection)
                 .Bind(options.Retry);
 
             ManagedIdentityCredential credential = new(options.ClientId, options);
-
             return builder.WithCredential(credential);
         }
 


### PR DESCRIPTION
## Description
Properly propagate `ClientId` from config

## Related issues
N/A

## Testing
New test

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
