### PR TITLE
Add ISchemaWriteGate to allow schema worker to skip writes on read-only SQL secondaries

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/SchemaJobWorkerTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Schema/SchemaJobWorkerTests.cs
@@ -30,6 +30,7 @@ public sealed class SchemaJobWorkerTests : IDisposable
     private readonly IProcessTerminator _processTerminator;
     private readonly ILogger<SchemaJobWorker> _logger;
     private readonly ISchemaDataStore _schemaDataStore;
+    private readonly ISchemaWriteGate _writeGate;
     private readonly SchemaJobWorker _worker;
     private int _callCount;
     private readonly CancellationTokenSource _cts = new CancellationTokenSource(1000);
@@ -41,8 +42,11 @@ public sealed class SchemaJobWorkerTests : IDisposable
         _processTerminator = Substitute.For<IProcessTerminator>();
         _logger = NullLogger<SchemaJobWorker>.Instance;
         _schemaDataStore = Substitute.For<ISchemaDataStore>();
+        _writeGate = Substitute.For<ISchemaWriteGate>();
+        _writeGate.CanWriteAsync(default).ReturnsForAnyArgs(Task.FromResult(true));
         var collection = new ServiceCollection();
         collection.AddSingleton<ISchemaDataStore>(_schemaDataStore);
+        collection.AddSingleton<ISchemaWriteGate>(_writeGate);
         _serviceProvider = collection.BuildServiceProvider();
         _schemaDataStore.DeleteExpiredInstanceSchemaAsync(default).ReturnsForAnyArgs(Task.CompletedTask);
 
@@ -299,5 +303,108 @@ public sealed class SchemaJobWorkerTests : IDisposable
     {
         _cts.Dispose();
         GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task GivenWriteGateReturnsFalse_WhenExecuting_UpsertIsSkipped()
+    {
+        _writeGate.CanWriteAsync(default).ReturnsForAnyArgs(Task.FromResult(false));
+
+        SchemaInformation info = new SchemaInformation(1, 5);
+        info.Current = null;
+
+        _schemaDataStore.GetCurrentVersionAsync(default).ReturnsForAnyArgs(x =>
+        {
+#pragma warning disable CA1849
+            if (_callCount++ > 0)
+            {
+                _cts.Cancel();
+            }
+#pragma warning restore CA1849
+
+            return Task.FromResult(new List<CurrentVersionInformation>
+            {
+                new CurrentVersionInformation(3, SchemaVersionStatus.completed, new List<string> { "primary-pod" }),
+            });
+        });
+
+        try
+        {
+            await _worker.ExecuteAsync(info, "secondary-pod", _cts.Token);
+        }
+        catch (TaskCanceledException)
+        {
+        }
+
+        await _schemaDataStore.DidNotReceive().UpsertInstanceSchemaInformationAsync(Arg.Any<string>(), Arg.Any<SchemaInformation>(), Arg.Any<CancellationToken>());
+        Assert.Equal(3, info.Current);
+    }
+
+    [Fact]
+    public async Task GivenWriteGateReturnsTrue_WhenExecuting_UpsertIsPerformed()
+    {
+        _writeGate.CanWriteAsync(default).ReturnsForAnyArgs(Task.FromResult(true));
+
+        SchemaInformation info = new SchemaInformation(1, 5);
+        info.Current = null;
+
+        _schemaDataStore.UpsertInstanceSchemaInformationAsync(default, default, default).ReturnsForAnyArgs(x =>
+        {
+#pragma warning disable CA1849
+            if (_callCount++ > 0)
+            {
+                _cts.Cancel();
+            }
+#pragma warning restore CA1849
+
+            return Task.FromResult(3);
+        });
+
+        try
+        {
+            await _worker.ExecuteAsync(info, "secondary-pod", _cts.Token);
+        }
+        catch (TaskCanceledException)
+        {
+        }
+
+        await _schemaDataStore.Received().UpsertInstanceSchemaInformationAsync(Arg.Any<string>(), Arg.Any<SchemaInformation>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenWriteGateReturnsTrue_WhenUpsertThrows3906_ReadOnlyFallbackIsUsed()
+    {
+        _writeGate.CanWriteAsync(default).ReturnsForAnyArgs(Task.FromResult(true));
+
+        SchemaInformation info = new SchemaInformation(1, 5);
+        info.Current = null;
+
+        _schemaDataStore.UpsertInstanceSchemaInformationAsync(default, default, default).ReturnsForAnyArgs<int>(x =>
+        {
+#pragma warning disable CA1849
+            if (_callCount++ > 0)
+            {
+                _cts.Cancel();
+            }
+#pragma warning restore CA1849
+
+            throw SqlExceptionFactory.Create(SqlErrorCodes.ReadOnlyDatabase);
+        });
+
+        _schemaDataStore.GetCurrentVersionAsync(default).ReturnsForAnyArgs(
+            Task.FromResult(new List<CurrentVersionInformation>
+            {
+                new CurrentVersionInformation(3, SchemaVersionStatus.completed, new List<string> { "primary-pod" }),
+            }));
+
+        try
+        {
+            await _worker.ExecuteAsync(info, "secondary-pod", _cts.Token);
+        }
+        catch (TaskCanceledException)
+        {
+        }
+
+        Assert.Equal(3, info.Current);
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/DefaultSchemaWriteGate.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/DefaultSchemaWriteGate.cs
@@ -1,0 +1,14 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.SqlServer.Features.Schema;
+
+/// <summary>
+/// Default <see cref="ISchemaWriteGate"/> implementation that always permits writes.
+/// Used when geo-replication is not configured.
+/// </summary>
+internal sealed class DefaultSchemaWriteGate : ISchemaWriteGate
+{
+}

--- a/src/Microsoft.Health.SqlServer/Features/Schema/ISchemaWriteGate.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/ISchemaWriteGate.cs
@@ -1,0 +1,31 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.SqlServer.Features.Schema;
+
+/// <summary>
+/// A gate that controls whether the schema job worker is permitted to write instance schema information.
+/// </summary>
+/// <remarks>
+/// The default implementation returns <see langword="true"/>, which is appropriate for services that are
+/// not configured for geo-replication. Services using geo-replication should provide an implementation
+/// that returns <see langword="false"/> when the SQL database is a read-only secondary, so that the
+/// schema worker skips writes entirely rather than attempting a write against a read-only replica.
+/// </remarks>
+public interface ISchemaWriteGate
+{
+    /// <summary>
+    /// Determines whether the schema job worker is permitted to write instance schema information.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> if the write should proceed; <see langword="false"/> if the database
+    /// is a read-only secondary and the write should be skipped.
+    /// </returns>
+    Task<bool> CanWriteAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+}

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaJobWorker.cs
@@ -67,22 +67,36 @@ public class SchemaJobWorker
             {
                 using IServiceScope scope = _serviceProvider.CreateScope();
                 ISchemaDataStore schemaDataStore = scope.ServiceProvider.GetRequiredService<ISchemaDataStore>();
+                ISchemaWriteGate writeGate = scope.ServiceProvider.GetRequiredService<ISchemaWriteGate>();
 
                 int? previous = schemaInformation.Current;
                 bool isReadOnlyDatabase = false;
 
-                try
+                if (!await writeGate.CanWriteAsync(cancellationToken).ConfigureAwait(false))
                 {
-                    schemaInformation.Current = await schemaDataStore.UpsertInstanceSchemaInformationAsync(instanceName, schemaInformation, cancellationToken).ConfigureAwait(false);
-                }
-                catch (SqlException ex) when (ex.Number == SqlErrorCodes.ReadOnlyDatabase)
-                {
-                    // On a geo-replicated secondary, the database is read-only. The InstanceSchema
-                    // table is replicated from primary, so the secondary does not need to register.
-                    // Read the current schema version instead.
+                    // The gate indicates the database is a read-only secondary; skip the write entirely
+                    // to avoid a connection failure before the write reaches the server.
                     isReadOnlyDatabase = true;
-                    _logger.LogInformation("Database is read-only (geo-replication secondary). Skipping instance schema upsert.");
+                    _logger.LogInformation("Schema write gate returned false; database is a read-only secondary. Reading schema version from replicated data.");
+                }
+                else
+                {
+                    try
+                    {
+                        schemaInformation.Current = await schemaDataStore.UpsertInstanceSchemaInformationAsync(instanceName, schemaInformation, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (SqlException ex) when (ex.Number == SqlErrorCodes.ReadOnlyDatabase)
+                    {
+                        // Race condition: the gate returned true but the database became a read-only
+                        // secondary between the gate check and the write. Fall back to reading the
+                        // current schema version from the replicated data.
+                        isReadOnlyDatabase = true;
+                        _logger.LogInformation("Database is read-only (geo-replication secondary). Skipping instance schema write.");
+                    }
+                }
 
+                if (isReadOnlyDatabase)
+                {
                     var versions = await schemaDataStore.GetCurrentVersionAsync(cancellationToken).ConfigureAwait(false);
                     var completedVersions = versions
                         .Where(v => v.Status == SchemaVersionStatus.completed && v.Id <= schemaInformation.MaximumSupportedVersion)

--- a/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
+++ b/src/Microsoft.Health.SqlServer/Registration/SqlServerBaseRegistrationExtensions.cs
@@ -118,6 +118,7 @@ public static class SqlServerBaseRegistrationExtensions
 
         services.TryAddScoped<ISchemaDataStore, SqlServerSchemaDataStore>();
         services.TryAddSingleton<SchemaJobWorker>();
+        services.TryAddSingleton<ISchemaWriteGate, DefaultSchemaWriteGate>();
         services.TryAddSingleton<IScriptProvider, ScriptProvider<TVersion>>();
         services.TryAddSingleton<IBaseScriptProvider, BaseScriptProvider>();
         services.TryAddScoped<SchemaUpgradeRunner>();


### PR DESCRIPTION
## Description

Fixes a crash-loop bug in services using `SchemaJobWorker` when running against a geo-replication read-only SQL secondary.

**Root cause:** On a geo-replication secondary, Azure SQL routes connections to a read-only replica endpoint. `SchemaJobWorker` calls `UpsertInstanceSchemaInformationAsync` which fails at `connection.Open()` with SQL error 18456 (login routed away from writable endpoint) — *before* the existing `catch (SqlException) when (ex.Number == 3906)` can fire — causing pods to crash-loop on startup.

**Fix:** Introduces `ISchemaWriteGate` — a proactive guard that services can implement to signal whether the current SQL instance is writable. `SchemaJobWorker` resolves the gate from DI each iteration and skips the upsert if `CanWriteAsync()` returns `false`. The existing 3906 catch is retained as a race-condition fallback.

## Changes

- **`ISchemaWriteGate`** — new interface with a default method returning `true`, so services not configured for geo-replication need no changes
- **`DefaultSchemaWriteGate`** — no-op default implementation (always returns `true`), registered via `TryAddSingleton` in `AddSqlServerManagement`
- **`SchemaJobWorker`** — resolves `ISchemaWriteGate` from the DI scope each iteration; skips the upsert if the gate returns `false`

## Testing

- Unit tests added to `SchemaJobWorkerTests`:
  - Gate returns `false` → upsert skipped, schema read from replica
  - Gate returns `true` → normal upsert path
  - Gate returns `true` but 3906 thrown → race-condition fallback handled

## Notes

Companion PR in `dicom-server` wires a `SqlRoleSchemaWriteGate` implementation that delegates to `ISqlRoleDetector.IsPrimaryAsync()` (queries `sys.dm_geo_replication_link_status`, cached 1 min): https://microsofthealth.visualstudio.com/DefaultCollection/Health/_git/dicom-server/pullrequest/62147