### PR TITLE
Add Missing JsonConverter to Operation State with Result

### DIFF
--- a/src/Microsoft.Health.Operations/OperationState.cs
+++ b/src/Microsoft.Health.Operations/OperationState.cs
@@ -59,9 +59,11 @@ public sealed class OperationState<TType, TResults> : IOperationState<TType>
     public TType? Type { get; init; }
 
     /// <inheritdoc cref="IOperationState{T}.CreatedTime"/>
+    [JsonConverter(typeof(UtcCompatibilityJsonConverter))]
     public DateTimeOffset CreatedTime { get; init; }
 
     /// <inheritdoc cref="IOperationState{T}.LastUpdatedTime"/>
+    [JsonConverter(typeof(UtcCompatibilityJsonConverter))]
     public DateTimeOffset LastUpdatedTime { get; init; }
 
     /// <inheritdoc cref="IOperationState{T}.Status"/>


### PR DESCRIPTION
Forgot to add `JsonConverter` to `OperationState<TType, TResult>`