### PR TITLE
Address Source Name Error

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -4,13 +4,13 @@
     <!-- When <clear /> is present, previously defined sources are ignored -->
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="Microsoft Health OSS" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirServer/_packaging/Public/nuget/v3/index.json" />
+    <add key="msft-health-oss" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirServer/_packaging/Public/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>
-    <packageSource key="Microsoft Health OSS">
+    <packageSource key="msft-health-oss">
       <package pattern="Microsoft.Health.*" />
       <package pattern="Mseng.Sql.Dac" />
     </packageSource>


### PR DESCRIPTION
## Description
The `dotnet-auth` tool used to authenticate the NuGet feed in the CI pipeline does not like spaces in the source name. See [here](https://github.com/microsoft/healthcare-shared-components/actions/runs/8289558439/job/22686185255).