### PR TITLE
Adding in UseQueueClientJobsForReindexing to SqlServerDataStoreConfig

### DIFF
--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -70,4 +70,9 @@ public class SqlServerDataStoreConfiguration
     /// If set, the maximum number of connections allowed in the pool to use when connecting to SQL.
     /// </summary>
     public int? MaxPoolSize { get; set; }
+
+    /// <summary>
+    /// Indicates whether the SQL Server data store should use Queueclient Jobs for Reindexing
+    /// </summary>
+    public bool UseQueueClientJobsForReindexing { get; set; }
 }


### PR DESCRIPTION
## Description
Adding UseQueueClientJobsForReindexing to SqlServerDataStoreConfiguration to support feature flag for enabling new reindex queueclient job vs legacy worker. Will be used as we migrate customers to new reindexing feature and removed once all customers have migrated. 

AB#146164

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
