### PR TITLE
Expire stale ValueCache<HealthReport> so /health/check surfaces Unhealthy

### DIFF
--- a/src/Microsoft.Health.Api.UnitTests/Features/HealthCheck/CachedHealthCheckMiddlewareTests.cs
+++ b/src/Microsoft.Health.Api.UnitTests/Features/HealthCheck/CachedHealthCheckMiddlewareTests.cs
@@ -1,0 +1,104 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Time.Testing;
+using Microsoft.Health.Api.Features.HealthChecks;
+using Microsoft.Health.Core.Features.Health;
+using Xunit;
+
+namespace Microsoft.Health.Api.UnitTests.Features.HealthCheck;
+
+public class CachedHealthCheckMiddlewareTests
+{
+    [Fact]
+    public async Task GivenFreshHealthyReport_WhenInvoked_ThenReturns200()
+    {
+        ValueCache<HealthReport> cache = new ValueCache<HealthReport>();
+        cache.Set(CreateReport(HealthStatus.Healthy));
+
+        DefaultHttpContext httpContext = CreateHttpContext();
+
+        CachedHealthCheckMiddleware middleware = new CachedHealthCheckMiddleware(_ => Task.CompletedTask, cache);
+        await middleware.InvokeAsync(httpContext);
+
+        Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
+        Assert.Equal("Healthy", await ReadOverallStatusAsync(httpContext));
+    }
+
+    [Fact]
+    public async Task GivenFreshUnhealthyReport_WhenInvoked_ThenReturns503()
+    {
+        ValueCache<HealthReport> cache = new ValueCache<HealthReport>();
+        cache.Set(CreateReport(HealthStatus.Unhealthy));
+
+        DefaultHttpContext httpContext = CreateHttpContext();
+
+        CachedHealthCheckMiddleware middleware = new CachedHealthCheckMiddleware(_ => Task.CompletedTask, cache);
+        await middleware.InvokeAsync(httpContext);
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GivenStalePublishedReport_WhenInvoked_ThenReturns503AndUnhealthy()
+    {
+        // Reproduces the production scenario where the publisher last published a Healthy report long ago
+        // and stopped publishing new reports because each iteration is timing out / failing. With ValueCache
+        // expiry, the stale report is no longer served and the middleware surfaces an Unhealthy 503.
+        FakeTimeProvider timeProvider = new(DateTimeOffset.UtcNow);
+        ValueCache<HealthReport> cache = new ValueCache<HealthReport>(TimeSpan.FromMinutes(5), timeProvider);
+        cache.Set(CreateReport(HealthStatus.Healthy));
+
+        timeProvider.Advance(TimeSpan.FromHours(6));
+
+        DefaultHttpContext httpContext = CreateHttpContext();
+
+        CachedHealthCheckMiddleware middleware = new CachedHealthCheckMiddleware(_ => Task.CompletedTask, cache);
+        await middleware.InvokeAsync(httpContext);
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, httpContext.Response.StatusCode);
+        Assert.Equal("Unhealthy", await ReadOverallStatusAsync(httpContext));
+    }
+
+    private static HealthReport CreateReport(HealthStatus status)
+    {
+        return new HealthReport(
+            new Dictionary<string, HealthReportEntry>
+            {
+                ["TestCheck"] = new HealthReportEntry(status, description: "test", duration: TimeSpan.Zero, exception: null, data: null),
+            },
+            TimeSpan.FromMilliseconds(1));
+    }
+
+    private static DefaultHttpContext CreateHttpContext()
+    {
+        DefaultHttpContext httpContext = new DefaultHttpContext();
+        httpContext.Response.Body = new MemoryStream();
+        return httpContext;
+    }
+
+    private static async Task<string> ReadOverallStatusAsync(DefaultHttpContext httpContext)
+    {
+        httpContext.Response.Body.Position = 0;
+        using JsonDocument doc = await JsonDocument.ParseAsync(httpContext.Response.Body, cancellationToken: CancellationToken.None);
+        foreach (JsonProperty prop in doc.RootElement.EnumerateObject())
+        {
+            if (string.Equals(prop.Name, "OverallStatus", StringComparison.OrdinalIgnoreCase))
+            {
+                return prop.Value.GetString();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Microsoft.Health.Api/Features/HealthChecks/CachedHealthCheckMiddleware.cs
+++ b/src/Microsoft.Health.Api/Features/HealthChecks/CachedHealthCheckMiddleware.cs
@@ -38,12 +38,16 @@ internal class CachedHealthCheckMiddleware
     {
         EnsureArg.IsNotNull(httpContext, nameof(httpContext));
 
-        // Get results
+        // Get the latest published HealthReport. ValueCache returns null if the report has gone stale
+        // (i.e., no fresh report has been published within the configured expiry). When that happens we
+        // surface an Unhealthy response rather than continuing to serve a stale report indefinitely.
         HealthReport latestReport = await _healthCheckReportCache.GetAsync(httpContext.RequestAborted).ConfigureAwait(false);
 
-        if (!DefaultStatusCodesMapping.TryGetValue(latestReport.Status, out var statusCode))
+        HealthStatus overallStatus = latestReport?.Status ?? HealthStatus.Unhealthy;
+
+        if (!DefaultStatusCodesMapping.TryGetValue(overallStatus, out var statusCode))
         {
-            var message = $"No status code mapping found for {nameof(HealthStatus)} value: {latestReport.Status}.";
+            var message = $"No status code mapping found for {nameof(HealthStatus)} value: {overallStatus}.";
             throw new InvalidOperationException(message);
         }
 
@@ -53,6 +57,15 @@ internal class CachedHealthCheckMiddleware
 
     private static object FormatReport(HealthReport healthReport)
     {
+        if (healthReport == null)
+        {
+            return new
+            {
+                OverallStatus = HealthStatus.Unhealthy.ToString(),
+                Details = Enumerable.Empty<object>(),
+            };
+        }
+
         return new
         {
             OverallStatus = healthReport.Status.ToString(),

--- a/src/Microsoft.Health.Core.UnitTests/Features/Health/ValueCacheTests.cs
+++ b/src/Microsoft.Health.Core.UnitTests/Features/Health/ValueCacheTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using Microsoft.Health.Core.Features.Health;
 using Xunit;
@@ -137,5 +138,61 @@ public class ValueCacheTests
     public void GivenInfiniteExpiry_WhenConstructed_ThenSucceeds()
     {
         _ = new ValueCache<string>(Timeout.InfiniteTimeSpan);
+    }
+
+    [Fact]
+    public async Task GivenStaleCache_WhenGetAsync_ThenLogsWarning()
+    {
+        FakeTimeProvider timeProvider = new FakeTimeProvider();
+        TestLogger<ValueCache<string>> logger = new TestLogger<ValueCache<string>>();
+        ValueCache<string> cache = new ValueCache<string>(TimeSpan.FromMinutes(5), timeProvider, logger);
+
+        cache.Set("v1");
+        timeProvider.Advance(TimeSpan.FromMinutes(6));
+
+        string result = await cache.GetAsync();
+
+        Assert.Null(result);
+        LogEntry entry = Assert.Single(logger.Entries, e => e.Level == LogLevel.Warning);
+        Assert.Contains("stale", entry.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("String", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GivenFreshCache_WhenGetAsync_ThenDoesNotLog()
+    {
+        FakeTimeProvider timeProvider = new FakeTimeProvider();
+        TestLogger<ValueCache<string>> logger = new TestLogger<ValueCache<string>>();
+        ValueCache<string> cache = new ValueCache<string>(TimeSpan.FromMinutes(5), timeProvider, logger);
+
+        cache.Set("v1");
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+        string result = await cache.GetAsync();
+
+        Assert.Equal("v1", result);
+        Assert.Empty(logger.Entries);
+    }
+
+    private sealed record LogEntry(LogLevel Level, string Message);
+
+    private sealed class TestLogger<T> : ILogger<T>
+    {
+        public System.Collections.Generic.List<LogEntry> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }

--- a/src/Microsoft.Health.Core.UnitTests/Features/Health/ValueCacheTests.cs
+++ b/src/Microsoft.Health.Core.UnitTests/Features/Health/ValueCacheTests.cs
@@ -1,0 +1,141 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
+using Microsoft.Health.Core.Features.Health;
+using Xunit;
+
+namespace Microsoft.Health.Core.UnitTests.Features.Health;
+
+public class ValueCacheTests
+{
+    [Fact]
+    public async Task GivenNoExpiry_WhenSetAndGet_ThenReturnsValue()
+    {
+        ValueCache<string> cache = new ValueCache<string>();
+
+        cache.Set("hello");
+
+        string result = await cache.GetAsync();
+
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public async Task GivenNoExpiry_WhenLongDelayBetweenSetAndGet_ThenStillReturnsValue()
+    {
+        FakeTimeProvider timeProvider = new(DateTimeOffset.UtcNow);
+        ValueCache<string> cache = new ValueCache<string>(Timeout.InfiniteTimeSpan, timeProvider);
+
+        cache.Set("hello");
+        timeProvider.Advance(TimeSpan.FromDays(7));
+
+        string result = await cache.GetAsync();
+
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public async Task GivenExpiry_WhenValueIsFresh_ThenReturnsValue()
+    {
+        FakeTimeProvider timeProvider = new(DateTimeOffset.UtcNow);
+        ValueCache<string> cache = new ValueCache<string>(TimeSpan.FromMinutes(5), timeProvider);
+
+        cache.Set("hello");
+        timeProvider.Advance(TimeSpan.FromMinutes(2));
+
+        string result = await cache.GetAsync();
+
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public async Task GivenExpiry_WhenValueIsExactlyAtExpiry_ThenReturnsValue()
+    {
+        FakeTimeProvider timeProvider = new(DateTimeOffset.UtcNow);
+        ValueCache<string> cache = new ValueCache<string>(TimeSpan.FromMinutes(5), timeProvider);
+
+        cache.Set("hello");
+        timeProvider.Advance(TimeSpan.FromMinutes(5));
+
+        string result = await cache.GetAsync();
+
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public async Task GivenExpiry_WhenValueIsStale_ThenReturnsNull()
+    {
+        FakeTimeProvider timeProvider = new(DateTimeOffset.UtcNow);
+        ValueCache<string> cache = new ValueCache<string>(TimeSpan.FromMinutes(5), timeProvider);
+
+        cache.Set("hello");
+        timeProvider.Advance(TimeSpan.FromMinutes(5).Add(TimeSpan.FromTicks(1)));
+
+        string result = await cache.GetAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GivenExpiry_WhenSetIsCalledAgainBeforeExpiry_ThenReturnsLatestValue()
+    {
+        FakeTimeProvider timeProvider = new(DateTimeOffset.UtcNow);
+        ValueCache<string> cache = new ValueCache<string>(TimeSpan.FromMinutes(5), timeProvider);
+
+        cache.Set("first");
+        timeProvider.Advance(TimeSpan.FromMinutes(4));
+        cache.Set("second");
+        timeProvider.Advance(TimeSpan.FromMinutes(4));
+
+        string result = await cache.GetAsync();
+
+        Assert.Equal("second", result);
+    }
+
+    [Fact]
+    public async Task GivenExpiry_WhenSetIsCalledAfterExpiry_ThenFreshAgain()
+    {
+        FakeTimeProvider timeProvider = new(DateTimeOffset.UtcNow);
+        ValueCache<string> cache = new ValueCache<string>(TimeSpan.FromMinutes(5), timeProvider);
+
+        cache.Set("first");
+        timeProvider.Advance(TimeSpan.FromMinutes(10));
+
+        Assert.Null(await cache.GetAsync());
+
+        cache.Set("second");
+
+        Assert.Equal("second", await cache.GetAsync());
+    }
+
+    [Fact]
+    public async Task GivenNoSet_WhenGetWithCancellation_ThenThrows()
+    {
+        ValueCache<string> cache = new ValueCache<string>();
+        using CancellationTokenSource cts = new();
+
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cache.GetAsync(cts.Token));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void GivenNonPositiveExpiry_WhenConstructed_ThenThrows(int seconds)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ValueCache<string>(TimeSpan.FromSeconds(seconds)));
+    }
+
+    [Fact]
+    public void GivenInfiniteExpiry_WhenConstructed_ThenSucceeds()
+    {
+        _ = new ValueCache<string>(Timeout.InfiniteTimeSpan);
+    }
+}

--- a/src/Microsoft.Health.Core.UnitTests/Microsoft.Health.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Core.UnitTests/Microsoft.Health.Core.UnitTests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NSubstitute" />

--- a/src/Microsoft.Health.Core/Features/Health/HealthReportCachingOptions.cs
+++ b/src/Microsoft.Health.Core/Features/Health/HealthReportCachingOptions.cs
@@ -1,0 +1,29 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+
+namespace Microsoft.Health.Core.Features.Health;
+
+/// <summary>
+/// Options that control how the cached <see cref="Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport"/>
+/// published by <c>HealthCheckCachePublisher</c> is treated by readers (e.g. the cached health-check middleware).
+/// </summary>
+public class HealthReportCachingOptions
+{
+    /// <summary>
+    /// Gets or sets the maximum age of a published <c>HealthReport</c> before it is considered stale.
+    /// </summary>
+    /// <remarks>
+    /// When the most recent publish is older than this value, readers receive <see langword="null"/>
+    /// instead of the stale report and the cached health-check middleware responds with
+    /// <c>503 Service Unavailable</c>. This protects against the case where the publisher iteration
+    /// has stopped completing (for example, a health check whose underlying dependency is hanging or
+    /// throwing for longer than the publisher period). Set to <see cref="Timeout.InfiniteTimeSpan"/>
+    /// to disable expiry. Defaults to 5 minutes.
+    /// </remarks>
+    public TimeSpan Expiry { get; set; } = TimeSpan.FromMinutes(5);
+}

--- a/src/Microsoft.Health.Core/Features/Health/HealthReportCachingOptions.cs
+++ b/src/Microsoft.Health.Core/Features/Health/HealthReportCachingOptions.cs
@@ -23,7 +23,16 @@ public class HealthReportCachingOptions
     /// <c>503 Service Unavailable</c>. This protects against the case where the publisher iteration
     /// has stopped completing (for example, a health check whose underlying dependency is hanging or
     /// throwing for longer than the publisher period). Set to <see cref="Timeout.InfiniteTimeSpan"/>
-    /// to disable expiry. Defaults to 5 minutes.
+    /// to disable expiry.
     /// </remarks>
+    /// <value>
+    /// Defaults to 5 minutes. This is intentionally several multiples of the typical publisher
+    /// <c>Period</c> (30s&#8211;1m) so that a single slow or skipped publish iteration does not
+    /// flip the service to <c>503</c>, while still bounding how long a wedged publisher can keep
+    /// serving a stale <c>Healthy</c> report. Five minutes also comfortably exceeds the worst-case
+    /// duration of a single probe (for example, the ~225s SqlClient retry budget for a transient
+    /// login failure), leaving roughly one publish cycle of headroom before the cache is treated
+    /// as stale.
+    /// </value>
     public TimeSpan Expiry { get; set; } = TimeSpan.FromMinutes(5);
 }

--- a/src/Microsoft.Health.Core/Features/Health/ValueCache.cs
+++ b/src/Microsoft.Health.Core/Features/Health/ValueCache.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -13,16 +14,58 @@ namespace Microsoft.Health.Core.Features.Health;
 /// Caches a single value of type <typeparamref name="T"/>.
 /// Asynchronously waits for the data to be set before the data can be retrieved.
 /// </summary>
+/// <remarks>
+/// Optionally accepts an expiry. When an expiry is configured, <see cref="GetAsync"/> returns
+/// <see langword="null"/> if the most recent <see cref="Set"/> happened longer than the expiry
+/// ago. This allows callers to detect when the cache has gone stale because the producer is no
+/// longer publishing fresh values (for example, a health-check publisher whose underlying probes
+/// are timing out or throwing).
+/// </remarks>
 /// <typeparam name="T">The data type</typeparam>
 public class ValueCache<T> where T : class
 {
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _expiry;
     private volatile T _cachedData;
+    private long _lastSetUtcTicks;
     private readonly TaskCompletionSource _init = new TaskCompletionSource();
+
+    public ValueCache()
+        : this(Timeout.InfiniteTimeSpan, TimeProvider.System)
+    { }
+
+    public ValueCache(TimeSpan expiry)
+        : this(expiry, TimeProvider.System)
+    { }
+
+    internal ValueCache(TimeSpan expiry, TimeProvider timeProvider)
+    {
+        if (expiry != Timeout.InfiniteTimeSpan && expiry <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expiry), expiry, "Expiry must be positive or Timeout.InfiniteTimeSpan.");
+        }
+
+        _expiry = expiry;
+        _timeProvider = EnsureArg.IsNotNull(timeProvider, nameof(timeProvider));
+    }
 
     public async Task<T> GetAsync(CancellationToken cancellationToken = default)
     {
         await _init.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        return _cachedData;
+
+        T data = _cachedData;
+
+        if (_expiry != Timeout.InfiniteTimeSpan)
+        {
+            long lastSetTicks = Interlocked.Read(ref _lastSetUtcTicks);
+            DateTimeOffset lastSet = new DateTimeOffset(lastSetTicks, TimeSpan.Zero);
+            if (_timeProvider.GetUtcNow() - lastSet > _expiry)
+            {
+                return null;
+            }
+        }
+
+        return data;
     }
 
     public void Set(T cachedData)
@@ -30,6 +73,7 @@ public class ValueCache<T> where T : class
         EnsureArg.IsNotNull(cachedData, nameof(cachedData));
 
         _cachedData = cachedData;
+        Interlocked.Exchange(ref _lastSetUtcTicks, _timeProvider.GetUtcNow().UtcTicks);
 
         if (!_init.Task.IsCompleted)
         {

--- a/src/Microsoft.Health.Core/Features/Health/ValueCache.cs
+++ b/src/Microsoft.Health.Core/Features/Health/ValueCache.cs
@@ -9,6 +9,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.Health.Core.Features.Health;
 
@@ -31,19 +33,28 @@ public class ValueCache<T> where T : class
 {
     private readonly TimeProvider _timeProvider;
     private readonly TimeSpan _expiry;
+    private readonly ILogger<ValueCache<T>> _logger;
     private volatile T? _cachedData;
     private long _lastSetUtcTicks;
     private readonly TaskCompletionSource _init = new TaskCompletionSource();
 
     public ValueCache()
-        : this(Timeout.InfiniteTimeSpan, TimeProvider.System)
+        : this(Timeout.InfiniteTimeSpan, TimeProvider.System, NullLogger<ValueCache<T>>.Instance)
     { }
 
     public ValueCache(TimeSpan expiry)
-        : this(expiry, TimeProvider.System)
+        : this(expiry, TimeProvider.System, NullLogger<ValueCache<T>>.Instance)
+    { }
+
+    public ValueCache(TimeSpan expiry, ILogger<ValueCache<T>> logger)
+        : this(expiry, TimeProvider.System, logger)
     { }
 
     internal ValueCache(TimeSpan expiry, TimeProvider timeProvider)
+        : this(expiry, timeProvider, NullLogger<ValueCache<T>>.Instance)
+    { }
+
+    internal ValueCache(TimeSpan expiry, TimeProvider timeProvider, ILogger<ValueCache<T>> logger)
     {
         if (expiry != Timeout.InfiniteTimeSpan && expiry <= TimeSpan.Zero)
         {
@@ -52,6 +63,7 @@ public class ValueCache<T> where T : class
 
         _expiry = expiry;
         _timeProvider = EnsureArg.IsNotNull(timeProvider, nameof(timeProvider));
+        _logger = EnsureArg.IsNotNull(logger, nameof(logger));
     }
 
     /// <summary>
@@ -72,8 +84,14 @@ public class ValueCache<T> where T : class
         {
             long lastSetTicks = Interlocked.Read(ref _lastSetUtcTicks);
             DateTimeOffset lastSet = new DateTimeOffset(lastSetTicks, TimeSpan.Zero);
-            if (_timeProvider.GetUtcNow() - lastSet > _expiry)
+            TimeSpan age = _timeProvider.GetUtcNow() - lastSet;
+            if (age > _expiry)
             {
+                _logger.LogWarning(
+                    "ValueCache<{ValueType}> returning null: cached value is stale (age {AgeSeconds:F1}s exceeds expiry {ExpirySeconds:F1}s). The producer has not refreshed the cache within the expiry window.",
+                    typeof(T).Name,
+                    age.TotalSeconds,
+                    _expiry.TotalSeconds);
                 return null;
             }
         }

--- a/src/Microsoft.Health.Core/Features/Health/ValueCache.cs
+++ b/src/Microsoft.Health.Core/Features/Health/ValueCache.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+#nullable enable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,14 +21,17 @@ namespace Microsoft.Health.Core.Features.Health;
 /// <see langword="null"/> if the most recent <see cref="Set"/> happened longer than the expiry
 /// ago. This allows callers to detect when the cache has gone stale because the producer is no
 /// longer publishing fresh values (for example, a health-check publisher whose underlying probes
-/// are timing out or throwing).
+/// are timing out or throwing). When constructed with the parameterless constructor (or with
+/// <see cref="Timeout.InfiniteTimeSpan"/>), the cache never expires and <see cref="GetAsync"/>
+/// only returns <see langword="null"/> in the trivial case where <typeparamref name="T"/> itself
+/// is null (which is prevented by <see cref="Set"/>'s <see cref="EnsureArg"/> guard).
 /// </remarks>
 /// <typeparam name="T">The data type</typeparam>
 public class ValueCache<T> where T : class
 {
     private readonly TimeProvider _timeProvider;
     private readonly TimeSpan _expiry;
-    private volatile T _cachedData;
+    private volatile T? _cachedData;
     private long _lastSetUtcTicks;
     private readonly TaskCompletionSource _init = new TaskCompletionSource();
 
@@ -49,11 +54,19 @@ public class ValueCache<T> where T : class
         _timeProvider = EnsureArg.IsNotNull(timeProvider, nameof(timeProvider));
     }
 
-    public async Task<T> GetAsync(CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Returns the most recently <see cref="Set"/> value, asynchronously waiting until <see cref="Set"/>
+    /// has been called at least once.
+    /// </summary>
+    /// <returns>
+    /// The cached value, or <see langword="null"/> if an expiry was configured and the most recent
+    /// <see cref="Set"/> is older than the expiry.
+    /// </returns>
+    public async Task<T?> GetAsync(CancellationToken cancellationToken = default)
     {
         await _init.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-        T data = _cachedData;
+        T? data = _cachedData;
 
         if (_expiry != Timeout.InfiniteTimeSpan)
         {

--- a/src/Microsoft.Health.Core/Features/HealthPublisher/HealthCheckPublisherExtensions.cs
+++ b/src/Microsoft.Health.Core/Features/HealthPublisher/HealthCheckPublisherExtensions.cs
@@ -8,6 +8,7 @@ using EnsureThat;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.HealthPublisher;
 using Microsoft.Health.Core.Features.Metric;
 
@@ -15,16 +16,25 @@ namespace Microsoft.Health.Core.Features.Health;
 
 public static class HealthCheckPublisherExtensions
 {
-    public static IServiceCollection AddHealthCheckCachePublisher(this IServiceCollection services, Action<HealthCheckPublisherOptions> configure = null)
+    public static IServiceCollection AddHealthCheckCachePublisher(this IServiceCollection services, Action<HealthCheckPublisherOptions> configure = null, Action<HealthReportCachingOptions> configureReportCache = null)
     {
         EnsureArg.IsNotNull(configure, nameof(configure));
 
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthCheckPublisher, HealthCheckCachePublisher>());
-        services.AddSingleton<ValueCache<HealthReport>>();
+        services.AddSingleton<ValueCache<HealthReport>>(sp =>
+        {
+            HealthReportCachingOptions reportCacheOptions = sp.GetService<IOptions<HealthReportCachingOptions>>()?.Value ?? new HealthReportCachingOptions();
+            return new ValueCache<HealthReport>(reportCacheOptions.Expiry);
+        });
 
         if (configure != null)
         {
             services.Configure(configure);
+        }
+
+        if (configureReportCache != null)
+        {
+            services.Configure(configureReportCache);
         }
 
         return services;

--- a/src/Microsoft.Health.Core/Features/HealthPublisher/HealthCheckPublisherExtensions.cs
+++ b/src/Microsoft.Health.Core/Features/HealthPublisher/HealthCheckPublisherExtensions.cs
@@ -8,6 +8,8 @@ using EnsureThat;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.HealthPublisher;
 using Microsoft.Health.Core.Features.Metric;
@@ -24,7 +26,8 @@ public static class HealthCheckPublisherExtensions
         services.AddSingleton<ValueCache<HealthReport>>(sp =>
         {
             HealthReportCachingOptions reportCacheOptions = sp.GetService<IOptions<HealthReportCachingOptions>>()?.Value ?? new HealthReportCachingOptions();
-            return new ValueCache<HealthReport>(reportCacheOptions.Expiry);
+            ILogger<ValueCache<HealthReport>> logger = sp.GetService<ILogger<ValueCache<HealthReport>>>() ?? NullLogger<ValueCache<HealthReport>>.Instance;
+            return new ValueCache<HealthReport>(reportCacheOptions.Expiry, logger);
         });
 
         if (configure != null)


### PR DESCRIPTION
## Summary

Add an expiry to `ValueCache<HealthReport>` so the cached aggregate health report is no longer served indefinitely after the publisher stops publishing fresh reports.

## Background — production scenario

In a Microsoft DICOM Server production deployment, a tenant's SQL database was deleted. After that, the affected pod's `/health/check` endpoint kept returning **200 OK** for **6+ days** even though every internal SQL probe was failing.

What we expected: the per-check `HealthCheckResultCache` would expire, the framework's `HealthCheckService.CheckHealthAsync` would convert the per-check exception into an Unhealthy entry, `HealthCheckCachePublisher.PublishAsync` would write a new Unhealthy report, and the middleware would return 503.

What actually happens: `SqlServerHealthCheck` issues a SQL retry storm that takes 30s+ to fail. The publisher's iteration is cancelled / aborted before the aggregate report is produced, so `PublishAsync` is never called with a fresh report. `ValueCache<HealthReport>` has **no expiry**, so the **6-day-old Healthy report** keeps being served by `CachedHealthCheckMiddleware`.

By contrast, a freshly-started pod returns 503 correctly because `ValueCache<HealthReport>` has not been `Set` yet.

## Fix

1. **`ValueCache<T>`** — add a constructor that accepts a `TimeSpan expiry`. When configured, `GetAsync` returns `null` if the latest `Set` happened longer than the expiry ago. The default constructor preserves the existing infinite-cache behavior, so all current `ValueCache<CustomerKeyHealth>` callers are unaffected.
2. **`HealthReportCachingOptions`** — new options class controlling the expiry of the published `HealthReport` (default 5 minutes; set `Timeout.InfiniteTimeSpan` to disable).
3. **`AddHealthCheckCachePublisher`** — registers `ValueCache<HealthReport>` with the configured expiry; new optional `Action<HealthReportCachingOptions> configureReportCache` parameter is additive (existing callers unchanged).
4. **`CachedHealthCheckMiddleware`** — when `GetAsync` returns `null` (stale), returns `503 Service Unavailable` with a synthetic Unhealthy body. This makes a long-lived pod whose publisher has gone silent behave the same as a brand-new pod whose publisher has not yet succeeded.

## Tests

All passing on net8.0, net9.0, net10.0.

- New `ValueCacheTests` covering fresh / stale / refresh-after-expiry / cancellation / argument validation.
- New `CachedHealthCheckMiddlewareTests` covering fresh Healthy → 200, fresh Unhealthy → 503, and the regression: stale published Healthy report → 503 with `OverallStatus = "Unhealthy"`.
- All existing `Microsoft.Health.Core.UnitTests` (47/47) and `Microsoft.Health.Api.UnitTests` (78/78) still pass.

## Out of scope

The upstream `SqlServerHealthCheck` swallowing only `IsCMKError` / `IsInvalidAccess` and propagating SQL retry-exhaustion exceptions (login-failure 18456, etc.) is a related but separate concern and not part of this PR.

## Compatibility

- `ValueCache<T>()` default constructor unchanged — infinite cache.
- `ValueCache<CustomerKeyHealth>` callers unaffected.
- `AddHealthCheckCachePublisher` adds an optional second parameter; existing call sites keep working.
- Default `HealthReportCachingOptions.Expiry` of 5 minutes is the only behavioral change for existing consumers of `AddHealthCheckCachePublisher`. Set `Expiry = Timeout.InfiniteTimeSpan` to opt out.
