### PR TITLE
Add Login Failed for User to the list of transient SQL errors

### DIFF
--- a/src/Microsoft.Health.SqlServer/Configs/SqlClientRetryOptions.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlClientRetryOptions.cs
@@ -71,6 +71,7 @@ public class SqlClientRetryOptions
 
                     // Additional .NET errors:
                     35,     // A connection was successfully established with the server, but then an error occurred during the login process. (provider: TCP Provider, error: 35 - An internal exception was caught)
+                    18456,  // Login failed for user '<token-identified principal>'.
 
                     // Additional Fhir Server errors:
                     8623    // The query processor ran out of internal resources and could not produce a query plan.


### PR DESCRIPTION
## Description
We are seeing frequent transient errors "Login failed for user '<token-identified principal>'.", some of which make it to the customer and result in a failed request. The dependency calls fail after ~100 ms, so it is clear there is no retry being applied here.

We had added retry logic here a while ago - https://github.com/microsoft/healthcare-shared-components/pull/397
But looks like since we switched to use `SqlRetryLogicProvider`, we don't have retries applying to our connection exceptions. 

Looking at `SqlRetryLogicProvider` https://github.com/dotnet/SqlClient/blob/420323799b60c3d7b058fcf944eb46d06fcf9a43/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/Common/SqlRetryLogicProvider.cs#L159
It will only retry if the exception is in the list of known transient exceptions. So adding this exception to the list of transient exceptions so we can retry in this case

## Related issues
Addresses #112867

## Testing
N/A

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
