### PR TITLE
Create extensions for defining cmk errors

### DIFF
--- a/src/Microsoft.Health.Encryption/Customer/Extensions/AzureStorageErrorExtensions.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Extensions/AzureStorageErrorExtensions.cs
@@ -1,0 +1,18 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Azure;
+
+namespace Microsoft.Health.Encryption.Customer.Extensions;
+
+public static class AzureStorageErrorExtensions
+{
+    private const string KeyVaultEncryptionNotFoundErrorCode = "KeyVaultEncryptionKeyNotFound";
+
+    public static bool IsCMKError(this RequestFailedException rfe)
+    {
+        return rfe?.ErrorCode == KeyVaultEncryptionNotFoundErrorCode;
+    }
+}

--- a/src/Microsoft.Health.Encryption/Customer/Health/AzureStorageHealthCheck.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/AzureStorageHealthCheck.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Core.Features.Health;
 using System.Collections.Generic;
+using Microsoft.Health.Encryption.Customer.Extensions;
 
 namespace Microsoft.Health.Encryption.Customer.Health;
 
@@ -26,7 +27,7 @@ public abstract class AzureStorageHealthCheck : StorageHealthCheck
         {
             return await CheckAzureStorageHealthAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (RequestFailedException rfe) when (rfe.ErrorCode == "KeyVaultEncryptionKeyNotFound")
+        catch (RequestFailedException rfe) when (rfe.IsCMKError())
         {
             return new HealthCheckResult(
                 HealthStatus.Degraded,

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
@@ -89,11 +89,9 @@ public class SchemaJobWorker
             {
                 // this could happen during schema initialization until base schema is not executed so can be ignored
             }
-            // Error: "Can not connect to the database in its current state". This error can be for various DB states (recovering, inacessible) but we assume that our DB will only hit this for Inaccessible state
-            catch (SqlException ex) when (ex.ErrorCode == 40925)
+            catch (SqlException ex) when (ex.IsCMKError())
             {
-                // this can happen when a user has misconfigured CMK for > 30 min, which results in the DB having a status of "Inacessible".
-                _logger.LogInformation(ex, "The SQL database cannot be accessed in its current state.");
+                _logger.LogInformation(ex, "The customer-managed key is misconfigured by the customer.");
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorCodes.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorCodes.cs
@@ -64,4 +64,24 @@ public static class SqlErrorCodes
     /// Cannot insert duplicate key row in object with unique index.
     /// </summary>
     public const short UniqueKeyConstraintViolation = 2601;
+
+    /// <summary>
+    /// Database '%.*ls' is not accessible due to Azure Key Vault critical error.
+    /// </summary>
+    public const int KeyVaultCriticalError = 40981;
+
+    /// <summary>
+    /// The Azure Key Vault client encountered an error with message '%s'.
+    /// </summary>
+    public const int KeyVaultEncounteredError = 33183;
+
+    /// <summary>
+    /// An error occurred while obtaining information for the Azure Key Vault client with message '%s'.
+    /// </summary>
+    public const int KeyVaultErrorObtainingInfo = 33184;
+
+    /// <summary>
+    /// Can not connect to the database in its current state.
+    /// </summary>
+    public const int CannotConnectToDBInCurrentState = 40925;
 }

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorExtensions.cs
@@ -1,0 +1,16 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Data.SqlClient;
+
+namespace Microsoft.Health.SqlServer.Features.Storage;
+
+public static class SqlErrorExtensions
+{
+    public static bool IsCMKError(this SqlException sqlEx)
+    {
+        return sqlEx?.Number is SqlErrorCodes.KeyVaultCriticalError or SqlErrorCodes.KeyVaultEncounteredError or SqlErrorCodes.KeyVaultErrorObtainingInfo or SqlErrorCodes.CannotConnectToDBInCurrentState;
+    }
+}


### PR DESCRIPTION
Today this can be used for health checks & our exception handling middleware. Eventually we will also need to update how all background processes will handle these exceptions (log as level 1 or 2 and not as errors) so these definitions will come in handy