### PR TITLE
Create New Methods for Creating SQL Connections with More Flexibility

### DIFF
--- a/src/Microsoft.Health.SqlServer/DefaultSqlConnectionBuilder.cs
+++ b/src/Microsoft.Health.SqlServer/DefaultSqlConnectionBuilder.cs
@@ -59,6 +59,26 @@ public class DefaultSqlConnectionBuilder : ISqlConnectionBuilder
 
     /// <inheritdoc />
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller must dispose result.")]
+    public SqlConnection CreateConnection(Action<SqlConnectionStringBuilder> configure = null)
+    {
+        SqlConnectionStringBuilder builder = GetConnectionStringBuilder();
+        configure?.Invoke(builder);
+
+        return new SqlConnection(builder.ToString()) { RetryLogicProvider = _retryProvider };
+    }
+
+    /// <inheritdoc />
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller must dispose result.")]
+    public async ValueTask<SqlConnection> CreateConnectionAsync(Action<SqlConnectionStringBuilder> configure = null, CancellationToken cancellationToken = default)
+    {
+        SqlConnectionStringBuilder builder = await GetConnectionStringBuilderAsync().ConfigureAwait(false);
+        configure?.Invoke(builder);
+
+        return new SqlConnection(builder.ToString()) { RetryLogicProvider = _retryProvider };
+    }
+
+    /// <inheritdoc />
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller must dispose result.")]
     public SqlConnection GetSqlConnection(string initialCatalog = null, int? maxPoolSize = null)
     {
         SqlConnectionStringBuilder builder = GetConnectionStringBuilder(initialCatalog, maxPoolSize);

--- a/src/Microsoft.Health.SqlServer/ISqlConnectionBuilder.cs
+++ b/src/Microsoft.Health.SqlServer/ISqlConnectionBuilder.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
@@ -19,6 +20,25 @@ public interface ISqlConnectionBuilder
     /// </summary>
     /// <value>The default initial catalog if specified; otherwise <see langword="null"/>.</value>
     string DefaultDatabase { get; }
+
+    /// <summary>
+    /// Gets a SQL connection as additionally configured by the caller.
+    /// </summary>
+    /// <param name="configure">An optional delegate for configuring the connection.</param>
+    /// <returns>The SQL connection.</returns>
+    SqlConnection CreateConnection(Action<SqlConnectionStringBuilder> configure = null);
+
+    /// <summary>
+    /// Gets a SQL connection as additionally configured by the caller.
+    /// </summary>
+    /// <param name="configure">An optional delegate for configuring the connection.</param>
+    /// <param name="cancellationToken">The optional cancellation token for suspending the asynchronous operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> representing the create operation. The value of the
+    /// <see cref="ValueTask{TResult}.Result"/> property is the connection.
+    /// </returns>
+    /// <exception cref="OperationCanceledException">The operation was canceled.</exception>
+    ValueTask<SqlConnection> CreateConnectionAsync(Action<SqlConnectionStringBuilder> configure = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets unopened sql connection with setting application intent to read only

--- a/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
+++ b/test/Microsoft.Health.SqlServer.Tests.Integration/Features/Schema/SchemaUpgradeRunnerTests.cs
@@ -38,8 +38,8 @@ public sealed class SchemaUpgradeRunnerTests : SqlIntegrationTestBase, IDisposab
         await base.InitializeAsync();
 
         var sqlConnection = Substitute.For<ISqlConnectionBuilder>();
-        sqlConnection.GetSqlConnection(Arg.Any<string>(), Arg.Any<int?>()).ReturnsForAnyArgs((x) => GetSqlConnection());
-        sqlConnection.GetSqlConnectionAsync(Arg.Any<string>(), Arg.Any<int?>()).ReturnsForAnyArgs((x) => GetSqlConnection());
+        sqlConnection.CreateConnection(default).ReturnsForAnyArgs(x => GetSqlConnection());
+        sqlConnection.CreateConnectionAsync(default, default).ReturnsForAnyArgs(x => GetSqlConnection());
         var config = Options.Create(new SqlServerDataStoreConfiguration());
 
         SqlRetryLogicBaseProvider sqlRetryLogicBaseProvider = SqlConfigurableRetryFactory.CreateFixedRetryProvider(new SqlClientRetryOptions().Settings);


### PR DESCRIPTION
## Description
Adds new method overloads that allow users to specify delegates on the connection string builder. The alternative would be creating more and more overloads for every connection property.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Feature
