### PR TITLE
Clear SQL connection pools on transport-level errors (TCP RST)

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Client/SqlConnectionPoolManagerTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Client/SqlConnectionPoolManagerTests.cs
@@ -1,0 +1,116 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.SqlServer.Features.Client;
+using Microsoft.Health.SqlServer.Features.Storage;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.SqlServer.UnitTests.Features.Client;
+
+public sealed class SqlConnectionPoolManagerTests
+{
+    private readonly ISqlConnectionPoolResetter _poolResetter;
+    private readonly ILogger<SqlConnectionPoolManager> _logger;
+    private readonly SqlConnectionPoolManager _poolManager;
+
+    public SqlConnectionPoolManagerTests()
+    {
+        _poolResetter = Substitute.For<ISqlConnectionPoolResetter>();
+        _logger = Substitute.For<ILogger<SqlConnectionPoolManager>>();
+        _poolManager = new SqlConnectionPoolManager(_poolResetter, _logger, TimeSpan.FromSeconds(1));
+    }
+
+    [Theory]
+    [InlineData(SqlErrorCodes.TransportLevelError)]
+    [InlineData(SqlErrorCodes.SemaphoreTimeout)]
+    [InlineData(SqlErrorCodes.ConnectionForciblyClosedByRemoteHost)]
+    public void HandleError_TransportError_ClearsPoolAndReturnsTrue(int errorCode)
+    {
+        SqlException exception = SqlExceptionFactory.Create(errorCode);
+
+        bool result = _poolManager.HandleError(exception);
+
+        Assert.True(result);
+        _poolResetter.Received(1).ClearAllPools();
+    }
+
+    [Fact]
+    public void HandleError_NonTransportError_DoesNotClearPoolAndReturnsFalse()
+    {
+        SqlException exception = SqlExceptionFactory.Create(18456); // Login failed
+
+        bool result = _poolManager.HandleError(exception);
+
+        Assert.False(result);
+        _poolResetter.DidNotReceive().ClearAllPools();
+    }
+
+    [Fact]
+    public void HandleError_NullException_ReturnsFalse()
+    {
+        bool result = _poolManager.HandleError(null);
+
+        Assert.False(result);
+        _poolResetter.DidNotReceive().ClearAllPools();
+    }
+
+    [Fact]
+    public void HandleError_SecondCallWithinCooldown_DoesNotClearPoolAgain()
+    {
+        SqlException exception = SqlExceptionFactory.Create(SqlErrorCodes.TransportLevelError);
+
+        bool firstResult = _poolManager.HandleError(exception);
+        bool secondResult = _poolManager.HandleError(exception);
+
+        Assert.True(firstResult);
+        Assert.False(secondResult);
+        _poolResetter.Received(1).ClearAllPools();
+    }
+
+    [Fact]
+    public void HandleError_AfterCooldownExpires_ClearsPoolAgain()
+    {
+        var shortCooldown = TimeSpan.FromMilliseconds(50);
+        var manager = new SqlConnectionPoolManager(_poolResetter, _logger, shortCooldown);
+        SqlException exception = SqlExceptionFactory.Create(SqlErrorCodes.TransportLevelError);
+
+        bool firstResult = manager.HandleError(exception);
+        Assert.True(firstResult);
+
+        Thread.Sleep(100); // Wait for cooldown to expire
+
+        bool secondResult = manager.HandleError(exception);
+        Assert.True(secondResult);
+
+        _poolResetter.Received(2).ClearAllPools();
+    }
+
+    [Theory]
+    [InlineData(SqlErrorCodes.TransportLevelError)]
+    [InlineData(SqlErrorCodes.SemaphoreTimeout)]
+    [InlineData(SqlErrorCodes.ConnectionForciblyClosedByRemoteHost)]
+    public void IsTransportError_WithTransportErrorCodes_ReturnsTrue(int errorCode)
+    {
+        SqlException exception = SqlExceptionFactory.Create(errorCode);
+
+        Assert.True(SqlConnectionPoolManager.IsTransportError(exception));
+    }
+
+    [Theory]
+    [InlineData(18456)] // Login failed
+    [InlineData(1205)]  // Deadlock
+    [InlineData(49918)] // Not enough resources
+    public void IsTransportError_WithNonTransportErrorCodes_ReturnsFalse(int errorCode)
+    {
+        SqlException exception = SqlExceptionFactory.Create(errorCode);
+
+        Assert.False(SqlConnectionPoolManager.IsTransportError(exception));
+    }
+}

--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Health/SqlServerHealthCheckTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Health/SqlServerHealthCheckTests.cs
@@ -74,7 +74,8 @@ public sealed class SqlServerHealthCheckTests
             _sqlTransactionHandler,
             _sqlConnectionBuilder,
             _sqlRetryLogicBaseProvider,
-            _sqlServerDataStoreConfiguration);
+            _sqlServerDataStoreConfiguration,
+            null);
 
         // Setting up the ObtainSqlConnectionWrapperAsync method to throw an exception.
         connectionWrapperFactory.ObtainSqlConnectionWrapperAsync(Arg.Any<CancellationToken>()).Returns(Task.FromException<SqlConnectionWrapper>(httpRequestException));

--- a/src/Microsoft.Health.SqlServer/Features/Client/DefaultSqlConnectionPoolResetter.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/DefaultSqlConnectionPoolResetter.cs
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Data.SqlClient;
+
+namespace Microsoft.Health.SqlServer.Features.Client;
+
+/// <summary>
+/// Default implementation that delegates to <see cref="SqlConnection.ClearAllPools"/>.
+/// </summary>
+internal sealed class DefaultSqlConnectionPoolResetter : ISqlConnectionPoolResetter
+{
+    public void ClearAllPools()
+    {
+        SqlConnection.ClearAllPools();
+    }
+}

--- a/src/Microsoft.Health.SqlServer/Features/Client/ISqlConnectionPoolResetter.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/ISqlConnectionPoolResetter.cs
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.SqlServer.Features.Client;
+
+/// <summary>
+/// Abstraction over SQL connection pool clearing to enable unit testing.
+/// </summary>
+public interface ISqlConnectionPoolResetter
+{
+    /// <summary>
+    /// Clears all SQL connection pools in the current process.
+    /// </summary>
+    void ClearAllPools();
+}

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionPoolManager.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionPoolManager.cs
@@ -1,0 +1,107 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.SqlServer.Features.Storage;
+
+namespace Microsoft.Health.SqlServer.Features.Client;
+
+/// <summary>
+/// Manages SQL connection pool clearing in response to transport-level errors.
+/// When a transport error (e.g., TCP RST from VFP reprogramming) is detected,
+/// all pooled connections are likely dead and must be discarded.
+/// A cooldown prevents excessive clearing from concurrent error storms.
+/// </summary>
+public class SqlConnectionPoolManager
+{
+    private readonly ISqlConnectionPoolResetter _poolResetter;
+    private readonly ILogger<SqlConnectionPoolManager> _logger;
+    private readonly TimeSpan _cooldown;
+
+    private long _lastResetTicks;
+
+    /// <summary>
+    /// Default cooldown of 30 seconds. VFP reprogramming completes in 1-3s, so this allows
+    /// full recovery while preventing thundering-herd clears from concurrent error storms.
+    /// </summary>
+    public static readonly TimeSpan DefaultCooldown = TimeSpan.FromSeconds(30);
+
+    public SqlConnectionPoolManager(
+        ISqlConnectionPoolResetter poolResetter,
+        ILogger<SqlConnectionPoolManager> logger,
+        TimeSpan? cooldown = null)
+    {
+        _poolResetter = poolResetter ?? throw new ArgumentNullException(nameof(poolResetter));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _cooldown = cooldown ?? DefaultCooldown;
+    }
+
+    /// <summary>
+    /// Call when a <see cref="SqlException"/> is caught. If the exception is a transport-level
+    /// error, clears all connection pools (subject to cooldown).
+    /// </summary>
+    /// <param name="exception">The SQL exception that was caught.</param>
+    /// <returns>True if the pool was cleared; false if the error was not a transport error or cooldown is active.</returns>
+    public bool HandleError(SqlException exception)
+    {
+        if (exception == null || !IsTransportError(exception))
+        {
+            return false;
+        }
+
+        return TryClearPools(exception);
+    }
+
+    private bool TryClearPools(SqlException exception)
+    {
+        long now = DateTime.UtcNow.Ticks;
+        long last = Interlocked.Read(ref _lastResetTicks);
+        long cooldownTicks = _cooldown.Ticks;
+
+        if (now - last <= cooldownTicks)
+        {
+            _logger.LogDebug(
+                "SQL connection pool clear skipped (cooldown active). Last clear was {ElapsedMs}ms ago.",
+                TimeSpan.FromTicks(now - last).TotalMilliseconds);
+            return false;
+        }
+
+        if (Interlocked.CompareExchange(ref _lastResetTicks, now, last) != last)
+        {
+            // Another thread won the race
+            return false;
+        }
+
+        _logger.LogWarning(
+            exception,
+            "Transport-level SQL error detected (error code: {ErrorCode}). Clearing all SQL connection pools to discard stale connections.",
+            exception.Number);
+
+        _poolResetter.ClearAllPools();
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether the given <see cref="SqlException"/> represents a transport-level error
+    /// indicating that the underlying TCP connection has been reset or severed.
+    /// </summary>
+    internal static bool IsTransportError(SqlException exception)
+    {
+        foreach (SqlError error in exception.Errors)
+        {
+            if (error.Number is SqlErrorCodes.TransportLevelError
+                or SqlErrorCodes.SemaphoreTimeout
+                or SqlErrorCodes.ConnectionForciblyClosedByRemoteHost)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapperFactory.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Client/SqlConnectionWrapperFactory.cs
@@ -21,12 +21,14 @@ public class SqlConnectionWrapperFactory
     private readonly ISqlConnectionBuilder _sqlConnectionBuilder;
     private readonly SqlRetryLogicBaseProvider _sqlRetryLogicBaseProvider;
     private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
+    private readonly SqlConnectionPoolManager _sqlConnectionPoolManager;
 
     public SqlConnectionWrapperFactory(
         SqlTransactionHandler sqlTransactionHandler,
         ISqlConnectionBuilder sqlConnectionBuilder,
         SqlRetryLogicBaseProvider sqlRetryLogicBaseProvider,
-        IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration)
+        IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
+        SqlConnectionPoolManager sqlConnectionPoolManager = null)
     {
         EnsureArg.IsNotNull(sqlTransactionHandler, nameof(sqlTransactionHandler));
         EnsureArg.IsNotNull(sqlConnectionBuilder, nameof(sqlConnectionBuilder));
@@ -36,6 +38,7 @@ public class SqlConnectionWrapperFactory
         _sqlTransactionHandler = sqlTransactionHandler;
         _sqlConnectionBuilder = sqlConnectionBuilder;
         _sqlRetryLogicBaseProvider = sqlRetryLogicBaseProvider;
+        _sqlConnectionPoolManager = sqlConnectionPoolManager;
     }
 
     public string DefaultDatabase => _sqlConnectionBuilder.DefaultDatabase;
@@ -44,7 +47,16 @@ public class SqlConnectionWrapperFactory
     public virtual async Task<SqlConnectionWrapper> GetConnectionWrapperAsync(Action<SqlConnectionStringBuilder> configure = null, bool enlistInTransaction = false, CancellationToken cancellationToken = default)
     {
         var sqlConnectionWrapper = new SqlConnectionWrapper(_sqlTransactionHandler, _sqlConnectionBuilder, _sqlRetryLogicBaseProvider, enlistInTransaction, _sqlServerDataStoreConfiguration);
-        await sqlConnectionWrapper.InitializeAsync(configure, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await sqlConnectionWrapper.InitializeAsync(configure, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (SqlException ex)
+        {
+            _sqlConnectionPoolManager?.HandleError(ex);
+            throw;
+        }
 
         return sqlConnectionWrapper;
     }
@@ -53,7 +65,16 @@ public class SqlConnectionWrapperFactory
     public virtual async Task<SqlConnectionWrapper> ObtainSqlConnectionWrapperAsync(CancellationToken cancellationToken, bool enlistInTransaction = false)
     {
         var sqlConnectionWrapper = new SqlConnectionWrapper(_sqlTransactionHandler, _sqlConnectionBuilder, _sqlRetryLogicBaseProvider, enlistInTransaction, _sqlServerDataStoreConfiguration);
-        await sqlConnectionWrapper.InitializeAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await sqlConnectionWrapper.InitializeAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (SqlException ex)
+        {
+            _sqlConnectionPoolManager?.HandleError(ex);
+            throw;
+        }
 
         return sqlConnectionWrapper;
     }
@@ -62,9 +83,18 @@ public class SqlConnectionWrapperFactory
     public async Task<SqlConnectionWrapper> ObtainSqlConnectionWrapperAsync(string initialCatalog, CancellationToken cancellationToken, bool enlistInTransaction = false)
     {
         var sqlConnectionWrapper = new SqlConnectionWrapper(_sqlTransactionHandler, _sqlConnectionBuilder, _sqlRetryLogicBaseProvider, enlistInTransaction, _sqlServerDataStoreConfiguration);
-        await sqlConnectionWrapper.InitializeAsync(
-            initialCatalog is not null ? b => b.InitialCatalog = initialCatalog : null,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await sqlConnectionWrapper.InitializeAsync(
+                initialCatalog is not null ? b => b.InitialCatalog = initialCatalog : null,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (SqlException ex)
+        {
+            _sqlConnectionPoolManager?.HandleError(ex);
+            throw;
+        }
 
         return sqlConnectionWrapper;
     }

--- a/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
@@ -25,15 +25,18 @@ public class SqlServerHealthCheck : StorageHealthCheck
 {
     private readonly ILogger<SqlServerHealthCheck> _logger;
     private readonly SqlConnectionWrapperFactory _sqlConnectionWrapperFactory;
+    private readonly SqlConnectionPoolManager _sqlConnectionPoolManager;
 
     public SqlServerHealthCheck(
         SqlConnectionWrapperFactory sqlConnectionWrapperFactory,
         ValueCache<CustomerKeyHealth> customerKeyHealthCache,
-        ILogger<SqlServerHealthCheck> logger)
+        ILogger<SqlServerHealthCheck> logger,
+        SqlConnectionPoolManager sqlConnectionPoolManager = null)
         : base(customerKeyHealthCache, logger)
     {
         _sqlConnectionWrapperFactory = EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+        _sqlConnectionPoolManager = sqlConnectionPoolManager;
     }
 
     public override async Task<HealthCheckResult> CheckStorageHealthAsync(CancellationToken cancellationToken)
@@ -65,6 +68,18 @@ public class SqlServerHealthCheck : StorageHealthCheck
                 DegradedDescription,
                 httpEx,
                 new Dictionary<string, object> { { "Reason", reason.ToString() } });
+        }
+        catch (SqlException sqlEx) when (SqlConnectionPoolManager.IsTransportError(sqlEx))
+        {
+            // Transport-level errors (TCP RST from VFP/SDN reprogramming) indicate all pooled connections are stale.
+            // Clear pools and report Unhealthy so the load balancer stops routing traffic until recovery.
+            _sqlConnectionPoolManager?.HandleError(sqlEx);
+
+            return new HealthCheckResult(
+                HealthStatus.Unhealthy,
+                "SQL transport error detected. Connection pools cleared.",
+                sqlEx,
+                new Dictionary<string, object> { { "Reason", HealthStatusReason.DataStoreConnectionDegraded.ToString() } });
         }
         catch (SqlException sqlEx) when (sqlEx.IsCMKError())
         {

--- a/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorCodes.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Storage/SqlErrorCodes.cs
@@ -94,4 +94,20 @@ public static class SqlErrorCodes
     /// Failed to update database because the database is read-only.
     /// </summary>
     public const short ReadOnlyDatabase = 3906;
+
+    /// <summary>
+    /// A transport-level error has occurred (TCP provider: error code 35).
+    /// Indicates the underlying TCP connection was reset (e.g., during VFP/SDN reprogramming).
+    /// </summary>
+    public const int TransportLevelError = 35;
+
+    /// <summary>
+    /// The semaphore timeout period has expired (TCP keepalive failure).
+    /// </summary>
+    public const int SemaphoreTimeout = 121;
+
+    /// <summary>
+    /// An existing connection was forcibly closed by the remote host.
+    /// </summary>
+    public const int ConnectionForciblyClosedByRemoteHost = 64;
 }

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -68,6 +68,8 @@ public static class SqlServerBaseRegistrationExtensions
         services.AddOptions();
         services.AddSqlRetryLogicProvider();
         services.TryAddSingleton<ISqlConnectionBuilder, DefaultSqlConnectionBuilder>();
+        services.TryAddSingleton<ISqlConnectionPoolResetter, DefaultSqlConnectionPoolResetter>();
+        services.TryAddSingleton<SqlConnectionPoolManager>();
 
         // Services to facilitate SQL connections
         // TODO: Does SqlTransactionHandler need to be registered directly? Should usage change to ITransactionHandler?


### PR DESCRIPTION
## Summary

When Azure VFP/SDN reprogramming occurs during Ionian.Infra deployments, all existing TCP connections to SQL are reset. ADO.NET connection pools retain these dead connections, causing cascading HTTP 500 failures for 2+ minutes until pooled connections time out naturally.

## Root Cause (ICM 800927137)

- **Trigger:** Ionian.Infra Ev2 deployment's `prod-virtualNetworkIsolation` step performs subnet PUTs with `Microsoft.Sql` service endpoint
- **Mechanism:** Azure VFP (Virtual Filtering Platform) reprogramming sends TCP RSTs to all active connections
- **Impact:** 321K errors over 30 days, 4 major weekly events (200-280 HTTP 500s each), matching infra deployment cadence

## Fix

Adds `SqlConnectionPoolManager` that:
1. **Detects** transport-level SQL errors (error codes 35, 121, 64)
2. **Clears** all connection pools via `SqlConnection.ClearAllPools()`
3. **Throttles** with a 30-second cooldown to prevent thundering-herd clears from concurrent error storms

### Integration Points
- **SqlConnectionWrapperFactory** — catches transport errors on `InitializeAsync()` and invokes pool manager
- **SqlServerHealthCheck** — returns `Unhealthy` on transport errors (removes pod from LB rotation until recovery)
- **DI Registration** — singleton `SqlConnectionPoolManager` with `ISqlConnectionPoolResetter` abstraction for testability

## Expected Impact

Based on Kusto analysis: pool clear at T+5s would prevent ~73% of cascading errors per event.

## Testing

- 13 new unit tests covering all error codes, cooldown behavior, and edge cases
- All existing 107 tests continue to pass (109 total, 2 pre-existing skips)
