### PR TITLE
Add positive telemetry for cmk

### DIFF
--- a/src/Microsoft.Health.Encryption/Customer/Health/KeyWrapUnwrapTestProvider.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/KeyWrapUnwrapTestProvider.cs
@@ -54,6 +54,8 @@ internal class KeyWrapUnwrapTestProvider : IKeyTestProvider
 
         try
         {
+            _logger.LogInformation("Trying Get, Wrap, and Unwrap on customer-managed key.");
+
             // Get Key
             await _keyClient.GetKeyAsync(_customerManagedKeyOptions.KeyName, _customerManagedKeyOptions.KeyVersion, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
## Description
Add telemetry when polling the key. We can use this to determine which accounts have CMK enabled.

## Related issues
Addresses #102883

