### PR TITLE
Use Direct Dependency for Protobuf to Easily Force Downstream Updates

### DIFF
--- a/src/Microsoft.Health.Operations.Functions.UnitTests/Microsoft.Health.Operations.Functions.UnitTests.csproj
+++ b/src/Microsoft.Health.Operations.Functions.UnitTests/Microsoft.Health.Operations.Functions.UnitTests.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />

--- a/src/Microsoft.Health.Operations.Functions/Microsoft.Health.Operations.Functions.csproj
+++ b/src/Microsoft.Health.Operations.Functions/Microsoft.Health.Operations.Functions.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" />
-    <PackageReference Include="Google.Protobuf" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Core" />

--- a/test/Microsoft.Health.Functions.Examples/Microsoft.Health.Functions.Examples.csproj
+++ b/test/Microsoft.Health.Functions.Examples/Microsoft.Health.Functions.Examples.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" />
-    <PackageReference Include="Google.Protobuf" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Core" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />

--- a/test/Microsoft.Health.Functions.Tests.Integration/Microsoft.Health.Functions.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Functions.Tests.Integration/Microsoft.Health.Functions.Tests.Integration.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" />
-    <PackageReference Include="Google.Protobuf" PrivateAssets="All" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />


### PR DESCRIPTION
## Description
- Use direct dependency to force downstream projects to update their respective versions

## Related issues
N/A

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
