### PR TITLE
Upgrade .NET Framework Target from .NET Framework 4.6.2 to 4.7.2

### DIFF
--- a/tools/Microsoft.Health.Tools.Sql.Tasks.Tests/Microsoft.Health.Tools.Sql.Tasks.Tests.csproj
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks.Tests/Microsoft.Health.Tools.Sql.Tasks.Tests.csproj
@@ -39,7 +39,7 @@
   </Target>
 
   <Target Name="PublishSqlTasksFull" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Full' ">
-    <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=net462" />
+    <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=net472" />
   </Target>
 
   <Import Project="..\Microsoft.Health.Tools.Sql.Tasks\Sql.test.targets" />

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Microsoft.Health.Tools.Sql.Tasks.csproj
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Microsoft.Health.Tools.Sql.Tasks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <Target Name="PublishAll" BeforeTargets="GenerateNuspec">
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=net462" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=net472" />
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=netstandard2.1" />
   </Target>
 

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.nuspec
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.nuspec
@@ -12,6 +12,6 @@
   <files>
     <file src="Sql.targets" target="build" />
     <file src="$publishDir$\netstandard2.1\**\*" target="build/netstandard2.1/" />
-    <file src="$publishDir$\net462\**\*" target="build/net462/" />
+    <file src="$publishDir$\net472\**\*" target="build/net472/" />
   </files>
 </package>

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.targets
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.targets
@@ -29,6 +29,6 @@
   </Target>
 
   <UsingTask TaskName="GenerateFullScript" AssemblyFile="netstandard2.1\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Core' Or '$(MSBuildRuntimeType)' == 'Mono'"/>
-  <UsingTask TaskName="GenerateFullScript" AssemblyFile="net462\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Full'"/>
+  <UsingTask TaskName="GenerateFullScript" AssemblyFile="net472\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Full'"/>
 
 </Project>

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.test.targets
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.test.targets
@@ -28,7 +28,7 @@
         SqlScript="@(SqlScript)" />
   </Target>
 
-  <UsingTask TaskName="GenerateFullScript" AssemblyFile="bin\$(Configuration)\publish\net462\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Full'"/>
+  <UsingTask TaskName="GenerateFullScript" AssemblyFile="bin\$(Configuration)\publish\net472\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Full'"/>
   <UsingTask TaskName="GenerateFullScript" AssemblyFile="bin\$(Configuration)\publish\netstandard2.1\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Core' Or '$(MSBuildRuntimeType)' == 'Mono'"/>
 
 </Project>


### PR DESCRIPTION
## Description
Upgrade .NET framework target from .NET framework 4.6.2 to 4.7.2 for modern package updates

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Breaking
