### PR TITLE
Use .NET 8 over .NET Standard 2.1 for SQL MSBuild Task

### DIFF
--- a/tools/Microsoft.Health.Tools.Sql.Tasks.Tests/Microsoft.Health.Tools.Sql.Tasks.Tests.csproj
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks.Tests/Microsoft.Health.Tools.Sql.Tasks.Tests.csproj
@@ -34,8 +34,12 @@
     <GeneratedFullScriptPath>Schema\$(LatestSchemaVersion).sql</GeneratedFullScriptPath>
   </PropertyGroup>
 
-  <Target Name="PublishSqlTasksCoreOrMono" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Core' Or '$(MSBuildRuntimeType)' == 'Mono'">
-    <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=netstandard2.1" />
+  <Target Name="PublishSqlTasksMono" Condition="'$(MSBuildRuntimeType)' == 'Mono'">
+    <Error Text="Mono is not supported." />
+  </Target>
+
+  <Target Name="PublishSqlTasksCore" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Core'">
+    <MSBuild Projects="..\Microsoft.Health.Tools.Sql.Tasks\Microsoft.Health.Tools.Sql.Tasks.csproj" Targets="Publish" Properties="TargetFramework=net8.0" />
   </Target>
 
   <Target Name="PublishSqlTasksFull" BeforeTargets="CoreCompile" Condition=" '$(MSBuildRuntimeType)' == 'Full' ">

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Helpers/SqlScriptParser.cs
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Helpers/SqlScriptParser.cs
@@ -22,10 +22,14 @@ public static class SqlScriptParser
     /// <returns>Sql object</returns>
     public static TSqlFragment ParseSqlFile(string sqlFile, TaskLoggingHelper taskLoggingHelper)
     {
+#if NETFRAMEWORK
         if (taskLoggingHelper == null)
         {
             throw new ArgumentNullException(nameof(taskLoggingHelper));
         }
+#else
+        ArgumentNullException.ThrowIfNull(taskLoggingHelper);
+#endif
 
         TSqlFragment sqlFragment = null;
         using (var stream = File.OpenRead(sqlFile))
@@ -39,7 +43,11 @@ public static class SqlScriptParser
                 StringBuilder sb = new StringBuilder();
                 foreach (var error in errors)
                 {
+#if NETFRAMEWORK
                     sb.AppendLine($"Line: {error.Line}, Number: {error.Number}, Message: {error.Message}");
+#else
+                    sb.AppendLine(System.Globalization.CultureInfo.InvariantCulture, $"Line: {error.Line}, Number: {error.Number}, Message: {error.Message}");
+#endif
                 }
 
                 taskLoggingHelper.LogError("Failed to parse the Sql file: {0}, Error: {1}", sqlFile, sb.ToString());

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Helpers/SqlScriptWriter.cs
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Helpers/SqlScriptWriter.cs
@@ -55,10 +55,14 @@ public class SqlScriptWriter : IDisposable
 
     public void Write(IReadOnlyCollection<TSqlFragment> sqlObjects)
     {
+#if NETFRAMEWORK
         if (sqlObjects == null)
         {
             throw new ArgumentNullException(nameof(sqlObjects));
         }
+#else
+        ArgumentNullException.ThrowIfNull(sqlObjects);
+#endif
 
         foreach (var sqlObject in sqlObjects)
         {

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Microsoft.Health.Tools.Sql.Tasks.csproj
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Microsoft.Health.Tools.Sql.Tasks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
@@ -23,7 +23,7 @@
 
   <Target Name="PublishAll" BeforeTargets="GenerateNuspec">
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=net472" />
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=netstandard2.1" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=net8.0" />
   </Target>
 
 </Project>

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.nuspec
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.nuspec
@@ -11,7 +11,7 @@
   </metadata>
   <files>
     <file src="Sql.targets" target="build" />
-    <file src="$publishDir$\netstandard2.1\**\*" target="build/netstandard2.1/" />
+    <file src="$publishDir$\net8.0\**\*" target="build/net8.0/" />
     <file src="$publishDir$\net472\**\*" target="build/net472/" />
   </files>
 </package>

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.targets
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.targets
@@ -19,6 +19,10 @@
     <GenerateFullScriptsOutputs Include="$(GeneratedFullScriptPath)" />
   </ItemGroup>
 
+  <Target Name="GenerateFullSqlScriptMono" Condition="'$(MSBuildRuntimeType)' == 'Mono'">
+    <Error Text="Mono is not supported." />
+  </Target>
+
   <Target Name="GenerateFullSqlScript" BeforeTargets="CollectGenerateFilesInputs" Inputs="@(GenerateFullScriptsInputs)" Outputs="@(GenerateFullScriptsOutputs)">
     <GenerateFullScript
         IntermediateOutputPath="$(IntermediateOutputPath)"
@@ -28,7 +32,7 @@
         SqlScript="@(SqlScript)" />
   </Target>
 
-  <UsingTask TaskName="GenerateFullScript" AssemblyFile="netstandard2.1\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Core' Or '$(MSBuildRuntimeType)' == 'Mono'"/>
+  <UsingTask TaskName="GenerateFullScript" AssemblyFile="net8.0\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Core'"/>
   <UsingTask TaskName="GenerateFullScript" AssemblyFile="net472\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Full'"/>
 
 </Project>

--- a/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.test.targets
+++ b/tools/Microsoft.Health.Tools.Sql.Tasks/Sql.test.targets
@@ -19,6 +19,10 @@
     <GenerateFullScriptsOutputs Include="$(GeneratedFullScriptPath)" />
   </ItemGroup>
 
+  <Target Name="GenerateFullSqlScriptMono" Condition="'$(MSBuildRuntimeType)' == 'Mono'">
+    <Error Text="Mono is not supported." />
+  </Target>
+
   <Target Name="GenerateFullSqlScript" BeforeTargets="CoreCompile" Inputs="@(GenerateFullScriptsInputs)" Outputs="@(GenerateFullScriptsOutputs)">
     <GenerateFullScript
         IntermediateOutputPath="$(IntermediateOutputPath)"
@@ -29,6 +33,6 @@
   </Target>
 
   <UsingTask TaskName="GenerateFullScript" AssemblyFile="bin\$(Configuration)\publish\net472\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Full'"/>
-  <UsingTask TaskName="GenerateFullScript" AssemblyFile="bin\$(Configuration)\publish\netstandard2.1\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Core' Or '$(MSBuildRuntimeType)' == 'Mono'"/>
+  <UsingTask TaskName="GenerateFullScript" AssemblyFile="bin\$(Configuration)\publish\net8.0\Microsoft.Health.Tools.Sql.Tasks.dll" Condition="'$(MSBuildRuntimeType)' == 'Core'"/>
 
 </Project>


### PR DESCRIPTION
## Description
Use .NET 8 for .NET Core builds to use more modern tooling. Remove support for Mono

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Breaking
