### PR TITLE
Normalize usage of DateTimeOffset for Operations

### DIFF
--- a/src/Microsoft.Health.Operations.Functions.Worker/DurableTask/NullOrchestrationCheckpoint.cs
+++ b/src/Microsoft.Health.Operations.Functions.Worker/DurableTask/NullOrchestrationCheckpoint.cs
@@ -20,8 +20,6 @@ public sealed class NullOrchestrationCheckpoint : IOrchestrationCheckpoint
     /// <value>The singleton instance.</value>
     public static NullOrchestrationCheckpoint Value { get; } = new NullOrchestrationCheckpoint();
 
-    DateTime? IOperationCheckpoint.CreatedTime => null;
-
     /// <inheritdoc cref="IOperationCheckpoint.CreatedAtTime" />
     public DateTimeOffset? CreatedAtTime => null;
 

--- a/src/Microsoft.Health.Operations.Functions/DurableTask/NullOrchestrationCheckpoint.cs
+++ b/src/Microsoft.Health.Operations.Functions/DurableTask/NullOrchestrationCheckpoint.cs
@@ -20,8 +20,6 @@ public sealed class NullOrchestrationCheckpoint : IOrchestrationCheckpoint
     /// <value>The singleton instance.</value>
     public static NullOrchestrationCheckpoint Value { get; } = new NullOrchestrationCheckpoint();
 
-    DateTime? IOperationCheckpoint.CreatedTime => null;
-
     /// <inheritdoc cref="IOperationCheckpoint.CreatedAtTime" />
     public DateTimeOffset? CreatedAtTime => null;
 

--- a/src/Microsoft.Health.Operations.UnitTests/OperationStateTests.cs
+++ b/src/Microsoft.Health.Operations.UnitTests/OperationStateTests.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Health.Operations.Serialization;
 using Xunit;
 
 namespace Microsoft.Health.Operations.UnitTests;
@@ -63,6 +65,7 @@ public class OperationStateTests
 
     private sealed class LegacyOperationState
     {
+        [JsonConverter(typeof(OperationIdJsonConverter))]
         public Guid OperationId { get; set; }
 
         public int Type { get; set; }

--- a/src/Microsoft.Health.Operations.UnitTests/OperationStateTests.cs
+++ b/src/Microsoft.Health.Operations.UnitTests/OperationStateTests.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Health.Operations.UnitTests;
 
 public class OperationStateTests
 {
-    public static IEnumerable<object[]> SerializationTestArguments => new object[][]
-    {
-        new object[] { typeof(OperationState<int>), new OperationState<int> { OperationId = Guid.NewGuid() } },
-        new object[] { typeof(OperationState<int, string>), new OperationState<int, string> { OperationId = Guid.NewGuid(), Results = "Hello World" } }
-    };
+    public static IEnumerable<object[]> SerializationTestArguments =>
+    [
+        [typeof(OperationState<int>), new OperationState<int> { OperationId = Guid.NewGuid() }],
+        [typeof(OperationState<int, string>), new OperationState<int, string> { OperationId = Guid.NewGuid(), Results = "Hello World" }]
+    ];
 
     [Theory]
     [MemberData(nameof(SerializationTestArguments))]
@@ -29,5 +29,73 @@ public class OperationStateTests
 
         Assert.True(element.TryGetProperty(nameof(IOperationState<int>.OperationId), out JsonElement property));
         Assert.Equal(state.OperationId.ToString(OperationId.FormatSpecifier), property.GetString());
+    }
+
+    [Fact]
+    public void GivenDateTimeRepresentations_WhenSerializing_ThenBothAreEquivalent()
+    {
+        LegacyOperationState before = new()
+        {
+            CreatedTime = DateTime.UtcNow.AddMinutes(-5),
+            LastUpdatedTime = DateTime.UtcNow,
+            OperationId = Guid.NewGuid(),
+            PercentComplete = 50,
+            Resources = [new Uri("https://example.com")],
+            Results = "Hello World",
+            Status = OperationStatus.Running,
+            Type = 42,
+        };
+
+        IOperationState<int> after = new LatestOperationState()
+        {
+            CreatedTime = before.CreatedTime,
+            LastUpdatedTime = before.LastUpdatedTime,
+            OperationId = before.OperationId,
+            PercentComplete = before.PercentComplete,
+            Resources = before.Resources,
+            Results = before.Results,
+            Status = before.Status,
+            Type = before.Type,
+        };
+
+        Assert.Equal(JsonSerializer.Serialize(before), JsonSerializer.Serialize(after));
+    }
+
+    private sealed class LegacyOperationState
+    {
+        public Guid OperationId { get; set; }
+
+        public int Type { get; set; }
+
+        public DateTime CreatedTime { get; set; }
+
+        public DateTime LastUpdatedTime { get; set; }
+
+        public OperationStatus Status { get; set; }
+
+        public int? PercentComplete { get; set; }
+
+        public IReadOnlyCollection<Uri>? Resources { get; set; }
+
+        public object? Results { get; set; }
+    }
+
+    private sealed class LatestOperationState : IOperationState<int>
+    {
+        public Guid OperationId { get; set; }
+
+        public int Type { get; set; }
+
+        public DateTimeOffset CreatedTime { get; set; }
+
+        public DateTimeOffset LastUpdatedTime { get; set; }
+
+        public OperationStatus Status { get; set; }
+
+        public int? PercentComplete { get; set; }
+
+        public IReadOnlyCollection<Uri>? Resources { get; set; }
+
+        public object? Results { get; set; }
     }
 }

--- a/src/Microsoft.Health.Operations.UnitTests/OperationStateTests.cs
+++ b/src/Microsoft.Health.Operations.UnitTests/OperationStateTests.cs
@@ -36,10 +36,10 @@ public class OperationStateTests
     [Fact]
     public void GivenDateTimeRepresentations_WhenSerializing_ThenBothAreEquivalent()
     {
-        LegacyOperationState before = new()
+        IOperationState<int> after = new LatestOperationState()
         {
-            CreatedTime = DateTime.UtcNow.AddMinutes(-5),
-            LastUpdatedTime = DateTime.UtcNow,
+            CreatedTime = DateTimeOffset.UtcNow.AddMinutes(-5),
+            LastUpdatedTime = DateTimeOffset.UtcNow,
             OperationId = Guid.NewGuid(),
             PercentComplete = 50,
             Resources = [new Uri("https://example.com")],
@@ -48,16 +48,16 @@ public class OperationStateTests
             Type = 42,
         };
 
-        IOperationState<int> after = new LatestOperationState()
+        LegacyOperationState before = new()
         {
-            CreatedTime = before.CreatedTime,
-            LastUpdatedTime = before.LastUpdatedTime,
-            OperationId = before.OperationId,
-            PercentComplete = before.PercentComplete,
-            Resources = before.Resources,
-            Results = before.Results,
-            Status = before.Status,
-            Type = before.Type,
+            CreatedTime = after.CreatedTime.UtcDateTime,
+            LastUpdatedTime = after.LastUpdatedTime.UtcDateTime,
+            OperationId = after.OperationId,
+            PercentComplete = after.PercentComplete,
+            Resources = after.Resources,
+            Results = after.Results,
+            Status = after.Status,
+            Type = after.Type,
         };
 
         Assert.Equal(JsonSerializer.Serialize(before), JsonSerializer.Serialize(after));

--- a/src/Microsoft.Health.Operations.UnitTests/Serialization/OperationIdJsonConverterTests.cs
+++ b/src/Microsoft.Health.Operations.UnitTests/Serialization/OperationIdJsonConverterTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -9,13 +9,12 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Health.Operations.Serialization;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Microsoft.Health.Operations.UnitTests.Serialization;
 
 public class OperationIdJsonConverterTests
 {
-    private static readonly JsonSerializerOptions DefaultOptions = new JsonSerializerOptions();
+    private static readonly JsonSerializerOptions DefaultOptions = new();
 
     [Theory]
     [InlineData("null")]
@@ -27,30 +26,19 @@ public class OperationIdJsonConverterTests
     [InlineData("\"0123456789abcdef0123456789abcde\"")]
     public void GivenInvalidToken_WhenReadingJson_ThenThrowJsonReaderException(string json)
     {
-        var jsonReader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
-
-        Assert.True(jsonReader.Read());
-        try
+        Assert.Throws<JsonException>(() =>
         {
-            // Note: the by-ref parameter prevents the test from leveraging Assert.Throws
+            Utf8JsonReader jsonReader = new(Encoding.UTF8.GetBytes(json));
+            Assert.True(jsonReader.Read());
             new OperationIdJsonConverter().Read(ref jsonReader, typeof(Guid), DefaultOptions);
-            throw ThrowsException.ForNoException(typeof(JsonException));
-        }
-        catch (Exception e)
-        {
-            if (e.GetType() != typeof(JsonException))
-            {
-                // TODO: Update with new method on next version of xUnit - https://github.com/xunit/xunit/issues/2741
-                throw ThrowsException.ForNoException(typeof(JsonException));
-            }
-        }
+        });
     }
 
     [Fact]
     public void GivenValidToken_WhenReadingJson_ThenReturnOperationId()
     {
         Guid expected = Guid.NewGuid();
-        var jsonReader = new Utf8JsonReader(Encoding.UTF8.GetBytes("\"" + expected.ToString(OperationId.FormatSpecifier) + "\""));
+        Utf8JsonReader jsonReader = new(Encoding.UTF8.GetBytes("\"" + expected.ToString(OperationId.FormatSpecifier) + "\""));
 
         Assert.True(jsonReader.Read());
         Guid actual = new OperationIdJsonConverter().Read(ref jsonReader, typeof(Guid), DefaultOptions);
@@ -61,14 +49,14 @@ public class OperationIdJsonConverterTests
     public void GivenGuid_WhenWritingJson_ThenWriteStringToken()
     {
         Guid expected = Guid.NewGuid();
-        using var buffer = new MemoryStream();
-        using var jsonWriter = new Utf8JsonWriter(buffer);
+        using MemoryStream buffer = new();
+        using Utf8JsonWriter jsonWriter = new(buffer);
 
         new OperationIdJsonConverter().Write(jsonWriter, expected, DefaultOptions);
         jsonWriter.Flush();
 
         buffer.Seek(0, SeekOrigin.Begin);
-        var jsonReader = new Utf8JsonReader(buffer.ToArray());
+        Utf8JsonReader jsonReader = new(buffer.ToArray());
 
         Assert.Equal(expected.ToString(OperationId.FormatSpecifier), JsonSerializer.Deserialize<string>(ref jsonReader, DefaultOptions));
     }

--- a/src/Microsoft.Health.Operations.UnitTests/Serialization/OperationIdJsonConverterTests.cs
+++ b/src/Microsoft.Health.Operations.UnitTests/Serialization/OperationIdJsonConverterTests.cs
@@ -29,7 +29,15 @@ public class OperationIdJsonConverterTests
         Assert.Throws<JsonException>(() =>
         {
             Utf8JsonReader jsonReader = new(Encoding.UTF8.GetBytes(json));
-            Assert.True(jsonReader.Read());
+            try
+            {
+                Assert.True(jsonReader.Read());
+            }
+            catch (JsonException)
+            {
+                Assert.Fail();
+            }
+
             new OperationIdJsonConverter().Read(ref jsonReader, typeof(Guid), DefaultOptions);
         });
     }

--- a/src/Microsoft.Health.Operations/IOperationCheckpoint.cs
+++ b/src/Microsoft.Health.Operations/IOperationCheckpoint.cs
@@ -17,16 +17,6 @@ public interface IOperationCheckpoint
     /// Gets the optional date and time the operation was started.
     /// </summary>
     /// <value>
-    /// The <see cref="DateTime"/> when the operation was started, or <see langword="null"/> if the date and
-    /// time may be found outside of the checkpoint.
-    /// </value>
-    [Obsolete("Please use CreatedAtTime as it always include time zone information.")]
-    DateTime? CreatedTime { get; }
-
-    /// <summary>
-    /// Gets the optional date and time the operation was started.
-    /// </summary>
-    /// <value>
     /// The <see cref="DateTimeOffset"/> when the operation was started, or <see langword="null"/> if the date and
     /// time may be found outside of the checkpoint.
     /// </value>

--- a/src/Microsoft.Health.Operations/IOperationState.cs
+++ b/src/Microsoft.Health.Operations/IOperationState.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Microsoft.Health.Operations.Serialization;
 
 namespace Microsoft.Health.Operations;
 
@@ -18,6 +20,7 @@ public interface IOperationState<T>
     /// Gets the operation ID.
     /// </summary>
     /// <value>The unique ID that denotes a particular operation.</value>
+    [JsonConverter(typeof(OperationIdJsonConverter))]
     Guid OperationId { get; }
 
     /// <summary>
@@ -29,14 +32,16 @@ public interface IOperationState<T>
     /// <summary>
     /// Gets the date and time the operation was started.
     /// </summary>
-    /// <value>The <see cref="DateTime"/> when the operation was started.</value>
-    DateTime CreatedTime { get; }
+    /// <value>The <see cref="DateTimeOffset"/> when the operation was started.</value>
+    [JsonConverter(typeof(UtcCompatibilityJsonConverter))]
+    DateTimeOffset CreatedTime { get; }
 
     /// <summary>
     /// Gets the last date and time the state was updated.
     /// </summary>
-    /// <value>The last <see cref="DateTime"/> when the operation state was updated.</value>
-    DateTime LastUpdatedTime { get; }
+    /// <value>The last <see cref="DateTimeOffset"/> when the operation state was updated.</value>
+    [JsonConverter(typeof(UtcCompatibilityJsonConverter))]
+    DateTimeOffset LastUpdatedTime { get; }
 
     /// <summary>
     /// Gets the execution status of the operation.

--- a/src/Microsoft.Health.Operations/OperationId.cs
+++ b/src/Microsoft.Health.Operations/OperationId.cs
@@ -27,10 +27,26 @@ public static class OperationId
     /// <summary>
     /// Parses the given value as an operation ID.
     /// </summary>
-    /// <param name="value">The operation ID to parse.</param>
+    /// <param name="input">The operation ID to parse.</param>
     /// <returns>The parsed operation ID.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="input"/> is <see langword="null"/>.</exception>
     /// <exception cref="FormatException">The value cannot be parsed as an operation ID.</exception>
-    public static Guid ParseExact(string value)
-        => Guid.ParseExact(value, FormatSpecifier);
+    public static Guid ParseExact(string input)
+        => Guid.ParseExact(input, FormatSpecifier);
+
+    /// <summary>
+    /// Attempts to parse the given value as an operation ID.
+    /// </summary>
+    /// <param name="input">The operation ID to parse.</param>
+    /// <param name="result">
+    /// When this method returns, contains the parsed value. If the method returns <see langword="true"/>,
+    /// <paramref name="result"/> contains a valid operation ID. If the method returns <see langword="false"/>,
+    /// <paramref name="result"/> equals <see cref="Guid.Empty"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the <paramref name="input"/> represented an operation ID;
+    /// otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool TryParseExact(string input, out Guid result)
+        => Guid.TryParseExact(input, FormatSpecifier, out result);
 }

--- a/src/Microsoft.Health.Operations/OperationState.cs
+++ b/src/Microsoft.Health.Operations/OperationState.cs
@@ -24,10 +24,12 @@ public sealed class OperationState<T> : IOperationState<T>
     public T? Type { get; init; }
 
     /// <inheritdoc cref="IOperationState{T}.CreatedTime"/>
-    public DateTime CreatedTime { get; init; }
+    [JsonConverter(typeof(UtcCompatibilityJsonConverter))]
+    public DateTimeOffset CreatedTime { get; init; }
 
     /// <inheritdoc cref="IOperationState{T}.LastUpdatedTime"/>
-    public DateTime LastUpdatedTime { get; init; }
+    [JsonConverter(typeof(UtcCompatibilityJsonConverter))]
+    public DateTimeOffset LastUpdatedTime { get; init; }
 
     /// <inheritdoc cref="IOperationState{T}.Status"/>
     public OperationStatus Status { get; init; }
@@ -57,10 +59,10 @@ public sealed class OperationState<TType, TResults> : IOperationState<TType>
     public TType? Type { get; init; }
 
     /// <inheritdoc cref="IOperationState{T}.CreatedTime"/>
-    public DateTime CreatedTime { get; init; }
+    public DateTimeOffset CreatedTime { get; init; }
 
     /// <inheritdoc cref="IOperationState{T}.LastUpdatedTime"/>
-    public DateTime LastUpdatedTime { get; init; }
+    public DateTimeOffset LastUpdatedTime { get; init; }
 
     /// <inheritdoc cref="IOperationState{T}.Status"/>
     public OperationStatus Status { get; init; }

--- a/src/Microsoft.Health.Operations/Serialization/UtcCompatibilityJsonConverter.cs
+++ b/src/Microsoft.Health.Operations/Serialization/UtcCompatibilityJsonConverter.cs
@@ -1,0 +1,52 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EnsureThat;
+
+namespace Microsoft.Health.Operations.Serialization;
+
+/// <summary>
+/// Represents a <see cref="JsonConverter{T}"/> for <see cref="DateTimeOffset"/>
+/// that ensures their JSON representation is equivalent to that of <see cref="DateTime"/>
+/// for UTC values.
+/// </summary>
+public sealed class UtcCompatibilityJsonConverter : JsonConverter<DateTimeOffset>
+{
+    /// <summary>
+    /// Reads the <see cref="DateTimeOffset"/> from its JSON representation.
+    /// </summary>
+    /// <param name="reader">The <see cref="Utf8JsonReader"/> whose current token is of type <see cref="JsonTokenType.String"/>.</param>
+    /// <param name="typeToConvert">The type of convert. Unused by the <see cref="UtcCompatibilityJsonConverter"/>.</param>
+    /// <param name="options">A collection of options that specify how serialization should be performed.</param>
+    /// <returns>The <see cref="DateTimeOffset"/> represented by the JSON string.</returns>
+    /// <exception cref="JsonException">The current token cannot be read as a <see cref="DateTimeOffset"/>.</exception>
+    public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType is JsonTokenType.String && DateTimeOffset.TryParse(reader.GetString(), out DateTimeOffset value)
+            ? value
+            : throw new JsonException();
+    }
+
+    /// <summary>
+    /// Writes the specified <paramref name="value"/> as a JSON string that is equivalent to <see cref="DateTime"/>
+    /// if the <see cref="DateTimeOffset"/> is in UTC.
+    /// </summary>
+    /// <param name="writer">The <see cref="Utf8JsonWriter"/> with which to write.</param>
+    /// <param name="value">The <see cref="DateTimeOffset"/>.</param>
+    /// <param name="options">A collection of options that specify how serialization should be performed.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="writer"/> is <see langword="null"/>.</exception>
+    public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
+    {
+        EnsureArg.IsNotNull(writer, nameof(writer));
+
+        if (value.Offset == TimeSpan.Zero)
+            writer.WriteStringValue(value.UtcDateTime.ToString("O"));
+        else
+            writer.WriteStringValue(value.ToString("O"));
+    }
+}

--- a/src/Microsoft.Health.Operations/Serialization/UtcCompatibilityJsonConverter.cs
+++ b/src/Microsoft.Health.Operations/Serialization/UtcCompatibilityJsonConverter.cs
@@ -26,11 +26,7 @@ public sealed class UtcCompatibilityJsonConverter : JsonConverter<DateTimeOffset
     /// <returns>The <see cref="DateTimeOffset"/> represented by the JSON string.</returns>
     /// <exception cref="JsonException">The current token cannot be read as a <see cref="DateTimeOffset"/>.</exception>
     public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-    {
-        return reader.TokenType is JsonTokenType.String && DateTimeOffset.TryParse(reader.GetString(), out DateTimeOffset value)
-            ? value
-            : throw new JsonException();
-    }
+        => JsonSerializer.Deserialize<DateTimeOffset>(ref reader);
 
     /// <summary>
     /// Writes the specified <paramref name="value"/> as a JSON string that is equivalent to <see cref="DateTime"/>
@@ -45,8 +41,8 @@ public sealed class UtcCompatibilityJsonConverter : JsonConverter<DateTimeOffset
         EnsureArg.IsNotNull(writer, nameof(writer));
 
         if (value.Offset == TimeSpan.Zero)
-            writer.WriteStringValue(value.UtcDateTime.ToString("O"));
+            JsonSerializer.Serialize(writer, value.UtcDateTime);
         else
-            writer.WriteStringValue(value.ToString("O"));
+            JsonSerializer.Serialize(writer, value);
     }
 }

--- a/test/Microsoft.Health.Functions.Examples/Sorting/SortingCheckpoint.cs
+++ b/test/Microsoft.Health.Functions.Examples/Sorting/SortingCheckpoint.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using EnsureThat;
-using Microsoft.Health.Operations;
 using Microsoft.Health.Operations.Functions.DurableTask;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -16,8 +15,6 @@ namespace Microsoft.Health.Functions.Examples.Sorting;
 
 internal sealed class SortingCheckpoint(int[] values, int sortedLength = 1, DateTimeOffset? createdAtTime = null) : SortingInput(values), IOrchestrationCheckpoint
 {
-    DateTime? IOperationCheckpoint.CreatedTime => CreatedAtTime?.DateTime;
-
     public DateTimeOffset? CreatedAtTime { get; } = createdAtTime;
 
     public int? PercentComplete => Values.Length == 0 ? 100 : (int)((double)SortedLength / Values.Length * 100);

--- a/test/Microsoft.Health.Functions.Worker.Examples/Sorting/SortingCheckpoint.cs
+++ b/test/Microsoft.Health.Functions.Worker.Examples/Sorting/SortingCheckpoint.cs
@@ -7,15 +7,12 @@ using System;
 using System.Collections.Generic;
 using EnsureThat;
 using Microsoft.DurableTask;
-using Microsoft.Health.Operations;
 using Microsoft.Health.Operations.Functions.Worker.DurableTask;
 
 namespace Microsoft.Health.Functions.Worker.Examples.Sorting;
 
 public sealed class SortingCheckpoint(int[] values, int sortedLength = 1, DateTimeOffset? createdAtTime = null) : SortingInput(values), IOrchestrationCheckpoint
 {
-    DateTime? IOperationCheckpoint.CreatedTime => CreatedAtTime?.DateTime;
-
     public DateTimeOffset? CreatedAtTime { get; } = createdAtTime;
 
     public int? PercentComplete => Values.Length == 0 ? 100 : (int)((double)SortedLength / Values.Length * 100);


### PR DESCRIPTION
- Use `DateTimeOffset` over `DateTime` to align with new APIs
- Remove deprecated property
- Ensure JSON backwards compatibility