### PR TITLE
Suppress error log for read-only database on geo-replicated secondary

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlServerSchemaDataStore.cs
@@ -123,6 +123,12 @@ internal class SqlServerSchemaDataStore : ISchemaDataStore
                 throw;
             }
 
+            if (sqlEx.Number == SqlErrorCodes.ReadOnlyDatabase)
+            {
+                // On a geo-replicated secondary, the database is read-only. The caller handles this gracefully.
+                throw;
+            }
+
             _logger.LogError(sqlEx, "Error from SQL database on upserting InstanceSchema information");
             throw;
         }


### PR DESCRIPTION
## Problem

On geo-replicated secondaries, `SqlServerSchemaDataStore.UpsertInstanceSchemaInformationAsync` logs SQL error 3906 (read-only database) as `LogError` every polling cycle before re-throwing to `SchemaJobWorker`. While `SchemaJobWorker` handles the exception gracefully (falls back to reading schema versions), the error log entry still appears, creating noise in monitoring.

## Fix

Add a check for `SqlErrorCodes.ReadOnlyDatabase` (3906) in the `catch (SqlException)` block of `UpsertInstanceSchemaInformationAsync`, following the same pattern used for `CouldNotFoundStoredProc` and CMK errors. The exception is re-thrown without logging, and `SchemaJobWorker` handles it gracefully.

## Testing

- Build verified (net9.0)
- No behavior change — only suppresses the noisy error log entry