### PR TITLE
Update sql exception to check number instead of errorcode

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
@@ -52,10 +52,10 @@ public class SqlServerHealthCheck : StorageHealthCheck
             return HealthCheckResult.Healthy("Successfully connected.");
         }
         // Filter on error codes for azure key vault https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors-31000-to-41399?view=sql-server-ver16
-        catch (SqlException e) when (e.ErrorCode is 40981 or 33183 or 33184 or 40925)
+        catch (SqlException e) when (e.Number is 40981 or 33183 or 33184 or 40925)
         {
             // Error 40925: "Can not connect to the database in its current state". This error can be for various DB states (recovering, inacessible) but we assume that our DB will only hit this for Inaccessible state
-            HealthStatusReason reason = e.ErrorCode is 40925
+            HealthStatusReason reason = e.Number is 40925
                 ? HealthStatusReason.DataStoreStateDegraded
                 : HealthStatusReason.CustomerManagedKeyAccessLost;
 


### PR DESCRIPTION
## Description
SqlException.Number will contain the error codes I'm looking for... not the property "ErrorCode" 
https://learn.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlexception.number?view=dotnet-plat-ext-7.0&redirectedfrom=MSDN#System_Data_SqlClient_SqlException_Number
