### PR TITLE
Use Microsoft.Extensions.Azure 1.9.0 for Latest .NET Versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,6 +32,7 @@
   <Choose>
     <When Condition="'$(TargetFramework)' == '$(PreviousVersion)'">
       <PropertyGroup>
+        <AzureExtensionsVersion>1.8.0</AzureExtensionsVersion>
         <ConfigurationBinderVersion>6.0.0</ConfigurationBinderVersion>
         <DependencyInjectionVersion>6.0.0</DependencyInjectionVersion>
         <FormatsAsn1Version>6.0.1</FormatsAsn1Version>
@@ -45,6 +46,7 @@
     </When>
     <When Condition="'$(TargetFramework)' == '$(LtsVersion)'">
       <PropertyGroup>
+        <AzureExtensionsVersion>1.9.0</AzureExtensionsVersion>
         <ConfigurationBinderVersion>8.0.2</ConfigurationBinderVersion>
         <DependencyInjectionVersion>8.0.2</DependencyInjectionVersion>
         <FormatsAsn1Version>8.0.1</FormatsAsn1Version>
@@ -59,6 +61,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
+        <AzureExtensionsVersion>1.9.0</AzureExtensionsVersion>
         <ConfigurationBinderVersion>9.0.0</ConfigurationBinderVersion>
         <DependencyInjectionVersion>9.0.0</DependencyInjectionVersion>
         <FormatsAsn1Version>9.0.0</FormatsAsn1Version>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.5.0" />
     <PackageVersion Include="Microsoft.DurableTask.Client" Version="1.5.0" />
     <PackageVersion Include="Microsoft.DurableTask.Client.OrchestrationServiceClientShim" Version="1.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.Azure" Version="$(AzureExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(SdkPackageVersion)" />


### PR DESCRIPTION
## Description
Update dependency for `Microsoft.Extensions.Azure` to `1.9.0` for .NET 8 and .NET 9
