### PR TITLE
Do not log error for CMK failures in Schema worker

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
@@ -117,6 +117,12 @@ internal class SqlServerSchemaDataStore : ISchemaDataStore
                 throw;
             }
 
+            if (sqlEx.IsCMKError())
+            {
+                // do not log error if it is a CMK error, since it is the customer's issue and not a system issue
+                throw;
+            }
+
             _logger.LogError(sqlEx, "Error from SQL database on upserting InstanceSchema information");
             throw;
         }


### PR DESCRIPTION
## Description
The exception first happens here, and is logged as an error https://github.com/microsoft/healthcare-shared-components/blob/ff171b29f6ca318dabede20694c1f19e02cfab36/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs#L120

We can see from the logs that later down the line its caught as a CMK error and handled correctly (no failure, log as information) but the error log is distracting to DRI https://github.com/microsoft/healthcare-shared-components/blob/ff171b29f6ca318dabede20694c1f19e02cfab36/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs#L92

## Related issues
Addresses 125949

## Testing
`IsCMKError` is already tested 

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
