### PR TITLE
Add HealthStatusReason for connected store

### DIFF
--- a/src/Microsoft.Health.Core.UnitTests/Features/HealthPublisher/HealthCheckMetricPublisherTests.cs
+++ b/src/Microsoft.Health.Core.UnitTests/Features/HealthPublisher/HealthCheckMetricPublisherTests.cs
@@ -60,12 +60,29 @@ public class HealthCheckMetricPublisherTests
             HealthStatus.Degraded,
             new HealthStatusReason[] {
                 HealthStatusReason.ServiceDegraded,
+                HealthStatusReason.ConnectedStoreDegraded,
                 HealthStatusReason.CustomerManagedKeyAccessLost,
                 HealthStatusReason.None });
 
         _healthCheckMetricPublisher.PublishAsync(report, CancellationToken.None);
 
         _resourceHealthSignalProvider.Received(1).EmitHealthMetric(HealthStatusReason.CustomerManagedKeyAccessLost, _resourceHealthDimensions);
+    }
+
+    [Fact]
+    public void GivenReportWithConnectedStoreDegraded_PublishAsync_ConnectedStoreDegradedPublished()
+    {
+        HealthReport report = CreateDummyHealthReport(
+            HealthStatus.Degraded,
+            new HealthStatusReason[] {
+                HealthStatusReason.ServiceDegraded,
+                HealthStatusReason.DataStoreStateDegraded,
+                HealthStatusReason.ConnectedStoreDegraded,
+                HealthStatusReason.None });
+
+        _healthCheckMetricPublisher.PublishAsync(report, CancellationToken.None);
+
+        _resourceHealthSignalProvider.Received(1).EmitHealthMetric(HealthStatusReason.ConnectedStoreDegraded, _resourceHealthDimensions);
     }
 
     [Fact]

--- a/src/Microsoft.Health.Core/Features/Health/HealthStatusReason.cs
+++ b/src/Microsoft.Health.Core/Features/Health/HealthStatusReason.cs
@@ -21,7 +21,7 @@ public enum HealthStatusReason
     /// </summary>
     ServiceDegraded,
     DataStoreStateDegraded,
-    ExternalStoreDegraded,
+    ConnectedStoreDegraded,
     CustomerManagedKeyAccessLost,
 
     /// <summary>

--- a/src/Microsoft.Health.Core/Features/Health/HealthStatusReason.cs
+++ b/src/Microsoft.Health.Core/Features/Health/HealthStatusReason.cs
@@ -21,6 +21,7 @@ public enum HealthStatusReason
     /// </summary>
     ServiceDegraded,
     DataStoreStateDegraded,
+    ExternalStoreDegraded,
     CustomerManagedKeyAccessLost,
 
     /// <summary>


### PR DESCRIPTION
## Description
Add HealthStatusReason for connected store. Using name "connected" here to match what we will tell the customer, however this status is NOT customer-facing, its for internal use only.

The order for severity determines how we evaluate status of the service - we will always pick the "highest" status to log out of everything being returned by the health check. Let's say the customer misconfigured their connected store, which would make the DCM health check return "ConnectedStoreDegraded", but SQL is also having an outage at the same time and the SQL health check returns "ServiceUnavailable". We would log a health metric of ServiceUnavailable for this instance of the service.

## Related issues
Addresses #106077

## Testing
Added unit test for new status

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch
