### PR TITLE
Adds empty check for schema available versions

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
@@ -85,9 +85,9 @@ public class SqlSchemaManager : ISchemaManager
                 .ExecuteAsync(FetchUpdatedAvailableVersionsAsync, token)
                 .ConfigureAwait(false);
 
-            if (availableVersions.Count == 1)
+            if (availableVersions == null || availableVersions.Count == 0 || availableVersions.Count == 1)
             {
-                _logger.LogError("There are no available versions.");
+                _logger.LogInformation("There are no available versions.");
                 return;
             }
 
@@ -240,6 +240,11 @@ public class SqlSchemaManager : ISchemaManager
     private async Task<List<AvailableVersion>> FetchUpdatedAvailableVersionsAsync(CancellationToken cancellationToken)
     {
         List<AvailableVersion> availableVersions = await _schemaClient.GetAvailabilityAsync(cancellationToken).ConfigureAwait(false);
+
+        if (availableVersions == null || availableVersions.Count == 0)
+        {
+            return availableVersions;
+        }
 
         availableVersions.Sort((x, y) => x.Id.CompareTo(y.Id));
 


### PR DESCRIPTION
## Description
Describe the changes in this PR.

## Related issues
Addresses [[issue #].](https://microsofthealth.visualstudio.com/Health/_workitems/edit/170734)

## Testing
This fixes the issue when available versions is empty
When schema versions return emtpy, then below exception is thrown
<img width="905" height="443" alt="image" src="https://github.com/user-attachments/assets/2f8958e6-5453-4274-a4a7-9c8dacba84f7" />
Unable to extract Container Id. Could not locate within mountinfo file at /proc/self/mountinfo
warn: Microsoft.Health.SqlServer.Features.Schema.Manager.BaseSchemaRunner[0]
      The base schema already exists.
Unhandled exception: System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at Microsoft.Health.SqlServer.Features.Schema.Manager.SqlSchemaManager.FetchUpdatedAvailableVersionsAsync(CancellationToken cancellationToken)

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
