### PR TITLE
Catch Aggregate exception

### DIFF
--- a/src/Microsoft.Health.Encryption.UnitTests/KeyWrapUnwrapTestProviderTests.cs
+++ b/src/Microsoft.Health.Encryption.UnitTests/KeyWrapUnwrapTestProviderTests.cs
@@ -52,7 +52,7 @@ public class KeyWrapUnwrapTestProviderTests
     public async Task GivenKeyVaultDnsFailure_WhenAssertHealthAsync_ThenUnhealthyReturned()
     {
         // Arrange
-        const string aggregateMessage = "Retry failed after 4 tries. Retry settings can be adjusted in ClientOptions.Retry or by configuring a custom retry policy in ClientOptions.RetryPolicy. (Name or service not known (czm282606251up-kv.vault.azure.net:443)) (Name or service not known (czm282606251up-kv.vault.azure.net:443)) (Name or service not known (czm282606251up-kv.vault.azure.net:443)) (Name or service not known (czm282606251up-kv.vault.azure.net:443))";
+        const string aggregateMessage = "Retry failed after 4 tries. Retry settings can be adjusted in ClientOptions.Retry or by configuring a custom retry policy in ClientOptions.RetryPolicy. (Name or service not known (name-kv.vault.azure.net:443)) (Name or service not known (name-kv.vault.azure.net:443)) (Name or service not known (name-kv.vault.azure.net:443)) (Name or service not known (name-kv.vault.azure.net:443))";
 
         var innerException = new HttpRequestException("Name or service not known (name-kv.vault.azure.net:443)");
         var aggregateException = new AggregateException(aggregateMessage, innerException, innerException, innerException, innerException);
@@ -62,7 +62,7 @@ public class KeyWrapUnwrapTestProviderTests
             .ThrowsAsync(aggregateException);
 
         var cmkOptions = Substitute.For<IOptions<CustomerManagedKeyOptions>>();
-        cmkOptions.Value.Returns(new CustomerManagedKeyOptions { KeyName = "test-key", KeyVaultUri = new Uri("https://czm282606251up-kv.vault.azure.net") });
+        cmkOptions.Value.Returns(new CustomerManagedKeyOptions { KeyName = "test-key", KeyVaultUri = new Uri("https://name-kv.vault.azure.net") });
 
         var provider = new KeyWrapUnwrapTestProvider(mockKeyClient, cmkOptions, NullLogger<KeyWrapUnwrapTestProvider>.Instance);
 

--- a/src/Microsoft.Health.Encryption.UnitTests/KeyWrapUnwrapTestProviderTests.cs
+++ b/src/Microsoft.Health.Encryption.UnitTests/KeyWrapUnwrapTestProviderTests.cs
@@ -3,8 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Identity;
+using Azure.Security.KeyVault.Keys;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Health;
@@ -12,6 +16,7 @@ using Microsoft.Health.Core.Features.Identity;
 using Microsoft.Health.Encryption.Customer.Configs;
 using Microsoft.Health.Encryption.Customer.Health;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Microsoft.Health.Encryption.UnitTests;
@@ -41,5 +46,32 @@ public class KeyWrapUnwrapTestProviderTests
         Assert.True(health.IsHealthy);
         Assert.Equal(HealthStatusReason.None, health.Reason);
         Assert.Null(health.Exception);
+    }
+
+    [Fact]
+    public async Task GivenKeyVaultDnsFailure_WhenAssertHealthAsync_ThenUnhealthyReturned()
+    {
+        // Arrange
+        const string aggregateMessage = "Retry failed after 4 tries. Retry settings can be adjusted in ClientOptions.Retry or by configuring a custom retry policy in ClientOptions.RetryPolicy. (Name or service not known (czm282606251up-kv.vault.azure.net:443)) (Name or service not known (czm282606251up-kv.vault.azure.net:443)) (Name or service not known (czm282606251up-kv.vault.azure.net:443)) (Name or service not known (czm282606251up-kv.vault.azure.net:443))";
+
+        var innerException = new HttpRequestException("Name or service not known (name-kv.vault.azure.net:443)");
+        var aggregateException = new AggregateException(aggregateMessage, innerException, innerException, innerException, innerException);
+
+        KeyClient mockKeyClient = Substitute.For<KeyClient>();
+        mockKeyClient.GetKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(aggregateException);
+
+        var cmkOptions = Substitute.For<IOptions<CustomerManagedKeyOptions>>();
+        cmkOptions.Value.Returns(new CustomerManagedKeyOptions { KeyName = "test-key", KeyVaultUri = new Uri("https://czm282606251up-kv.vault.azure.net") });
+
+        var provider = new KeyWrapUnwrapTestProvider(mockKeyClient, cmkOptions, NullLogger<KeyWrapUnwrapTestProvider>.Instance);
+
+        // Act
+        CustomerKeyHealth health = await provider.AssertHealthAsync();
+
+        // Assert
+        Assert.False(health.IsHealthy);
+        Assert.Equal(HealthStatusReason.CustomerManagedKeyAccessLost, health.Reason);
+        Assert.IsType<AggregateException>(health.Exception);
     }
 }

--- a/src/Microsoft.Health.Encryption.UnitTests/KeyWrapUnwrapTestProviderTests.cs
+++ b/src/Microsoft.Health.Encryption.UnitTests/KeyWrapUnwrapTestProviderTests.cs
@@ -4,11 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.Identity;
-using Azure.Security.KeyVault.Keys;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Health;
@@ -16,7 +13,6 @@ using Microsoft.Health.Core.Features.Identity;
 using Microsoft.Health.Encryption.Customer.Configs;
 using Microsoft.Health.Encryption.Customer.Health;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Microsoft.Health.Encryption.UnitTests;
@@ -51,20 +47,15 @@ public class KeyWrapUnwrapTestProviderTests
     [Fact]
     public async Task GivenKeyVaultDnsFailure_WhenAssertHealthAsync_ThenUnhealthyReturned()
     {
-        // Arrange
-        const string aggregateMessage = "Retry failed after 4 tries. Retry settings can be adjusted in ClientOptions.Retry or by configuring a custom retry policy in ClientOptions.RetryPolicy. (Name or service not known (name-kv.vault.azure.net:443)) (Name or service not known (name-kv.vault.azure.net:443)) (Name or service not known (name-kv.vault.azure.net:443)) (Name or service not known (name-kv.vault.azure.net:443))";
-
-        var innerException = new HttpRequestException("Name or service not known (name-kv.vault.azure.net:443)");
-        var aggregateException = new AggregateException(aggregateMessage, innerException, innerException, innerException, innerException);
-
-        KeyClient mockKeyClient = Substitute.For<KeyClient>();
-        mockKeyClient.GetKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(aggregateException);
-
+        // Arrange - use a non-existent Key Vault URI to trigger a real DNS failure
         var cmkOptions = Substitute.For<IOptions<CustomerManagedKeyOptions>>();
-        cmkOptions.Value.Returns(new CustomerManagedKeyOptions { KeyName = "test-key", KeyVaultUri = new Uri("https://name-kv.vault.azure.net") });
+        cmkOptions.Value.Returns(new CustomerManagedKeyOptions
+        {
+            KeyName = "test-key",
+            KeyVaultUri = new Uri("https://does-not-exist-kv.vault.azure.net"),
+        });
 
-        var provider = new KeyWrapUnwrapTestProvider(mockKeyClient, cmkOptions, NullLogger<KeyWrapUnwrapTestProvider>.Instance);
+        var provider = new KeyWrapUnwrapTestProvider(_externalCredentialProvider, cmkOptions, NullLogger<KeyWrapUnwrapTestProvider>.Instance);
 
         // Act
         CustomerKeyHealth health = await provider.AssertHealthAsync();
@@ -72,6 +63,6 @@ public class KeyWrapUnwrapTestProviderTests
         // Assert
         Assert.False(health.IsHealthy);
         Assert.Equal(HealthStatusReason.CustomerManagedKeyAccessLost, health.Reason);
-        Assert.IsType<AggregateException>(health.Exception);
+        Assert.NotNull(health.Exception);
     }
 }

--- a/src/Microsoft.Health.Encryption/Customer/Health/KeyWrapUnwrapTestProvider.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/KeyWrapUnwrapTestProvider.cs
@@ -46,6 +46,18 @@ internal class KeyWrapUnwrapTestProvider : IKeyTestProvider
         }
     }
 
+    internal KeyWrapUnwrapTestProvider(
+        KeyClient keyClient,
+        IOptions<CustomerManagedKeyOptions> cmkOptions,
+        ILogger<KeyWrapUnwrapTestProvider> logger)
+    {
+        EnsureArg.IsNotNull(cmkOptions, nameof(cmkOptions));
+
+        _keyClient = EnsureArg.IsNotNull(keyClient, nameof(keyClient));
+        _customerManagedKeyOptions = EnsureArg.IsNotNull(cmkOptions.Value, nameof(cmkOptions.Value));
+        _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+    }
+
     public async Task<CustomerKeyHealth> AssertHealthAsync(CancellationToken cancellationToken = default)
     {
         if (_keyClient == null)
@@ -71,14 +83,23 @@ internal class KeyWrapUnwrapTestProvider : IKeyTestProvider
         }
         catch (Exception ex) when (ex is RequestFailedException or CryptographicException or InvalidOperationException or NotSupportedException)
         {
-            _logger.LogInformation(ex, AccessLostMessage);
-
-            return new CustomerKeyHealth
-            {
-                IsHealthy = false,
-                Reason = HealthStatusReason.CustomerManagedKeyAccessLost,
-                Exception = ex,
-            };
+            return HandleKeyAccessFailure(ex);
         }
+        catch (AggregateException ex) when (ex.Message.Contains("vault.azure.net", StringComparison.OrdinalIgnoreCase))
+        {
+            return HandleKeyAccessFailure(ex);
+        }
+    }
+
+    private CustomerKeyHealth HandleKeyAccessFailure(Exception ex)
+    {
+        _logger.LogInformation(ex, AccessLostMessage);
+
+        return new CustomerKeyHealth
+        {
+            IsHealthy = false,
+            Reason = HealthStatusReason.CustomerManagedKeyAccessLost,
+            Exception = ex,
+        };
     }
 }

--- a/src/Microsoft.Health.Encryption/Customer/Health/KeyWrapUnwrapTestProvider.cs
+++ b/src/Microsoft.Health.Encryption/Customer/Health/KeyWrapUnwrapTestProvider.cs
@@ -46,18 +46,6 @@ internal class KeyWrapUnwrapTestProvider : IKeyTestProvider
         }
     }
 
-    internal KeyWrapUnwrapTestProvider(
-        KeyClient keyClient,
-        IOptions<CustomerManagedKeyOptions> cmkOptions,
-        ILogger<KeyWrapUnwrapTestProvider> logger)
-    {
-        EnsureArg.IsNotNull(cmkOptions, nameof(cmkOptions));
-
-        _keyClient = EnsureArg.IsNotNull(keyClient, nameof(keyClient));
-        _customerManagedKeyOptions = EnsureArg.IsNotNull(cmkOptions.Value, nameof(cmkOptions.Value));
-        _logger = EnsureArg.IsNotNull(logger, nameof(logger));
-    }
-
     public async Task<CustomerKeyHealth> AssertHealthAsync(CancellationToken cancellationToken = default)
     {
         if (_keyClient == null)
@@ -81,11 +69,9 @@ internal class KeyWrapUnwrapTestProvider : IKeyTestProvider
 
             return new CustomerKeyHealth();
         }
-        catch (Exception ex) when (ex is RequestFailedException or CryptographicException or InvalidOperationException or NotSupportedException)
-        {
-            return HandleKeyAccessFailure(ex);
-        }
-        catch (AggregateException ex) when (ex.Message.Contains("vault.azure.net", StringComparison.OrdinalIgnoreCase))
+        catch (Exception ex) when (
+            ex is RequestFailedException or CryptographicException or InvalidOperationException or NotSupportedException
+            || (ex is AggregateException aggregate && aggregate.Message.Contains("vault.azure.net", StringComparison.OrdinalIgnoreCase) && aggregate.Message.Contains("Name or service not known", StringComparison.OrdinalIgnoreCase)))
         {
             return HandleKeyAccessFailure(ex);
         }


### PR DESCRIPTION
## Description
When a customer's Key Vault DNS is unresolvable (returns "Name or service not known"), the StorageInitializedHealthCheck returns Unhealthy (503) instead of Degraded (200) with a CMK-related message.

A DNS resolution failure throws HttpRequestException (wrapping SocketException: Name or service not known), which the Azure SDK retry policy wraps in AggregateException. Neither type is in the catch filter, so the exception escapes to CustomerKeyValidationBackgroundService.CheckHealth(), which resets the CMK health cache to healthy by design ("unexpected errors should not be categorized as customer misconfiguration"). This causes StorageInitializedHealthCheck to conclude CMK is fine and return Unhealthy (503) — when the correct response is Degraded (200).

## Impact
AKS readiness probes see 503 → pods get pulled from service
Customer gets full outage instead of a graceful degraded state indicating a CMK misconfiguration
Masks the real issue (Key Vault unreachable) behind a generic "storage not initialized" error

## Example of exception:
exception type: System.AggregateException
exception message: Retry failed after 4 tries. Retry settings can be adjusted in ClientOptions.Retry or by configuring a custom retry policy in ClientOptions.RetryPolicy. (Name or service not known (name-kv.vault.azure.net:443)) (Name or service not known (name-kv.vault.azure.net:443)) (Name or service not known (name-kv.vault.azure.net:443)) (Name or service not known (name-kv.vault.azure.net:443))

## Related issues
Addresses [issue #196329](https://microsofthealth.visualstudio.com/Health/_workitems/edit/196329).
## Testing
Added unit test

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
