### PR TITLE
Make constructor of abstract classes protected

### DIFF
--- a/src/Microsoft.Health.Encryption/Customer/Health/AzureStorageHealthCheck.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/AzureStorageHealthCheck.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Encryption.Customer.Health;
 
 public abstract class AzureStorageHealthCheck : StorageHealthCheck
 {
-    internal AzureStorageHealthCheck(ValueCache<CustomerKeyHealth> customerKeyHealthCache, ILogger<StorageHealthCheck> logger)
+    protected AzureStorageHealthCheck(ValueCache<CustomerKeyHealth> customerKeyHealthCache, ILogger<StorageHealthCheck> logger)
         : base(customerKeyHealthCache, logger)
     {
     }

--- a/src/Microsoft.Health.Encryption/Customer/Health/StorageHealthCheck.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/StorageHealthCheck.cs
@@ -18,7 +18,7 @@ public abstract class StorageHealthCheck : IHealthCheck
     private readonly ValueCache<CustomerKeyHealth> _customerKeyHealthCache;
     private readonly ILogger<StorageHealthCheck> _logger;
 
-    internal StorageHealthCheck(ValueCache<CustomerKeyHealth> customerKeyHealthCache, ILogger<StorageHealthCheck> logger)
+    protected StorageHealthCheck(ValueCache<CustomerKeyHealth> customerKeyHealthCache, ILogger<StorageHealthCheck> logger)
     {
         _customerKeyHealthCache = EnsureArg.IsNotNull(customerKeyHealthCache, nameof(customerKeyHealthCache));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));


### PR DESCRIPTION
Change from internal -> protected so they can be accessed by other health checks outside of this project