### PR TITLE
AuditLoggingFilterAttribute - Null check validation

### DIFF
--- a/src/Microsoft.Health.Api.UnitTests/Features/Audit/AuditLoggingFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Api.UnitTests/Features/Audit/AuditLoggingFilterAttributeTests.cs
@@ -1,0 +1,63 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Health.Api.Features.Audit;
+using Microsoft.Health.Core.Features.Security;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Api.UnitTests.Features.Audit;
+
+public class AuditLoggingFilterAttributeTests
+{
+    [Fact]
+    public void GivenNoTimerInHttpContextItems_WhenOnResultExecuted_ThenNoExceptionIsThrown()
+    {
+        IClaimsExtractor claimsExtractor = Substitute.For<IClaimsExtractor>();
+        IAuditHelper auditHelper = Substitute.For<IAuditHelper>();
+        var auditLoggingFilterAttribute = new AuditLoggingFilterAttribute(claimsExtractor, auditHelper);
+
+        var httpContext = new DefaultHttpContext();
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var resultExecutedContext = new ResultExecutedContext(actionContext, new List<IFilterMetadata>(), new EmptyResult(), controller: null);
+
+        var exception = Record.Exception(() => auditLoggingFilterAttribute.OnResultExecuted(resultExecutedContext));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void GivenTimerAddedOnActionExecuting_WhenOnResultExecuted_ThenDurationIsLoggedFromTimer()
+    {
+        IClaimsExtractor claimsExtractor = Substitute.For<IClaimsExtractor>();
+        IAuditHelper auditHelper = Substitute.For<IAuditHelper>();
+        var auditLoggingFilterAttribute = new AuditLoggingFilterAttribute(claimsExtractor, auditHelper);
+
+        var httpContext = new DefaultHttpContext();
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+        var actionExecutingContext = new ActionExecutingContext(actionContext, new List<IFilterMetadata>(), new Dictionary<string, object>(), controller: null);
+        var resultExecutedContext = new ResultExecutedContext(actionContext, new List<IFilterMetadata>(), new EmptyResult(), controller: null);
+
+        auditLoggingFilterAttribute.OnActionExecuting(actionExecutingContext);
+
+        object timer = httpContext.Items["timer"];
+        Assert.IsType<Stopwatch>(timer);
+
+        Thread.Sleep(2);
+
+        auditLoggingFilterAttribute.OnResultExecuted(resultExecutedContext);
+
+        auditHelper.Received(1).LogExecuted(httpContext, claimsExtractor, Arg.Any<bool>(), Arg.Is<long?>(d => d.HasValue && d.Value > 0));
+    }
+}

--- a/src/Microsoft.Health.Api/Features/Audit/AuditLoggingFilterAttribute.cs
+++ b/src/Microsoft.Health.Api/Features/Audit/AuditLoggingFilterAttribute.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Health.Api.Features.Audit;
 [SuppressMessage("Performance", "CA1813:Avoid unsealed attributes", Justification = "This attribute is meant to be extended.")]
 public class AuditLoggingFilterAttribute : ActionFilterAttribute
 {
+    private const string TimerKey = "timer";
+
     public AuditLoggingFilterAttribute(
         IClaimsExtractor claimsExtractor,
         IAuditHelper auditHelper)
@@ -36,7 +38,7 @@ public class AuditLoggingFilterAttribute : ActionFilterAttribute
     {
         EnsureArg.IsNotNull(context, nameof(context));
 
-        context.HttpContext.Items["timer"] = Stopwatch.StartNew();
+        context.HttpContext.Items[TimerKey] = Stopwatch.StartNew();
 
         AuditHelper.LogExecuting(context.HttpContext, ClaimsExtractor);
 
@@ -54,8 +56,11 @@ public class AuditLoggingFilterAttribute : ActionFilterAttribute
     {
         EnsureArg.IsNotNull(context, nameof(context));
 
-        var stopwatch = (Stopwatch)context.HttpContext.Items["timer"];
-        long durationMs = stopwatch.ElapsedMilliseconds;
+        long durationMs = 0;
+        if (context.HttpContext.Items.TryGetValue(TimerKey, out object timerObj) && timerObj is Stopwatch stopwatch)
+        {
+            durationMs = stopwatch.ElapsedMilliseconds;
+        }
 
         AuditHelper.LogExecuted(context.HttpContext, ClaimsExtractor, durationMs: durationMs);
 


### PR DESCRIPTION
## Description

In an ASP.NET execution, if a MVC filter (_ActionFilterAttribute_) stops the execution of the request, ASP.NET still executes '_OnResultExecuted_' for all remaining filters. 

In those cases, if the method _OnActionExecuting_ of _AuditLoggingFilterAttribute_ was not executed, then it raises a null reference exception, as the element "_timer_" is not present in the _HttpContext_.

In this PR we are adding a new logic to handle the absence of "_timer_", and avoid the exception if a previous MVC filter stopped the request execution. 

## Related issues
Addresses [AB#188081](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/188081)

## Testing
- Validated through unit tests. 

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
