### PR TITLE
Check for null lockHandle before using

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -96,14 +96,15 @@ public sealed class SchemaInitializer : IHostedService
             try
             {
                 IDistributedSynchronizationHandle lockHandle = await sqlLock.TryAcquireAsync(TimeSpan.FromSeconds(30), cancellationToken).ConfigureAwait(false);
+
+                if (lockHandle == null)
+                {
+                    _logger.LogInformation("Schema upgrade lock was not acquired, skipping");
+                    return;
+                }
+
                 await using (lockHandle.ConfigureAwait(false))
                 {
-                    if (lockHandle == null)
-                    {
-                        _logger.LogInformation("Schema upgrade lock was not acquired, skipping");
-                        return;
-                    }
-
                     _logger.LogInformation("Schema upgrade lock acquired");
 
                     // Recheck the version with lock


### PR DESCRIPTION
## Description
Update the check for the lockHandle being NULL before the using in SchemaInitializer.  If the lockHandle is null, and we pass in a NULL value to the using () clause, this can result in a Null Ref exception when .Net disposes of the resources from the using.

## Related issues
Addresses [issue AB#113443].

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
