### PR TITLE
Removes SqlManagementObject references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,4 @@
 <Project>
-
   <ItemGroup>
     <PackageVersion Include="Azure.Core" Version="1.44.1" />
     <PackageVersion Include="Azure.Identity" Version="1.13.2" />
@@ -70,7 +69,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.SqlServer.DacFx" Version="162.5.57" />
-    <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="172.52.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
@@ -92,5 +90,4 @@
     <PackageVersion Include="xunit.extensibility.core" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
-
 </Project>

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -122,8 +122,11 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         await ExecuteWithGoSupport(script, sqlCommandWrapper, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task ExecuteWithGoSupport(string script, SqlCommandWrapper sqlCommandWrapper, CancellationToken cancellationToken)
+    private async Task ExecuteWithGoSupport(string script, SqlCommandWrapper sqlCommandWrapper, CancellationToken cancellationToken)
     {
+        sqlCommandWrapper.CommandTimeout = (int)_sqlServerDataStoreConfiguration.StatementTimeout.TotalSeconds;
+        _logger.LogInformation("SqlCommandWrapper timeout sets to {StatementTimeout} seconds", sqlCommandWrapper.CommandTimeout);
+
         foreach (string statement in script.Split(["\nGO"], StringSplitOptions.RemoveEmptyEntries))
         {
             sqlCommandWrapper.CommandText = statement;

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SchemaManagerDataStore.cs
@@ -14,8 +14,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Client;
-using Microsoft.SqlServer.Management.Common;
-using Microsoft.SqlServer.Management.Smo;
 
 namespace Microsoft.Health.SqlServer.Features.Schema.Manager;
 
@@ -44,8 +42,6 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
 
-        var serverConnection = GetServerConnectionWithTimeout(sqlCommandWrapper.Connection);
-
         try
         {
             // FullSchemaSnapshot script(x.sql) inserts 'started' status into the SchemaVersion table itself.
@@ -54,17 +50,16 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
                 await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.started.ToString(), cancellationToken).ConfigureAwait(false);
             }
 
-            var server = new Server(serverConnection);
             var watch = Stopwatch.StartNew();
             _logger.LogInformation("Script execution started at {UtcTime}", DateTime.UtcNow);
 
-            server.ConnectionContext.ExecuteNonQuery(script);
+            await ExecuteWithGoSupport(script, sqlCommandWrapper, cancellationToken).ConfigureAwait(false);
 
             watch.Stop();
             _logger.LogInformation("Script execution time is {ElapsedTime}", watch.Elapsed);
             await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.completed.ToString(), cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
+        catch (Exception e) when (e is SqlException)
         {
             await UpsertSchemaVersionAsync(sqlCommandWrapper.Connection, version, SchemaVersionStatus.failed.ToString(), cancellationToken).ConfigureAwait(false);
             throw;
@@ -124,8 +119,16 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
 
-        var server = new Server(GetServerConnectionWithTimeout(sqlCommandWrapper.Connection));
-        server.ConnectionContext.ExecuteNonQuery(script);
+        await ExecuteWithGoSupport(script, sqlCommandWrapper, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task ExecuteWithGoSupport(string script, SqlCommandWrapper sqlCommandWrapper, CancellationToken cancellationToken)
+    {
+        foreach (string statement in script.Split(["\nGO"], StringSplitOptions.RemoveEmptyEntries))
+        {
+            sqlCommandWrapper.CommandText = statement;
+            await sqlCommandWrapper.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />
@@ -156,13 +159,5 @@ public class SchemaManagerDataStore : ISchemaManagerDataStore
         sqlCommandWrapper.CommandText = "SELECT COUNT(*) FROM dbo.InstanceSchema";
 
         return (int)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) != 0;
-    }
-
-    private ServerConnection GetServerConnectionWithTimeout(SqlConnection sqlConnection)
-    {
-        var serverConnection = new ServerConnection(sqlConnection);
-        serverConnection.StatementTimeout = (int)_sqlServerDataStoreConfiguration.StatementTimeout.TotalSeconds;
-        _logger.LogInformation("ServerConnection timeout sets to {TimeoutSeconds} seconds", serverConnection.StatementTimeout);
-        return serverConnection;
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Health.SqlServer.Features.Schema.Extensions;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Exceptions;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Model;
-using Microsoft.SqlServer.Management.Common;
 using Polly;
 
 namespace Microsoft.Health.SqlServer.Features.Schema.Manager;
@@ -175,7 +174,7 @@ public class SqlSchemaManager : ISchemaManager
         }
         catch (Exception ex)
         {
-            if (ex is SqlException || ex is ExecutionFailureException)
+            if (ex is SqlException)
             {
                 _logger.LogError(ex, "Script execution has failed.");
             }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
@@ -12,7 +12,6 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
-using Microsoft.SqlServer.Management.Common;
 
 namespace Microsoft.Health.SqlServer.Features.Schema;
 
@@ -63,7 +62,7 @@ public class SchemaUpgradeRunner
 
             _logger.LogInformation("Completed applying schema {Version}", version);
         }
-        catch (Exception e) when (e is SqlException || e is ExecutionFailureException)
+        catch (Exception e) when (e is SqlException)
         {
             _logger.LogError(e, "Failed applying schema {Version}", version);
             await FailSchemaVersionAsync(version, cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
+++ b/src/Microsoft.Health.SqlServer/Microsoft.Health.SqlServer.csproj
@@ -33,7 +33,6 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
-    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" />

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
@@ -15,7 +15,6 @@ using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using Microsoft.Health.SqlServer.Features.Storage;
-using Microsoft.SqlServer.Management.Common;
 using NSubstitute;
 using Xunit;
 using Xunit.Abstractions;
@@ -96,7 +95,7 @@ public sealed class SchemaUpgradeRunnerTests : SqlIntegrationTestBase, IDisposab
         await _schemaDataStore.ExecuteScriptAsync("Insert into SchemaVersion values (2, 'started')", CancellationToken.None);
 
         // attempt 1 : To apply schemaVersion-2 fails
-        await Assert.ThrowsAsync<ExecutionFailureException>(() => _runner.ApplySchemaAsync(2, applyFullSchemaSnapshot: true, CancellationToken.None));
+        await Assert.ThrowsAsync<SqlException>(() => _runner.ApplySchemaAsync(2, applyFullSchemaSnapshot: true, CancellationToken.None));
 
         // attempt 2 : To apply schemaVersion-2 passes
         await _runner.ApplySchemaAsync(2, applyFullSchemaSnapshot: true, CancellationToken.None);

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Microsoft.Health.SqlServer.Tests.Integration.csproj
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Microsoft.Health.SqlServer.Tests.Integration.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />


### PR DESCRIPTION
## Description
Removes Microsoft.SqlServer.SqlManagementObjects from ScriptRunner. 
Microsoft.SqlServer.SqlManagementObjects does not support ActiveDirectortyWorkloadIdentity:
![image](https://github.com/user-attachments/assets/447463ab-8af2-441b-9ab2-9afe5740753a)

vs Microsoft.Data.SqlClient
![image](https://github.com/user-attachments/assets/51fcdb20-cc8e-4714-9cb5-00a1b8c2ed7d)

## Testing
Existing tests should pass.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch (Same functionality)
