### PR TITLE
Gate SqlSchemaManager.ApplySchema on ISchemaWriteGate

### DIFF
--- a/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/Manager/SqlSchemaManager.cs
@@ -14,6 +14,8 @@ using EnsureThat;
 using Medino;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema.Extensions;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Exceptions;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Model;
@@ -28,6 +30,10 @@ public class SqlSchemaManager : ISchemaManager
     private readonly ISchemaClient _schemaClient;
     private readonly ILogger<SqlSchemaManager> _logger;
     private readonly IMediator _mediator;
+    private readonly ISchemaWriteGate _schemaWriteGate;
+    private readonly ISchemaMetrics _schemaMetrics;
+    private readonly string _databaseName;
+    private readonly string _region;
 
     private const int RetryAttempts = 3;
 
@@ -36,13 +42,22 @@ public class SqlSchemaManager : ISchemaManager
         ISchemaManagerDataStore schemaManagerDataStore,
         ISchemaClient schemaClient,
         IMediator mediator,
+        ISchemaWriteGate schemaWriteGate,
+        ISchemaMetrics schemaMetrics,
+        IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
         ILogger<SqlSchemaManager> logger)
     {
         _baseSchemaRunner = EnsureArg.IsNotNull(baseSchemaRunner, nameof(baseSchemaRunner));
         _schemaManagerDataStore = EnsureArg.IsNotNull(schemaManagerDataStore, nameof(schemaManagerDataStore));
         _schemaClient = EnsureArg.IsNotNull(schemaClient, nameof(schemaClient));
         _mediator = EnsureArg.IsNotNull(mediator, nameof(mediator));
+        _schemaWriteGate = EnsureArg.IsNotNull(schemaWriteGate, nameof(schemaWriteGate));
+        _schemaMetrics = EnsureArg.IsNotNull(schemaMetrics, nameof(schemaMetrics));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+
+        SqlServerDataStoreConfiguration configuration = EnsureArg.IsNotNull(sqlServerDataStoreConfiguration?.Value, nameof(sqlServerDataStoreConfiguration));
+        _region = configuration.Region;
+        _databaseName = TryGetDatabaseName(configuration.ConnectionString);
     }
 
     internal TimeSpan RetrySleepDuration { get; set; } = TimeSpan.FromSeconds(20);
@@ -51,6 +66,18 @@ public class SqlSchemaManager : ISchemaManager
     public virtual async Task ApplySchema(MutuallyExclusiveType type, bool force = false, CancellationToken token = default)
     {
         EnsureArg.IsNotNull(type, nameof(type));
+
+        // On a read-only geo-replication secondary the schema is replicated from the primary and
+        // cannot be advanced from here, so ISchemaWriteGate returns false. Checking the gate before
+        // any of the calls below (which can perform DDL, e.g. EnsureBaseSchemaExistsAsync) ensures a
+        // role transition cannot race with an unsafe secondary write. Services not configured for
+        // geo-replication get the default gate, which always permits writes, preserving existing
+        // behavior for non-geo resources and databases without a replication link.
+        if (!await _schemaWriteGate.CanWriteAsync(token).ConfigureAwait(false))
+        {
+            await ReportReadOnlySecondaryAsync(token).ConfigureAwait(false);
+            return;
+        }
 
         try
         {
@@ -297,5 +324,56 @@ public class SqlSchemaManager : ISchemaManager
         int latestVersion = await _schemaManagerDataStore.GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation("Latest schema version in db is : {Version}", latestVersion);
         return latestVersion;
+    }
+
+    // Reports the state of a write denied by ISchemaWriteGate, sharing status determination, log
+    // messages, and metrics with SchemaInitializer via SchemaWriteGateDiagnostics. The current and
+    // maximum supported versions are fetched best-effort: on failure (for example, the base schema
+    // does not exist yet), the status falls back to Unknown so this method never throws, since the
+    // apply command must still return successfully as a no-op.
+    private async Task ReportReadOnlySecondaryAsync(CancellationToken cancellationToken)
+    {
+        int? currentVersion = null;
+        int? maximumSupportedVersion = null;
+
+        try
+        {
+            currentVersion = await _schemaManagerDataStore.GetCurrentSchemaVersionAsync(cancellationToken).ConfigureAwait(false);
+
+            List<AvailableVersion> availableVersions = await _schemaClient.GetAvailabilityAsync(cancellationToken).ConfigureAwait(false);
+            if (availableVersions != null && availableVersions.Count > 0)
+            {
+                maximumSupportedVersion = availableVersions[^1].Id;
+            }
+        }
+        catch (Exception ex) when (ex is SchemaManagerException or HttpRequestException or SqlException)
+        {
+            _logger.LogWarning(ex, "Unable to determine the current schema version while the write gate denied writes.");
+        }
+
+        SecondarySchemaStatus status = SchemaWriteGateDiagnostics.GetSecondarySchemaStatus(currentVersion, maximumSupportedVersion);
+        SchemaWriteGateDiagnostics.LogReadOnlySecondaryStatus(_logger, status, currentVersion, maximumSupportedVersion);
+
+        if (status == SecondarySchemaStatus.Behind)
+        {
+            _schemaMetrics.SchemaBehind(_databaseName, currentVersion.Value, _region);
+        }
+    }
+
+    private static string TryGetDatabaseName(string connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return null;
+        }
+
+        try
+        {
+            return new SqlConnectionStringBuilder(connectionString).InitialCatalog;
+        }
+        catch (Exception ex) when (ex is ArgumentException or FormatException or KeyNotFoundException)
+        {
+            return null;
+        }
     }
 }

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -193,7 +193,7 @@ public sealed class SchemaInitializer : IHostedService
         }
 
         SecondarySchemaStatus status = GetSecondarySchemaStatus(_schemaInformation.Current, _schemaInformation.MaximumSupportedVersion);
-        LogReadOnlySecondarySchemaStatus(status);
+        SchemaWriteGateDiagnostics.LogReadOnlySecondaryStatus(_logger, status, _schemaInformation.Current, _schemaInformation.MaximumSupportedVersion);
 
         if (status == SecondarySchemaStatus.Behind)
         {
@@ -203,47 +203,10 @@ public sealed class SchemaInitializer : IHostedService
         return false;
     }
 
-    internal static SecondarySchemaStatus GetSecondarySchemaStatus(int? currentVersion, int maximumSupportedVersion)
-    {
-        if (!currentVersion.HasValue)
-        {
-            return SecondarySchemaStatus.Unknown;
-        }
-
-        if (currentVersion < maximumSupportedVersion)
-        {
-            return SecondarySchemaStatus.Behind;
-        }
-
-        return currentVersion > maximumSupportedVersion ? SecondarySchemaStatus.Ahead : SecondarySchemaStatus.Current;
-    }
-
-    private void LogReadOnlySecondarySchemaStatus(SecondarySchemaStatus status)
-    {
-        switch (status)
-        {
-            case SecondarySchemaStatus.Unknown:
-                _logger.LogWarning("Schema write gate denied writes (read-only geo-replication secondary), but the current schema version could not be determined. Skipping schema upgrade.");
-                break;
-            case SecondarySchemaStatus.Behind:
-                _logger.LogInformation(
-                    "Schema write gate denied writes (read-only geo-replication secondary). Schema is behind. Current version: {CurrentVersion}; latest supported version: {LatestVersion}. Skipping schema upgrade.",
-                    _schemaInformation.Current,
-                    _schemaInformation.MaximumSupportedVersion);
-                break;
-            case SecondarySchemaStatus.Ahead:
-                _logger.LogWarning(
-                    "Schema write gate denied writes (read-only geo-replication secondary). The replicated schema (version {CurrentVersion}) is newer than the maximum version supported by this instance ({LatestVersion}); this instance may be running outdated code. Skipping schema upgrade.",
-                    _schemaInformation.Current,
-                    _schemaInformation.MaximumSupportedVersion);
-                break;
-            default:
-                _logger.LogInformation(
-                    "Schema write gate denied writes (read-only geo-replication secondary). Schema is current at version {CurrentVersion}. Skipping schema upgrade.",
-                    _schemaInformation.Current);
-                break;
-        }
-    }
+    // Delegates to the logic shared with SqlSchemaManager, the other independent schema-write path
+    // in this package, so both report identical status for a given (current, maximum) version pair.
+    internal static SecondarySchemaStatus GetSecondarySchemaStatus(int? currentVersion, int? maximumSupportedVersion)
+        => SchemaWriteGateDiagnostics.GetSecondarySchemaStatus(currentVersion, maximumSupportedVersion);
 
     private async Task GetCurrentSchemaVersionAsync(CancellationToken cancellationToken)
     {

--- a/src/Microsoft.Health.SqlServer/Features/Schema/SchemaWriteGateDiagnostics.cs
+++ b/src/Microsoft.Health.SqlServer/Features/Schema/SchemaWriteGateDiagnostics.cs
@@ -1,0 +1,69 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Health.SqlServer.Features.Schema;
+
+/// <summary>
+/// Shared logic for reporting the state of a read-only geo-replication secondary once
+/// <see cref="ISchemaWriteGate"/> has denied a write. Used by both <see cref="SchemaInitializer"/>
+/// and <see cref="Manager.SqlSchemaManager"/> so the two independent schema-write paths in this
+/// package produce identical status determination, log messages, and metrics.
+/// </summary>
+internal static class SchemaWriteGateDiagnostics
+{
+    /// <summary>
+    /// Compares the replicated schema version against the maximum version supported by the running
+    /// instance to describe the state of a read-only geo-replication secondary.
+    /// </summary>
+    /// <param name="currentVersion">The schema version currently applied to the database, if known.</param>
+    /// <param name="maximumSupportedVersion">The maximum schema version supported by the running instance, if known.</param>
+    public static SecondarySchemaStatus GetSecondarySchemaStatus(int? currentVersion, int? maximumSupportedVersion)
+    {
+        if (!currentVersion.HasValue || !maximumSupportedVersion.HasValue)
+        {
+            return SecondarySchemaStatus.Unknown;
+        }
+
+        if (currentVersion < maximumSupportedVersion)
+        {
+            return SecondarySchemaStatus.Behind;
+        }
+
+        return currentVersion > maximumSupportedVersion ? SecondarySchemaStatus.Ahead : SecondarySchemaStatus.Current;
+    }
+
+    /// <summary>
+    /// Logs the outcome of a write denied by <see cref="ISchemaWriteGate"/>, using the given
+    /// <paramref name="status"/> to select the appropriate level and message.
+    /// </summary>
+    public static void LogReadOnlySecondaryStatus(ILogger logger, SecondarySchemaStatus status, int? currentVersion, int? maximumSupportedVersion)
+    {
+        switch (status)
+        {
+            case SecondarySchemaStatus.Unknown:
+                logger.LogWarning("Schema write gate denied writes (read-only geo-replication secondary), but the current schema version could not be determined. Skipping schema upgrade.");
+                break;
+            case SecondarySchemaStatus.Behind:
+                logger.LogInformation(
+                    "Schema write gate denied writes (read-only geo-replication secondary). Schema is behind. Current version: {CurrentVersion}; latest supported version: {LatestVersion}. Skipping schema upgrade.",
+                    currentVersion,
+                    maximumSupportedVersion);
+                break;
+            case SecondarySchemaStatus.Ahead:
+                logger.LogWarning(
+                    "Schema write gate denied writes (read-only geo-replication secondary). The replicated schema (version {CurrentVersion}) is newer than the maximum version supported by this instance ({LatestVersion}); this instance may be running outdated code. Skipping schema upgrade.",
+                    currentVersion,
+                    maximumSupportedVersion);
+                break;
+            default:
+                logger.LogInformation(
+                    "Schema write gate denied writes (read-only geo-replication secondary). Schema is current at version {CurrentVersion}. Skipping schema upgrade.",
+                    currentVersion);
+                break;
+        }
+    }
+}

--- a/test/SchemaManager.UnitTests/SqlSchemaManagerTests.cs
+++ b/test/SchemaManager.UnitTests/SqlSchemaManagerTests.cs
@@ -9,6 +9,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Medino;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.SqlServer.Configs;
+using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Exceptions;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Model;
@@ -24,12 +27,28 @@ public class SqlSchemaManagerTests
     private readonly ISchemaClient _client = Substitute.For<ISchemaClient>();
     private readonly IBaseSchemaRunner _baseSchemaRunner = Substitute.For<IBaseSchemaRunner>();
     private readonly IMediator _mediator = Substitute.For<IMediator>();
+    private readonly ISchemaWriteGate _schemaWriteGate = Substitute.For<ISchemaWriteGate>();
+    private readonly ISchemaMetrics _schemaMetrics = Substitute.For<ISchemaMetrics>();
 
     public SqlSchemaManagerTests()
     {
         _baseSchemaRunner.EnsureBaseSchemaExistsAsync(default).ReturnsForAnyArgs(Task.FromResult(true));
         _baseSchemaRunner.EnsureInstanceSchemaRecordExistsAsync(default).ReturnsForAnyArgs(Task.FromResult(true));
-        _sqlSchemaManager = new SqlSchemaManager(_baseSchemaRunner, _schemaManagerDataStore, _client, _mediator, NullLogger<SqlSchemaManager>.Instance);
+        _schemaWriteGate.CanWriteAsync(default).ReturnsForAnyArgs(Task.FromResult(true));
+        _sqlSchemaManager = CreateSchemaManager(_schemaWriteGate, _schemaMetrics);
+    }
+
+    private SqlSchemaManager CreateSchemaManager(ISchemaWriteGate schemaWriteGate, ISchemaMetrics schemaMetrics, string region = null)
+    {
+        return new SqlSchemaManager(
+            _baseSchemaRunner,
+            _schemaManagerDataStore,
+            _client,
+            _mediator,
+            schemaWriteGate,
+            schemaMetrics,
+            Options.Create(new SqlServerDataStoreConfiguration { ConnectionString = "Server=(local);Database=TestDb;", Region = region }),
+            NullLogger<SqlSchemaManager>.Instance);
     }
 
     [Fact]
@@ -178,5 +197,76 @@ public class SqlSchemaManagerTests
         await _sqlSchemaManager.ApplySchema(new MutuallyExclusiveType { Latest = false, Version = 2, Next = false });
 
         await _schemaManagerDataStore.DidNotReceive().ExecuteScriptAndCompleteSchemaVersionAsync(Arg.Is("script"), Arg.Is(2), Arg.Is(false), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenWriteGateReturnsFalse_WhenApplySchema_ThenSkipsWithoutApplyingAnySchema()
+    {
+        _schemaWriteGate.CanWriteAsync(default).ReturnsForAnyArgs(Task.FromResult(false));
+
+        await _sqlSchemaManager.ApplySchema(new MutuallyExclusiveType { Latest = true });
+
+        await _baseSchemaRunner.DidNotReceiveWithAnyArgs().EnsureBaseSchemaExistsAsync(default);
+        await _schemaManagerDataStore.DidNotReceiveWithAnyArgs().ExecuteScriptAndCompleteSchemaVersionAsync(default, default, default, default);
+    }
+
+    [Fact]
+    public async Task GivenWriteGateReturnsFalseAndSchemaBehind_WhenApplySchema_ThenEmitsSchemaBehindMetric()
+    {
+        SqlSchemaManager sqlSchemaManager = CreateSchemaManager(FalseGate(), _schemaMetrics, region: "eastus2");
+        _schemaManagerDataStore.GetCurrentSchemaVersionAsync(default).ReturnsForAnyArgs(Task.FromResult(3));
+        _client.GetAvailabilityAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new List<AvailableVersion> { new AvailableVersion(3, "_script/3.sql", "_script/3.diff.sql"), new AvailableVersion(5, "_script/5.sql", "_script/5.diff.sql") });
+
+        await sqlSchemaManager.ApplySchema(new MutuallyExclusiveType { Latest = true });
+
+        _schemaMetrics.Received(1).SchemaBehind(Arg.Any<string>(), 3, "eastus2");
+    }
+
+    [Theory]
+    [InlineData(5)] // current
+    [InlineData(7)] // ahead
+    public async Task GivenWriteGateReturnsFalseAndSchemaNotBehind_WhenApplySchema_ThenDoesNotEmitMetric(int currentVersion)
+    {
+        SqlSchemaManager sqlSchemaManager = CreateSchemaManager(FalseGate(), _schemaMetrics);
+        _schemaManagerDataStore.GetCurrentSchemaVersionAsync(default).ReturnsForAnyArgs(Task.FromResult(currentVersion));
+        _client.GetAvailabilityAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new List<AvailableVersion> { new AvailableVersion(5, "_script/5.sql", "_script/5.diff.sql") });
+
+        await sqlSchemaManager.ApplySchema(new MutuallyExclusiveType { Latest = true });
+
+        _schemaMetrics.DidNotReceiveWithAnyArgs().SchemaBehind(default, default, default);
+    }
+
+    [Fact]
+    public async Task GivenWriteGateReturnsFalseAndAvailabilityLookupFails_WhenApplySchema_ThenSkipsWithoutThrowing()
+    {
+        SqlSchemaManager sqlSchemaManager = CreateSchemaManager(FalseGate(), _schemaMetrics);
+        _schemaManagerDataStore.GetCurrentSchemaVersionAsync(default).ReturnsForAnyArgs(Task.FromResult(3));
+        _client.GetAvailabilityAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(Task.FromException<List<AvailableVersion>>(new SchemaManagerException("unavailable")));
+
+        await sqlSchemaManager.ApplySchema(new MutuallyExclusiveType { Latest = true });
+
+        _schemaMetrics.DidNotReceiveWithAnyArgs().SchemaBehind(default, default, default);
+        await _schemaManagerDataStore.DidNotReceiveWithAnyArgs().ExecuteScriptAndCompleteSchemaVersionAsync(default, default, default, default);
+    }
+
+    [Fact]
+    public async Task GivenWriteGateReturnsTrue_WhenApplySchema_ThenDoesNotEmitMetric()
+    {
+        _schemaManagerDataStore.GetCurrentSchemaVersionAsync(default).ReturnsForAnyArgs(Task.FromResult(1));
+        _client.GetCurrentVersionInformationAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new List<CurrentVersion> { });
+        _client.GetAvailabilityAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new List<AvailableVersion> { new AvailableVersion(1, "_script/1.sql", "_script/1.diff.sql"), new AvailableVersion(2, "_script/2.sql", "_script/2.diff.sql") });
+        _client.GetCompatibilityAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new CompatibleVersion(1, 2));
+        _client.GetDiffScriptAsync(2, Arg.Any<CancellationToken>()).Returns("script");
+
+        await _sqlSchemaManager.ApplySchema(new MutuallyExclusiveType { Latest = false, Version = 2, Next = false });
+
+        _schemaMetrics.DidNotReceiveWithAnyArgs().SchemaBehind(default, default, default);
+    }
+
+    private static ISchemaWriteGate FalseGate()
+    {
+        ISchemaWriteGate gate = Substitute.For<ISchemaWriteGate>();
+        gate.CanWriteAsync(default).ReturnsForAnyArgs(Task.FromResult(false));
+        return gate;
     }
 }

--- a/tools/SchemaManager/Program.cs
+++ b/tools/SchemaManager/Program.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Client;
+using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using Microsoft.Health.SqlServer.Features.Schema.Messages.Notifications;
 using Microsoft.Health.SqlServer.Features.Storage;
@@ -89,9 +90,28 @@ public static class Program
         services.AddScoped<SqlConnectionWrapperFactory>();
         services.AddScoped<SqlTransactionHandler>();
         services.AddScoped<ISchemaManagerDataStore, SchemaManagerDataStore>();
+
+        // This standalone console does not use AddSqlServerManagement, so it does not get a real
+        // geo-replication-aware ISchemaWriteGate/ISchemaMetrics. Register no-op implementations
+        // that preserve today's behavior (always permit writes, never emit metrics); hosts that
+        // need to skip schema writes on a read-only secondary should register their own gate.
+        services.TryAddSingleton<ISchemaWriteGate, AlwaysWritableSchemaWriteGate>();
+        services.TryAddSingleton<ISchemaMetrics, NoOpSchemaMetrics>();
+
         services.AddSingleton<ISchemaManager, SqlSchemaManager>();
         services.AddMedino(c => c.RegisterServicesFromAssemblyContaining<SchemaUpgradedNotification>());
         services.AddLogging(configure => configure.AddConsole());
         return services.BuildServiceProvider();
+    }
+
+    private sealed class AlwaysWritableSchemaWriteGate : ISchemaWriteGate
+    {
+    }
+
+    private sealed class NoOpSchemaMetrics : ISchemaMetrics
+    {
+        public void SchemaBehind(string databaseName, int schemaVersion, string region)
+        {
+        }
     }
 }


### PR DESCRIPTION
## Summary

SqlSchemaManager.ApplySchema is the code path actually executed by the schema-manager CLI's pply command, which is what downstream K8s/region-agnostic schema jobs (e.g. DICOM's) run. Unlike SchemaInitializer/SchemaJobWorker, it never checked ISchemaWriteGate (added in #1469), so it could still attempt DDL against a read-only geo-replication secondary and fail with a compatibility exception instead of completing as a no-op.

This PR gates SqlSchemaManager.ApplySchema the same way SchemaInitializer.CanApplySchemaUpdatesAsync is gated, reusing the shared status/logging logic rather than duplicating it.

## Changes

- **SchemaWriteGateDiagnostics** (new): extracted GetSecondarySchemaStatus and the status-based log-message selection out of SchemaInitializer into a shared internal static helper, so both schema-write paths in this package report identical status and messages for the same (current, maximum) version pair.
- **SchemaInitializer**: refactored to delegate to SchemaWriteGateDiagnostics. Pure refactor — public surface (GetSecondarySchemaStatus) and behavior are unchanged; SchemaInitializerTests passes unmodified.
- **SqlSchemaManager**: added ISchemaWriteGate, ISchemaMetrics, and IOptions<SqlServerDataStoreConfiguration> constructor dependencies.
  - ApplySchema now checks ISchemaWriteGate.CanWriteAsync before any call that can perform DDL (including EnsureBaseSchemaExistsAsync), so a role transition cannot race with an unsafe secondary write.
  - When the gate denies writes, it best-effort determines the current/maximum schema version (via the existing ISchemaManagerDataStore/ISchemaClient), logs the read-only-secondary status via the shared helper, emits ISchemaMetrics.SchemaBehind when the secondary is behind, and returns successfully — a no-op, not a failure — so the regional deployment job can proceed.
  - Failures while probing status during the no-op path are caught and logged; they never prevent the successful no-op return.
  - The database name for the metric is derived from the configured connection string's Initial Catalog.
  - Hosts not configured for geo-replication get the default ISchemaWriteGate (DefaultSchemaWriteGate, always permits writes), preserving existing behavior.
- **	ools/SchemaManager (sample console)**: this project wires SqlSchemaManager manually (it doesn't call AddSqlServerManagement), so it now registers no-op ISchemaWriteGate/ISchemaMetrics implementations that preserve its existing always-write behavior.
- **Tests**: added unit tests to SqlSchemaManagerTests mirroring SchemaInitializerTests' coverage — gate denies writes without any DDL, metric emitted only when behind, gate/version-lookup failures don't throw, and gate permits normal apply without emitting a metric.

## Breaking change

Adding required constructor parameters to SqlSchemaManager is a breaking change for any host that constructs it directly (rather than via AddSqlServerManagement, which already registers defaults for all three new dependencies). Downstream consumers upgrading this package must ensure ISchemaWriteGate, ISchemaMetrics, and IOptions<SqlServerDataStoreConfiguration> are registered wherever SqlSchemaManager is constructed.

## Validation

- `dotnet build` on the full solution: 0 errors, 0 warnings.
- `dotnet test` on `SchemaManager.UnitTests`: 17/17 passed (11 existing + 6 new).
- `dotnet test` on `Microsoft.Health.SqlServer.UnitTests`: 113/113 passed (2 pre-existing skips, unrelated), confirming the `SchemaInitializer` refactor is behavior-preserving.

## Related

- Follows up on #1469, which added `ISchemaWriteGate`/`ISchemaMetrics` but only wired them into `SchemaInitializer`, not `SqlSchemaManager` (the actual DDL path used by CLI/K8s job consumers).
- Related to microsofthealth/Health dicom-server ADO Bug 205093 ("Prevent schema updates on geo-secondary databases"), where the in-repo `GeoAwareSchemaManager` decorator currently provides this same protection using its own `ISqlRoleDetector`-based role check. Once this package ships and is consumed, that decorator becomes redundant for hosts that also wire a real `ISchemaWriteGate` (e.g. DICOM's schema-manager console already does, via `AddSqlServerGeoReplication` replacing the default gate) — simplifying that decorator away is a separate follow-up in dicom-server.