### PR TITLE
Ignore Microsoft.IdentityModel to upgrade >=7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       interval: "daily"
       time: "08:00"
       timezone: "America/Los_Angeles"
+    package-regex: "^Microsoft.Identity.*$"
+    ignore:
+      - version: ">= 7.0.0"
     open-pull-requests-limit: 30
 
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,9 @@ updates:
       timezone: "America/Los_Angeles"
     package-regex: "^Microsoft.Identity.*$"
     ignore:
-      - version: ">= 7.0.0"
+      - dependency-name: "IdentityModel"
+        # Ignore all Dependabot updates for version >= 7.0.0
+        versions: ["7.*"]
     open-pull-requests-limit: 30
 
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,8 @@ updates:
       interval: "daily"
       time: "08:00"
       timezone: "America/Los_Angeles"
-    package-regex: "^Microsoft.Identity.*$"
     ignore:
-      - dependency-name: "IdentityModel"
+      - dependency-name: "Microsoft.IdentityModel.*"
         # Ignore all Dependabot updates for version >= 7.0.0
         versions: ["7.*"]
     open-pull-requests-limit: 30


### PR DESCRIPTION
## Description
Ignore Microsoft.IdentityModel to upgrade >=7.x

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
