### PR TITLE
[Health Check] Reason as string

### DIFF
--- a/src/Microsoft.Health.Core.UnitTests/Features/HealthPublisher/HealthCheckMetricPublisherTests.cs
+++ b/src/Microsoft.Health.Core.UnitTests/Features/HealthPublisher/HealthCheckMetricPublisherTests.cs
@@ -135,7 +135,7 @@ public class HealthCheckMetricPublisherTests
                 "some description",
                 TimeSpan.Zero,
                 exception: null,
-                data: new Dictionary<string, object>() { { "Reason", includedReason } }));
+                data: new Dictionary<string, object>() { { "Reason", includedReason.ToString() } }));
         }
 
         return new HealthReport(entries, overallStatus, TimeSpan.Zero);

--- a/src/Microsoft.Health.Encryption/Customer/Health/AzureStorageHealthCheck.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/AzureStorageHealthCheck.cs
@@ -32,7 +32,7 @@ public abstract class AzureStorageHealthCheck : StorageHealthCheck
                 HealthStatus.Degraded,
                 DegradedDescription,
                 rfe,
-                new Dictionary<string, object> { { "Reason", HealthStatusReason.CustomerManagedKeyAccessLost } });
+                new Dictionary<string, object> { { "Reason", HealthStatusReason.CustomerManagedKeyAccessLost.ToString() } });
         }
     }
 

--- a/src/Microsoft.Health.Encryption/Customer/Health/StorageHealthCheck.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/StorageHealthCheck.cs
@@ -36,7 +36,7 @@ public abstract class StorageHealthCheck : IHealthCheck
                 HealthStatus.Degraded,
                 DegradedDescription,
                 cmkStatus.Exception,
-                new Dictionary<string, object> { { "Reason", cmkStatus.Reason } });
+                new Dictionary<string, object> { { "Reason", cmkStatus.Reason.ToString() } });
         }
 
         return await CheckStorageHealthAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
@@ -63,7 +63,7 @@ public class SqlServerHealthCheck : StorageHealthCheck
                 HealthStatus.Degraded,
                 DegradedDescription,
                 e,
-                new Dictionary<string, object> { { "Reason", reason } });
+                new Dictionary<string, object> { { "Reason", reason.ToString() } });
         }
     }
 }


### PR DESCRIPTION
Modifying the Health Check logic to return the failure reason as string, instead of an integer. 

The behavior I want to avoid is the following one, where the reason is returned as a number.

![image](https://github.com/microsoft/healthcare-shared-components/assets/3812247/336872ed-7d30-4fa4-af06-a1dbd8ce1f06)
