### PR TITLE
Resolve Workflow Warnings

### DIFF
--- a/.github/actions/dotnet-publish/action.yml
+++ b/.github/actions/dotnet-publish/action.yml
@@ -15,12 +15,6 @@ inputs:
   packageVersion:
     description: The NuGet package version
     required: true
-  servicePrincipalClientId:
-    description: The client ID for the service principal used to push artifacts.
-    required: true
-  servicePrincipalTenantId:
-    description: The tenant ID for the service principal used to push artifacts.
-    required: true
   symbolsAccountName:
     default: microsofthealthoss
     description: The Azure DevOps account name containing the symbol server
@@ -45,13 +39,6 @@ runs:
       name: packages
       path: ${{ inputs.packageFolder }}
 
-  - name: az login
-    uses: azure/login@v2
-    with:
-      allow-no-subscriptions: true
-      client-id: ${{ inputs.servicePrincipalClientId }}
-      tenant-id: ${{ inputs.servicePrincipalTenantId }}
-  
   # GUID below is for Azure DevOps: https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/manage-personal-access-tokens-via-api?view=azure-devops
   - name: Fetch Token
     id: az-account

--- a/.github/workflows/packages-ci.yml
+++ b/.github/workflows/packages-ci.yml
@@ -41,15 +41,19 @@ jobs:
         fileVersion: ${{ steps.version.outputs.fileVersion }}
         informationalVersion: ${{ steps.version.outputs.informationalVersion }}
 
+    - name: Login
+      uses: azure/login@v2
+      with:
+        allow-no-subscriptions: true
+        client-id: ${{ secrets.CLIENT_ID }}
+        tenant-id: ${{ secrets.TENANT_ID }}
+
     - name: Publish
       uses: ./.github/actions/dotnet-publish
       with:
         buildConfiguration: Release
         packageFolder: ${{ github.workspace }}/packages
-        packagePat: ${{ secrets.PACKAGING_TOKEN }}
         packageVersion: ${{ steps.version.outputs.nuGetVersion }}
-        servicePrincipalClientId: ${{ secrets.CLIENT_ID }}
-        servicePrincipalTenantId: ${{ secrets.TENANT_ID }}
 
     - name: Release
       uses: ./.github/actions/github-release


### PR DESCRIPTION
## Description
This PR attempts to remove some workflow warnings by:
1. Removing the unused `packagePat` argument
2. Moving `azure/login` outside of a local composite action
