### PR TITLE
Bound SqlServerHealthCheck with a per-probe timeout so failures publish before the publisher's outer timeout fires

### DIFF
--- a/src/Microsoft.Health.SqlServer.UnitTests/Features/Health/SqlServerHealthCheckTests.cs
+++ b/src/Microsoft.Health.SqlServer.UnitTests/Features/Health/SqlServerHealthCheckTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -79,8 +80,94 @@ public sealed class SqlServerHealthCheckTests
         // Setting up the ObtainSqlConnectionWrapperAsync method to throw an exception.
         connectionWrapperFactory.ObtainSqlConnectionWrapperAsync(Arg.Any<CancellationToken>()).Returns(Task.FromException<SqlConnectionWrapper>(httpRequestException));
 
-        var sqlHealthCheck = new SqlServerHealthCheck(connectionWrapperFactory, _cache, _logger);
+        var sqlHealthCheck = new SqlServerHealthCheck(connectionWrapperFactory, _cache, _sqlServerDataStoreConfiguration, _logger);
 
         return await sqlHealthCheck.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task GivenASqlHealthCheck_WhenSqlConnectionWrapperThrowsLoginFailure_ThenReturnsUnhealthyWithException()
+    {
+        // SQL error 18456 = "Login failed for user" — what happens when the database is deleted.
+        SqlException loginFailure = SqlExceptionFactory.Create(18456, "Login failed for user 'svc'. The database does not exist.");
+
+        SqlConnectionWrapperFactory connectionWrapperFactory = Substitute.For<SqlConnectionWrapperFactory>(
+            _sqlTransactionHandler,
+            _sqlConnectionBuilder,
+            _sqlRetryLogicBaseProvider,
+            _sqlServerDataStoreConfiguration);
+
+        connectionWrapperFactory.ObtainSqlConnectionWrapperAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SqlConnectionWrapper>(loginFailure));
+
+        var sqlHealthCheck = new SqlServerHealthCheck(connectionWrapperFactory, _cache, _sqlServerDataStoreConfiguration, _logger);
+
+        HealthCheckResult result = await sqlHealthCheck.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Same(loginFailure, result.Exception);
+        Assert.Equal(HealthStatusReason.DataStoreConnectionDegraded.ToString(), result.Data["Reason"]);
+    }
+
+    [Fact]
+    public async Task GivenASqlHealthCheck_WhenProbeExceedsConfiguredTimeout_ThenReturnsUnhealthy()
+    {
+        var configWithShortTimeout = new SqlServerDataStoreConfiguration
+        {
+            HealthCheckProbeTimeout = TimeSpan.FromMilliseconds(50),
+        };
+        IOptions<SqlServerDataStoreConfiguration> options = Substitute.For<IOptions<SqlServerDataStoreConfiguration>>();
+        options.Value.Returns(configWithShortTimeout);
+
+        SqlConnectionWrapperFactory connectionWrapperFactory = Substitute.For<SqlConnectionWrapperFactory>(
+            _sqlTransactionHandler,
+            _sqlConnectionBuilder,
+            _sqlRetryLogicBaseProvider,
+            _sqlServerDataStoreConfiguration);
+
+        // Simulate the SQL wrapper hanging until its token is cancelled (the probe-internal CTS will trip).
+        connectionWrapperFactory.ObtainSqlConnectionWrapperAsync(Arg.Any<CancellationToken>())
+            .Returns(async callInfo =>
+            {
+                CancellationToken token = callInfo.Arg<CancellationToken>();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token).ConfigureAwait(false);
+                return null;
+            });
+
+        var sqlHealthCheck = new SqlServerHealthCheck(connectionWrapperFactory, _cache, options, _logger);
+
+        HealthCheckResult result = await sqlHealthCheck.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("timeout", result.Description, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(HealthStatusReason.DataStoreConnectionDegraded.ToString(), result.Data["Reason"]);
+    }
+
+    [Fact]
+    public async Task GivenASqlHealthCheck_WhenCallerCancels_ThenOperationCanceledExceptionPropagates()
+    {
+        // When the framework's outer token cancels (the caller), we must NOT swallow it — the
+        // framework's hosted service relies on OCE propagation to distinguish "publisher cancelled
+        // the batch" from a real health failure.
+        SqlConnectionWrapperFactory connectionWrapperFactory = Substitute.For<SqlConnectionWrapperFactory>(
+            _sqlTransactionHandler,
+            _sqlConnectionBuilder,
+            _sqlRetryLogicBaseProvider,
+            _sqlServerDataStoreConfiguration);
+
+        connectionWrapperFactory.ObtainSqlConnectionWrapperAsync(Arg.Any<CancellationToken>())
+            .Returns(async callInfo =>
+            {
+                CancellationToken token = callInfo.Arg<CancellationToken>();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token).ConfigureAwait(false);
+                return null;
+            });
+
+        var sqlHealthCheck = new SqlServerHealthCheck(connectionWrapperFactory, _cache, _sqlServerDataStoreConfiguration, _logger);
+
+        using var callerCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => sqlHealthCheck.CheckHealthAsync(new HealthCheckContext(), callerCts.Token));
     }
 }

--- a/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -67,6 +67,17 @@ public class SqlServerDataStoreConfiguration
     public TimeSpan CommandTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
+    /// Specifies a per-probe timeout for the SQL data store health check.
+    /// The SQL probe is a fast liveness check, not a real workload, so it should not be allowed
+    /// to inherit the full retry / connect-timeout budget of normal SQL operations. If the probe
+    /// has not completed within this window the underlying SQL call is cancelled and the health
+    /// check returns <see cref="Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy"/>
+    /// with diagnostics, ensuring the failure is published before the framework's
+    /// <c>HealthCheckPublisherOptions.Timeout</c> cancels the entire publish batch.
+    /// </summary>
+    public TimeSpan HealthCheckProbeTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
     /// If set, the maximum number of connections allowed in the pool to use when connecting to SQL.
     /// </summary>
     public int? MaxPoolSize { get; set; }

--- a/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Health/SqlServerHealthCheck.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
@@ -11,43 +12,65 @@ using EnsureThat;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Health;
 using Microsoft.Health.Encryption.Customer.Health;
+using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.SqlServer.Features.Health;
 
 /// <summary>
-/// An <see cref="IHealthCheck"/> implementation that verifies connectivity to the SQL database
+/// An <see cref="IHealthCheck"/> implementation that verifies connectivity to the SQL database.
 /// </summary>
+/// <remarks>
+/// The probe is bounded by <see cref="SqlServerDataStoreConfiguration.HealthCheckProbeTimeout"/> so
+/// that a deleted/unreachable database (which can otherwise exhaust the SqlClient connect-timeout
+/// plus retry budget for ~70s) cannot consume the full
+/// <c>HealthCheckPublisherOptions.Timeout</c> and cause the publisher to skip publishing the
+/// resulting failure. When the probe times out or any <see cref="SqlException"/> escapes, the
+/// check returns <see cref="HealthStatus.Unhealthy"/> with the underlying exception attached so
+/// the published <see cref="HealthReport"/> contains real diagnostics.
+/// </remarks>
 public class SqlServerHealthCheck : StorageHealthCheck
 {
     private readonly ILogger<SqlServerHealthCheck> _logger;
     private readonly SqlConnectionWrapperFactory _sqlConnectionWrapperFactory;
+    private readonly TimeSpan _probeTimeout;
 
     public SqlServerHealthCheck(
         SqlConnectionWrapperFactory sqlConnectionWrapperFactory,
         ValueCache<CustomerKeyHealth> customerKeyHealthCache,
+        IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
         ILogger<SqlServerHealthCheck> logger)
         : base(customerKeyHealthCache, logger)
     {
         _sqlConnectionWrapperFactory = EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+
+        EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
+        _probeTimeout = sqlServerDataStoreConfiguration.Value.HealthCheckProbeTimeout;
     }
 
     public override async Task<HealthCheckResult> CheckStorageHealthAsync(CancellationToken cancellationToken)
     {
+        using CancellationTokenSource probeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (_probeTimeout > TimeSpan.Zero && _probeTimeout != Timeout.InfiniteTimeSpan)
+        {
+            probeCts.CancelAfter(_probeTimeout);
+        }
+
         try
         {
             _logger.LogInformation($"Performing health check for {nameof(SqlServerHealthCheck)}");
 
-            using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken).ConfigureAwait(false);
+            using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(probeCts.Token).ConfigureAwait(false);
             using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
 
             sqlCommandWrapper.CommandText = "select @@DBTS";
 
-            await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            await sqlCommandWrapper.ExecuteScalarAsync(probeCts.Token).ConfigureAwait(false);
 
             _logger.LogInformation("Successfully connected to SQL database.");
 
@@ -78,6 +101,35 @@ public class SqlServerHealthCheck : StorageHealthCheck
                 DegradedDescription,
                 sqlEx,
                 new Dictionary<string, object> { { "Reason", reason.ToString() } });
+        }
+        catch (OperationCanceledException) when (probeCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            // The probe exceeded its per-probe budget (the caller did not cancel). Surface this as
+            // Unhealthy so the publisher can record and ship a real failure instead of waiting for
+            // the framework's outer timeout to fire (which would skip publishing entirely).
+            _logger.LogWarning("SQL health check probe exceeded its timeout of {ProbeTimeoutSeconds}s.", _probeTimeout.TotalSeconds);
+
+            return new HealthCheckResult(
+                HealthStatus.Unhealthy,
+                description: $"SQL health check probe exceeded its timeout of {_probeTimeout.TotalSeconds}s.",
+                exception: null,
+                data: new Dictionary<string, object> { { "Reason", HealthStatusReason.DataStoreConnectionDegraded.ToString() } });
+        }
+        catch (SqlException sqlEx)
+        {
+            // Any other SqlException (login failure on deleted DB, connection refused, timeout, etc.).
+            // Convert to Unhealthy explicitly so the publisher gets a real Unhealthy entry with the
+            // underlying exception attached. Without this, the exception would propagate out of
+            // CheckHealthAsync and be either (a) converted by the framework into Unhealthy (fine, but
+            // only if cancellation has not been requested) or (b) lost entirely if the publisher's
+            // outer token has already cancelled.
+            _logger.LogWarning(sqlEx, "SQL health check failed with SqlException (Number={SqlErrorNumber}).", sqlEx.Number);
+
+            return new HealthCheckResult(
+                HealthStatus.Unhealthy,
+                description: "Failed to connect to SQL database.",
+                exception: sqlEx,
+                data: new Dictionary<string, object> { { "Reason", HealthStatusReason.DataStoreConnectionDegraded.ToString() } });
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes a production scenario where `/health/check` returns 200 OK even though the SQL database has been deleted, because the publisher pipeline never gets a chance to publish the failure.

## Root cause
1. `SqlServerHealthCheck` issues a SQL query against the deleted DB.
2. SqlClient's connect-timeout (30s) plus retry policy (`ConnectRetryCount` + `ConnectRetryInterval`) can take **70+ seconds** for a single failed connection attempt.
3. The framework's `HealthCheckPublisherHostedService` creates a linked `CancellationTokenSource` bounded by `HealthCheckPublisherOptions.Timeout` (default 30s).
4. The SQL retry exhaustion consumes the entire budget; the outer token cancels mid-probe.
5. The framework distinguishes "cancellation" from "exception": when `cancellationToken.IsCancellationRequested == true`, the `OperationCanceledException` is **not** converted into `HealthStatus.Unhealthy`. It propagates up to the hosted service, which treats the whole batch as cancelled — `PublishAsync` is **never called**.
6. The previously cached `HealthReport` (`Healthy`) stays in `ValueCache<HealthReport>` indefinitely, so `CachedHealthCheckMiddleware` keeps returning 200.

## Fix
- New `SqlServerDataStoreConfiguration.HealthCheckProbeTimeout` (default 10s).
- `SqlServerHealthCheck.CheckStorageHealthAsync` now wraps the SQL call in a linked `CancellationTokenSource` with `CancelAfter(HealthCheckProbeTimeout)`. Failing fast inside the publisher's budget guarantees the result reaches `PublishAsync`.
- Any `SqlException` that escapes the probe is converted to `HealthCheckResult.Unhealthy(...)` explicitly, with the `SqlException` attached so consumers see real diagnostics.
- A probe-timeout `OperationCanceledException` (where the caller did **not** cancel) is converted to `Unhealthy` with a clear description.
- Caller-initiated cancellation (the framework's outer token) is still allowed to propagate as `OperationCanceledException`, preserving the hosted service's "cancelled batch vs real failure" distinction.

## Test plan
- 3 new unit tests in `SqlServerHealthCheckTests`:
  - login-failure (`SqlException` 18456) → `Unhealthy` with the exception attached.
  - probe exceeds configured timeout → `Unhealthy` with timeout description.
  - caller cancels → `OperationCanceledException` propagates (not swallowed).
- Existing tests still pass.
- Build clean (0 warnings, 0 errors).
- `dotnet test src/Microsoft.Health.SqlServer.UnitTests` → 100/100 (+2 skipped) on net8/9/10.

## Related
Complements #1425 (`ValueCache<HealthReport>` expiry as a generic safety net for any publisher hang). This PR fixes the SQL-specific root cause; #1425 catches anything else that can wedge the publisher.