### PR TITLE
Prevent command injection in release action

### DIFF
--- a/.github/actions/dotnet-build/action.yml
+++ b/.github/actions/dotnet-build/action.yml
@@ -28,11 +28,7 @@ runs:
 
   - name: 'Install Azure Functions Core Tools'
     shell: bash
-    run: |
-      npm install --global azure-functions-core-tools@4 ` 
-        --unsafe-perm=true ` 
-        --registry=https://registry.npmjs.org/ ` 
-        --userconfig=/dev/null
+    run: npm install --global azure-functions-core-tools@4 --unsafe-perm=true --registry=https://registry.npmjs.org/ --userconfig=/dev/null
 
   - name: 'Start Azurite'
     shell: bash

--- a/.github/actions/dotnet-build/action.yml
+++ b/.github/actions/dotnet-build/action.yml
@@ -29,16 +29,28 @@ runs:
   - name: 'Install Azure Functions Core Tools'
     shell: bash
     run: |
-      functionsVersion=4.9.0
-      archive="$RUNNER_TEMP/Azure.Functions.Cli.linux-x64.$functionsVersion.zip"
+      release=$(gh api 'repos/Azure/azure-functions-core-tools/releases?per_page=100' \
+        --jq 'map(select(.draft == false and .prerelease == false and (.tag_name | test("^4\\.")))) | first')
+      asset=$(jq -c '.assets[] | select(.name | test("^Azure\\.Functions\\.Cli\\.linux-x64\\.4\\.[0-9.]+\\.zip$"))' <<< "$release")
+      assetName=$(jq -r '.name' <<< "$asset")
+      assetUrl=$(jq -r '.browser_download_url' <<< "$asset")
+      expectedDigest=$(jq -r '.digest | sub("^sha256:"; "")' <<< "$asset")
+
+      if [[ -z "$assetName" || -z "$assetUrl" || ! "$expectedDigest" =~ ^[0-9a-f]{64}$ ]]; then
+        echo "Unable to resolve the latest stable Azure Functions Core Tools 4.x release." >&2
+        exit 1
+      fi
+
+      archive="$RUNNER_TEMP/$assetName"
       installDirectory="$RUNNER_TEMP/azure-functions-core-tools"
-      curl --fail --location --retry 3 --output "$archive" \
-        "https://github.com/Azure/azure-functions-core-tools/releases/download/$functionsVersion/Azure.Functions.Cli.linux-x64.$functionsVersion.zip"
-      echo "2bf6409dd0a15b4210159da2b407265e8e193cd4ebeeafb0ed126420675142ce  $archive" | sha256sum --check
+      curl --fail --location --retry 3 --output "$archive" "$assetUrl"
+      echo "$expectedDigest  $archive" | sha256sum --check
       mkdir --parents "$installDirectory"
       unzip -q "$archive" -d "$installDirectory"
       chmod +x "$installDirectory/func"
       echo "$installDirectory" >> "$GITHUB_PATH"
+    env:
+      GH_TOKEN: ${{ github.token }}
 
   - name: 'Start Azurite'
     shell: bash

--- a/.github/actions/dotnet-build/action.yml
+++ b/.github/actions/dotnet-build/action.yml
@@ -29,6 +29,7 @@ runs:
   - name: 'Install Azure Functions Core Tools'
     shell: bash
     run: |
+      # npm 4.14.0 references a private Azure Artifacts feed; use release assets until upstream issue #5569 is fixed.
       release=$(gh api 'repos/Azure/azure-functions-core-tools/releases?per_page=100' \
         --jq 'map(select(.draft == false and .prerelease == false and (.tag_name | test("^4\\.")))) | first')
       asset=$(jq -c '.assets[] | select(.name | test("^Azure\\.Functions\\.Cli\\.linux-x64\\.4\\.[0-9.]+\\.zip$"))' <<< "$release")

--- a/.github/actions/dotnet-build/action.yml
+++ b/.github/actions/dotnet-build/action.yml
@@ -28,7 +28,11 @@ runs:
 
   - name: 'Install Azure Functions Core Tools'
     shell: bash
-    run: npm i -g azure-functions-core-tools@4 --unsafe-perm true
+    run: |
+      npm install --global azure-functions-core-tools@4 ` 
+        --unsafe-perm=true ` 
+        --registry=https://registry.npmjs.org/ ` 
+        --userconfig=/dev/null
 
   - name: 'Start Azurite'
     shell: bash

--- a/.github/actions/dotnet-build/action.yml
+++ b/.github/actions/dotnet-build/action.yml
@@ -28,7 +28,17 @@ runs:
 
   - name: 'Install Azure Functions Core Tools'
     shell: bash
-    run: npm install --global azure-functions-core-tools@4 --unsafe-perm=true --registry=https://registry.npmjs.org/ --userconfig=/dev/null
+    run: |
+      functionsVersion=4.9.0
+      archive="$RUNNER_TEMP/Azure.Functions.Cli.linux-x64.$functionsVersion.zip"
+      installDirectory="$RUNNER_TEMP/azure-functions-core-tools"
+      curl --fail --location --retry 3 --output "$archive" \
+        "https://github.com/Azure/azure-functions-core-tools/releases/download/$functionsVersion/Azure.Functions.Cli.linux-x64.$functionsVersion.zip"
+      echo "2bf6409dd0a15b4210159da2b407265e8e193cd4ebeeafb0ed126420675142ce  $archive" | sha256sum --check
+      mkdir --parents "$installDirectory"
+      unzip -q "$archive" -d "$installDirectory"
+      chmod +x "$installDirectory/func"
+      echo "$installDirectory" >> "$GITHUB_PATH"
 
   - name: 'Start Azurite'
     shell: bash

--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -27,16 +27,21 @@ runs:
     shell: bash
     run: |
       # Read first line of title
-      readarray -t lines <<< "${{ inputs.title }}"
+      readarray -t lines <<< "$RELEASE_TITLE"
 
-      gh release create "${{ inputs.tag }}" \
-        --repo "${{ inputs.repository }}" \
-        --target ${{ inputs.commitSha }} \
+      gh release create "$RELEASE_TAG" \
+        --repo "$REPOSITORY" \
+        --target "$COMMIT_SHA" \
         --title "${lines[0]}" \
         --generate-notes
 
-      for pkg in ${{ inputs.packageFolder }}/*.nupkg; do
-          gh release upload "${{ inputs.tag }}" $pkg --repo "${{ inputs.repository }}" --clobber
+      for pkg in "$PACKAGE_FOLDER"/*.nupkg; do
+          gh release upload "$RELEASE_TAG" "$pkg" --repo "$REPOSITORY" --clobber
       done
     env:
+      COMMIT_SHA: ${{ inputs.commitSha }}
       GITHUB_TOKEN: ${{ inputs.gitHubToken }}
+      PACKAGE_FOLDER: ${{ inputs.packageFolder }}
+      RELEASE_TAG: ${{ inputs.tag }}
+      RELEASE_TITLE: ${{ inputs.title }}
+      REPOSITORY: ${{ inputs.repository }}


### PR DESCRIPTION
Pass composite action inputs through environment variables before using them in Bash, and quote all expansions to prevent command substitution and word splitting from release metadata.

[AB#205474](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/205474)

## Description
Describe the changes in this PR.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## [Semver Change](https://github.com/microsoft/healthcare-shared-components/blob/main/docs/Versioning.md)
Patch|Skip|Feature|Breaking
