### PR TITLE
Create CMK singleton cache

### DIFF
--- a/src/Microsoft.Health.Encryption.UnitTests/CustomerManagedKeyHealthCacheTests.cs
+++ b/src/Microsoft.Health.Encryption.UnitTests/CustomerManagedKeyHealthCacheTests.cs
@@ -1,0 +1,69 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Health.Core.Features.Health;
+using Microsoft.Health.Encryption.Customer.Health;
+using Xunit;
+
+namespace Microsoft.Health.Encryption.UnitTests;
+
+public class CustomerManagedKeyHealthCacheTests
+{
+    [Fact]
+    public void Instance_ShouldBeSingleton()
+    {
+        // Act
+        var instance1 = CustomerManagedKeyHealthCache.Instance;
+        var instance2 = CustomerManagedKeyHealthCache.Instance;
+
+        // Assert
+        Assert.Same(instance1, instance2);
+    }
+
+    [Fact]
+    public async Task SetAndGet_ShouldReturnSameValue()
+    {
+        // Arrange
+        var health = new CustomerKeyHealth
+        {
+            IsHealthy = false,
+            Reason = HealthStatusReason.ServiceUnavailable,
+            Exception = new InvalidOperationException("Test exception")
+        };
+
+        // Act
+        CustomerManagedKeyHealthCache.Instance.Set(health);
+
+        // Assert
+        var cachedHealth = await CustomerManagedKeyHealthCache.Instance.GetAsync();
+        Assert.False(cachedHealth.IsHealthy);
+        Assert.Equal(HealthStatusReason.ServiceUnavailable, cachedHealth.Reason);
+        Assert.IsType<InvalidOperationException>(cachedHealth.Exception);
+    }
+
+    [Fact]
+    public async Task Set_ShouldOverwritePreviousValue()
+    {
+        // Arrange
+        var health1 = new CustomerKeyHealth { IsHealthy = true, Reason = HealthStatusReason.None };
+        var health2 = new CustomerKeyHealth { IsHealthy = false, Reason = HealthStatusReason.CustomerManagedKeyAccessLost };
+
+        // Act
+        CustomerManagedKeyHealthCache.Instance.Set(health1);
+        var cachedHealth1 = await CustomerManagedKeyHealthCache.Instance.GetAsync();
+
+        CustomerManagedKeyHealthCache.Instance.Set(health2);
+        var cachedHealth2 = await CustomerManagedKeyHealthCache.Instance.GetAsync();
+
+        // Assert
+        Assert.True(cachedHealth1.IsHealthy);
+        Assert.Equal(HealthStatusReason.None, cachedHealth1.Reason);
+
+        Assert.False(cachedHealth2.IsHealthy);
+        Assert.Equal(HealthStatusReason.CustomerManagedKeyAccessLost, cachedHealth2.Reason);
+    }
+}

--- a/src/Microsoft.Health.Encryption/Customer/Health/CustomerKeyValidationBackgroundService.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/CustomerKeyValidationBackgroundService.cs
@@ -53,6 +53,9 @@ internal class CustomerKeyValidationBackgroundService : BackgroundService
         {
             CustomerKeyHealth customerKeyHealth = await _keyWrapUnwrapTestProvider.AssertHealthAsync(cancellationToken).ConfigureAwait(false);
             _customerManagedKeyHealth.Set(customerKeyHealth);
+
+            // Singleton cache for the customer key health
+            CustomerManagedKeyHealthCache.Instance.Set(customerKeyHealth);
         }
         catch (Exception ex)
         {
@@ -60,6 +63,9 @@ internal class CustomerKeyValidationBackgroundService : BackgroundService
 
             // reset to healthy so unexpected errors are not categorized as a customer misconfiguration
             _customerManagedKeyHealth.Set(new CustomerKeyHealth());
+
+            // Singleton cache for the customer key health
+            CustomerManagedKeyHealthCache.Instance.Set(new CustomerKeyHealth());
         }
     }
 }

--- a/src/Microsoft.Health.Encryption/Customer/Health/CustomerManagedKeyHealthCache.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/CustomerManagedKeyHealthCache.cs
@@ -1,0 +1,13 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Core.Features.Health;
+
+namespace Microsoft.Health.Encryption.Customer.Health;
+
+internal static class CustomerManagedKeyHealthCache
+{
+    public static ValueCache<CustomerKeyHealth> Instance { get; } = new();
+}


### PR DESCRIPTION
## Description
We want to validate if service is in unhealthy state due CMK issue, then we return correct health check value for FHIR service. Adding this CMK singleton cache to re-use current logic.
 
## Related issues
Addresses [issue #161015].

## Testing
Added unit test

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
