### PR TITLE
Add new error to handle too many parameters

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorCodes.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorCodes.cs
@@ -84,4 +84,9 @@ public static class SqlErrorCodes
     /// Can not connect to the database in its current state.
     /// </summary>
     public const int CannotConnectToDBInCurrentState = 40925;
+
+    /// <summary>
+    /// The incoming request has too many parameters. The server supports a maximum of %d parameters.
+    /// </summary>
+    public const int TooManyParameters = 8003;
 }


### PR DESCRIPTION
## Description
We noticed that when we send too many parameters, SQL says:

For reference: see [Error 8003](https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors-8000-to-8999?view=sql-server-ver16)

The incoming request has too many parameters. The server supports a maximum of %d parameters. Reduce the number of parameters and resend the request.


## Related issues
Addresses [issue #146152].

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
