### PR TITLE
Update schema validation to log as information

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
@@ -120,7 +120,7 @@ public class SqlSchemaManager : ISchemaManager
                     retryCount: RetryAttempts,
                     sleepDurationProvider: retryCount => TimeSpan.FromSeconds(60),
                     onRetry: (exception, sleepDuration, retryCount, context) =>
-                        _logger.LogWarning(exception, "Attempt {Attempt} of {MaxAttempts} of validating version compatiblity", retryCount, RetryAttempts))
+                        _logger.LogInformation(exception, "Attempt {Attempt} of {MaxAttempts} of validating version compatiblity", retryCount, RetryAttempts))
                 .ExecuteAsync(t => ValidateVersionCompatibility(availableVersions[^1].Id, t), token)
                 .ConfigureAwait(false);
 


### PR DESCRIPTION
## Description
We see this warning every time we deploy due to the TTL of the old pods still showing schema information, and therefore showing as incompatible with the new version.
Updating this to be information so it is not treated as an issue.

## Related issues
Addresses 117262

## Testing
N/A

