### PR TITLE
Add unknown error to sql retry

### DIFF
--- a/src/Microsoft.Health.SqlServer/Configs/SqlClientRetryOptions.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlClientRetryOptions.cs
@@ -72,6 +72,7 @@ public class SqlClientRetryOptions
                     // Additional .NET errors:
                     35,     // A connection was successfully established with the server, but then an error occurred during the login process. (provider: TCP Provider, error: 35 - An internal exception was caught)
                     18456,  // Login failed for user '<token-identified principal>'.
+                    258, // System.ComponentModel.Win32Exception (258): Unknown error 258
 
                     // Additional Fhir Server errors:
                     8623    // The query processor ran out of internal resources and could not produce a query plan.


### PR DESCRIPTION
## Description
We are seeing these errors intermittently in the service - we should retry instead of immediately returning 500s

## Related issues
Addresses 128422

## Testing
N/A

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
