### PR TITLE
Add .netstandard2.0 to Microsoft.Health.MeasurementUtility target frameworks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PreviousVersion>net6.0</PreviousVersion>
+    <LegacyVersion>netstandard2.0</LegacyVersion>
     <Product>Microsoft Health</Product>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RootDirectory>$(MSBuildThisFileDirectory)</RootDirectory>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PreviousVersion>net6.0</PreviousVersion>
-    <LegacyVersion>netstandard2.0</LegacyVersion>
     <Product>Microsoft Health</Product>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RootDirectory>$(MSBuildThisFileDirectory)</RootDirectory>

--- a/src/Microsoft.Health.MeasurementUtility/Microsoft.Health.MeasurementUtility.csproj
+++ b/src/Microsoft.Health.MeasurementUtility/Microsoft.Health.MeasurementUtility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Common utilities used by Microsoft Health.</Description>
-    <TargetFrameworks>$(SupportedFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(LegacyVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.MeasurementUtility/Microsoft.Health.MeasurementUtility.csproj
+++ b/src/Microsoft.Health.MeasurementUtility/Microsoft.Health.MeasurementUtility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Common utilities used by Microsoft Health.</Description>
-    <TargetFrameworks>$(LegacyVersion);$(SupportedFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;$(SupportedFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.MeasurementUtility/Microsoft.Health.MeasurementUtility.csproj
+++ b/src/Microsoft.Health.MeasurementUtility/Microsoft.Health.MeasurementUtility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Common utilities used by Microsoft Health.</Description>
-    <TargetFrameworks>$(LegacyVersion)</TargetFrameworks>
+    <TargetFrameworks>$(LegacyVersion);$(SupportedFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Added .netstandard2.0 to Microsoft.Health.MeasurementUtility.csproj target frameworks for use in Microsoft.Health.Events project in MedTech repo.

## Testing
Referenced generated dll for netstandard2.0 on my local machine in MedTech projects to verify leveraging TrackDuration(). Also, tested with unit test project.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Small backwards-compatible change. Not incrementing semver manually.
