### PR TITLE
Add additional error for cmk issues; add tests

### DIFF
--- a/src/Microsoft.Health.Encryption.UnitTests/AzureStorageErrorExtensionsTests.cs
+++ b/src/Microsoft.Health.Encryption.UnitTests/AzureStorageErrorExtensionsTests.cs
@@ -1,0 +1,33 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Azure;
+using Microsoft.Health.Encryption.Customer.Extensions;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Health.Encryption.UnitTests;
+
+public class AzureStorageErrorExtensionsTests
+{
+    public static IEnumerable<object[]> GetExceptionToResultMapping
+    {
+        get
+        {
+            yield return new object[] { new RequestFailedException(403, "The key vault key is not found to unwrap the encryption key.", "KeyVaultEncryptionKeyNotFound", innerException: null), true };
+            yield return new object[] { new RequestFailedException(403, "The key vault is not found for encryption.", "KeyVaultVaultNotFound", innerException: null), true };
+            yield return new object[] { new RequestFailedException(403, "Another kind of error.", "AnotherKindOfError", innerException: null), false };
+            yield return new object[] { new RequestFailedException("Undefined error"), false };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(GetExceptionToResultMapping))]
+    public void GivenRequestFailedException_WhenIsCMKErrorIsCalled_ThenReturnExpectedResult(RequestFailedException exception, bool expectedResult)
+    {
+        bool result = exception.IsCMKError();
+        Assert.Equal(expectedResult, result);
+    }
+}

--- a/src/Microsoft.Health.Encryption/Customer/Extensions/AzureStorageErrorExtensions.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Extensions/AzureStorageErrorExtensions.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
 using Azure;
 
 namespace Microsoft.Health.Encryption.Customer.Extensions;
@@ -10,9 +12,12 @@ namespace Microsoft.Health.Encryption.Customer.Extensions;
 public static class AzureStorageErrorExtensions
 {
     private const string KeyVaultEncryptionNotFoundErrorCode = "KeyVaultEncryptionKeyNotFound";
+    private const string KeyVaultNotFoundErrorCode = "KeyVaultVaultNotFound";
+
+    private static readonly List<string> KeyVaultErrorCodes = new List<string>() { KeyVaultEncryptionNotFoundErrorCode, KeyVaultNotFoundErrorCode };
 
     public static bool IsCMKError(this RequestFailedException rfe)
     {
-        return rfe?.ErrorCode == KeyVaultEncryptionNotFoundErrorCode;
+        return KeyVaultErrorCodes.Exists(value => value.Equals(rfe?.ErrorCode, StringComparison.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
## Description
Found while looking at a bug in dicom where the CMK error was not being classified properly. Theres another error we can get if the key vault itself does not exist anymore (has been deleted). Adding that here + unit tests

## Related issues
Addresses 125465

## Testing
Unit tests

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
