### PR TITLE
Adds not empty check

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
@@ -192,7 +192,7 @@ public class SqlSchemaManager : ISchemaManager
             List<AvailableVersion> availableVersions = await _schemaClient.GetAvailabilityAsync(cancellationToken).ConfigureAwait(false);
 
             // To ensure that schema version null/0 is not printed
-            if (availableVersions[0].Id == 0)
+            if (availableVersions != null && availableVersions.Count > 0 && availableVersions[0].Id == 0)
             {
                 availableVersions.RemoveAt(0);
             }


### PR DESCRIPTION
## Description
Ensure that availableVersions list is not empty before iterating over the first object.

## Related issues
[Addresses [issue #].](https://microsofthealth.visualstudio.com/Health/_workitems/edit/130229)

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
