### PR TITLE
Fixing InvalidOperationException from SchemaInitializer.

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -169,7 +169,7 @@ public sealed class SchemaInitializer : IHostedService
 
         // Ensure to publish the Schema notifications even when schema is up-to date and Schema Initializer is called again (like restarting FHIR server will call this again)
         // There is a dependency on this notification in FHIR server to enable some background jobs
-        if (!schemaUpgradedNotificationSent)
+        if (!schemaUpgradedNotificationSent && _schemaInformation.Current.HasValue)
         {
             await _mediator.NotifySchemaUpgradedAsync((int)_schemaInformation.Current, false).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Description
Fixing the exception below that occurs on SchemaInitalizer.InitializeAsync.

System.InvalidOperationException: Nullable object must have a value.

## Related issues
Addresses [issue #118108].

[Bug 118108](https://microsofthealth.visualstudio.com/Health/_workitems/edit/118108): IHost.StartAsync fails for SchemaManagerService due to exceptions from SchemaInitializer.

## Testing
Tested in the Fhir validation pipeline for health-paas.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
