### PR TITLE
Add Missing CI Permission

### DIFF
--- a/.github/workflows/packages-ci.yml
+++ b/.github/workflows/packages-ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   validate:


### PR DESCRIPTION
## Description
Add missing CI workflow permission for OIDC usage. See here: https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended
